### PR TITLE
Refactor the management of fragments.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
@@ -16,6 +16,8 @@
  */
 package com.pajato.android.gamechat.account;
 
+import android.support.v7.app.AppCompatActivity;
+
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -64,6 +66,11 @@ public enum AccountManager {
     /** Register a given account and provider ids. */
     public void register(final String accountId) {
         // Perform the Firebase authentication thing using the given ids.
+    }
+
+    /** Initialize the account manager. */
+    public void init(final AppCompatActivity context) {
+        // tbd
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -17,37 +17,23 @@
 
 package com.pajato.android.gamechat.main;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
 import android.support.design.widget.Snackbar;
-import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.GravityCompat;
-import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountManager;
-import com.pajato.android.gamechat.fragment.ChatFragment;
-import com.pajato.android.gamechat.fragment.GameFragment;
 import com.pajato.android.gamechat.intro.IntroActivity;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /** Provide a main activity to display the chat and game panesl. */
 public class MainActivity extends AppCompatActivity
@@ -63,11 +49,6 @@ public class MainActivity extends AppCompatActivity
     /** The preferences file name. */
     private static final String PREFS = "GameChatPrefs";
 
-    // Private instance variables
-    private GameChatPagerAdapter mAdapter;
-
-    // Public instance methods
-
     // Protected instance methods
 
     /**
@@ -76,32 +57,12 @@ public class MainActivity extends AppCompatActivity
      * @see android.app.Activity#onCreate(Bundle)
      */
     @Override protected void onCreate(Bundle savedInstanceState) {
-        // Deal with the main activity creation.  Layout the main activity, set up the toolbar, and
-        // the floating action button.
+        // Deal with the main activity creation.  Layout the main activity and initialize app state.
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
-
-        // Set up the navigation drawer and view.
-        DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
-        final int OPEN_ID = R.string.navigation_drawer_action_open;
-        final int CLOSE_ID = R.string.navigation_drawer_action_close;
-        ActionBarDrawerToggle toggle =
-            new ActionBarDrawerToggle(this, drawer, toolbar, OPEN_ID, CLOSE_ID);
-
-        drawer.addDrawerListener(toggle);
-        toggle.syncState();
-        NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
-        navigationView.setNavigationItemSelectedListener(this);
-
-        // Init the app state.
-        mAdapter = new GameChatPagerAdapter(getSupportFragmentManager(), this);
-        ViewPager viewPager = (ViewPager) findViewById(R.id.viewpager);
-        viewPager.setAdapter(mAdapter);
-        TabLayout tabLayout = (TabLayout) findViewById(R.id.tablayout);
-        tabLayout.setupWithViewPager(viewPager);
+        init();
+        PaneManager.instance.init(this);
+        AccountManager.instance.init(this);
 
         // Determine if an account needs to be set up.
         if (!AccountManager.instance.hasAccount()) {
@@ -176,7 +137,8 @@ public class MainActivity extends AppCompatActivity
      */
     public void onNewGame(final View view) {
         // Pass responsibility for this onClick listener onto GameFragment
-        ((GameFragment) mAdapter.getItem(1)).onNewGame(view);
+        // This should be made gone once the FAB button takes over.
+        PaneManager.instance.onNewGame(view);
     }
 
     /** The FAB click handler.  Show the various options. */
@@ -192,83 +154,26 @@ public class MainActivity extends AppCompatActivity
      */
     public void tileOnClick(final View view) {
         // Pass responsibility for this onClick listener onto GameFragment
-        ((GameFragment) mAdapter.getItem(1)).tileOnClick(view);
+        PaneManager.instance.tileOnClick(view);
     }
 
     // Private instance methods.
 
-    // Private nested classes
-
-    /**
-     * Provide a class to handle the view pager setup.
-     */
-    private static class GameChatPagerAdapter extends FragmentPagerAdapter {
-        private enum Panel {
-            chat(R.string.chat, ChatFragment.class),
-            game(R.string.game, GameFragment.class);
-
-            /** The panel title resource id. */
-            public int titleId;
-            /** The fragment class associated with the panel. */
-            public Class<? extends Fragment> fragmentClass;
-            public Fragment fragment;
-
-            /** Create the enum value instance given a title resource id and a fragment class. */
-            Panel(final int titleId, final Class<? extends Fragment> fragmentClass) {
-                this.titleId = titleId;
-                this.fragmentClass = fragmentClass;
-            }
-        }
-
-        /** A list of panels ordered left to right. */
-        private List<Panel> panelList = new ArrayList<>();
-
-        /** The fragment manager used to commit the fragment. */
-        private Map<Panel, String> titles = new HashMap<>();
-
-        /**
-         * Build an adapter to handle the panels.
-         *
-         * @param manager The fragment manager.
-         */
-        public GameChatPagerAdapter(final FragmentManager manager, final Context context) {
-            // Create the adapter and add the panels to the panel list.
-            super(manager);
-            panelList.add(Panel.chat);
-            panelList.add(Panel.game);
-            titles.put(Panel.chat, context.getString(Panel.chat.titleId));
-            titles.put(Panel.game, context.getString(Panel.game.titleId));
-        }
-
-        /** Implement the getItem() interface by dereferencing the fragment from the Panel. */
-        @Override public Fragment getItem(int position) {
-            Fragment currFragment = panelList.get(position).fragment;
-            try {
-                if(currFragment == null) {
-                    currFragment = panelList.get(position).fragmentClass.newInstance();
-                    Log.d(TAG, String.format("getFragment: Created fragment {%s}.", currFragment));
-                    panelList.get(position).fragment = currFragment;
-                } else {
-                    Log.d(TAG, String.format("getFragment: Fragment {%s} already exists.", currFragment));
-                }
-            } catch (InstantiationException exc) {
-                Log.e(TAG, "Unexpected Instantiation Exception creating fragment!", exc);
-            } catch (IllegalAccessException exc) {
-                Log.e(TAG, "Unexpected Illegal Access Exception creating fragment!", exc);
-            }
-            return currFragment;
-        }
-
-        /** Implement the getCount() interface by using the panel list size. */
-        @Override public int getCount() {
-            return panelList.size();
-        }
-
-        /** Implement the getPageTitle() interface by using the title stored in the fragment. */
-        @Override public CharSequence getPageTitle(int position) {
-            return titles.get(panelList.get(position));
-        }
-
+    /** Initialize the main activity. */
+    private void init() {
+        // Set up the app components: toolbar, FAB button, and navigation drawer.
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
+        DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
+        final int OPEN_ID = R.string.navigation_drawer_action_open;
+        final int CLOSE_ID = R.string.navigation_drawer_action_close;
+        ActionBarDrawerToggle toggle =
+            new ActionBarDrawerToggle(this, drawer, toolbar, OPEN_ID, CLOSE_ID);
+        drawer.addDrawerListener(toggle);
+        toggle.syncState();
+        NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
+        navigationView.setNavigationItemSelectedListener(this);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.main;
+
+import android.os.Bundle;
+import android.support.design.widget.TabLayout;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.fragment.ChatFragment;
+import com.pajato.android.gamechat.fragment.GameFragment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Provide a singleton to manage the main fragments used to display the chat and game panels. */
+public enum PaneManager {
+    instance;
+
+    // Private class constants
+
+    /** The logcat tag constant. */
+    private static final String TAG = PaneManager.class.getSimpleName();
+
+    /** The fragment list index for the game fragment. */
+    private static final int GAME_INDEX = 1;
+
+    // Private instance variables
+
+    /** The view pager adapter. */
+    private GameChatPagerAdapter mAdapter;
+
+    /** The repository for the pane fragments. */
+    private List<Fragment> fragmentList = new ArrayList<>();
+
+    /** The repository for the fragment titles. */
+    private List<String> titleList = new ArrayList<>();
+
+    // Public instance methods
+
+    /**
+     * Set up the app per the characteristics of the running device.
+     *
+     * @see android.app.Activity#onCreate(Bundle)
+     */
+    public void init(final AppCompatActivity context) {
+        // Clear the current panes and determine if a paging layout is active.
+        fragmentList.clear();
+        titleList.clear();
+        titleList.add(context.getString(R.string.chat));
+        titleList.add(context.getString(R.string.game));
+        ViewPager viewPager = (ViewPager) context.findViewById(R.id.viewpager);
+        if (viewPager != null) {
+            // The app is running on a smart phone.  Create the pane fragments and set up the
+            // adapter for the pager.
+            fragmentList.add(new ChatFragment());
+            fragmentList.add(new GameFragment());
+            viewPager.setAdapter(new GameChatPagerAdapter(context.getSupportFragmentManager()));
+            TabLayout tabLayout = (TabLayout) context.findViewById(R.id.tablayout);
+            tabLayout.setupWithViewPager(viewPager);
+        } else {
+            // The app is running on a tablet and the fragments have been created.  Add them to the
+            // fragment map.
+            //TODO: uncomment these for tablets:
+            //fragmentList.add((Fragment) context.findViewById(R.id.chatFragment));
+            //fragmentList.add((Fragment) context.findViewById(R.id.gameFragment));
+        }
+    }
+
+    /** Handle the delegated tile click by delegating it to the game fragment. */
+    public void tileOnClick(final View view) {
+        // Delegate this to the game fragment.
+        ((GameFragment) fragmentList.get(GAME_INDEX)).tileOnClick(view);
+    }
+
+    /** Handle the delegated new game click by delegating it to the game fragment. */
+    public void onNewGame(final View view) {
+        // Delegate this to the game fragment.
+        ((GameFragment) fragmentList.get(GAME_INDEX)).onNewGame(view);
+    }
+
+    // Nested classes
+
+    /** Provide a class to handle the view pager setup. */
+    private class GameChatPagerAdapter extends FragmentPagerAdapter {
+
+        /** Build an adapter to handle the panels for a given fragment manager. */
+        public GameChatPagerAdapter(final FragmentManager manager) {
+            // Create the adapter and add the panels to the panel list.
+            super(manager);
+        }
+
+        /** Implement getItem() by using the fragment list. */
+        @Override public Fragment getItem(int position) {
+            return fragmentList.get(position);
+        }
+
+        /** Implement getCount() by using the fragment list size. */
+        @Override public int getCount() {
+            return fragmentList.size();
+        }
+
+        /** Implement getPageTitle() by using the title list. */
+        @Override public CharSequence getPageTitle(int position) {
+            return titleList.get(position);
+        }
+
+    }
+
+}


### PR DESCRIPTION
<h1>Rationale:</h1>

The original design using an enum to manage the chat and game panel fragments was fraught with testing issues emanating from mismangement of the activity and fragment lifecycle.  This commit introduces a redesign that provides a better fit for lifecycle management.  All tests now pass reliably on both a Nexus 6 smartphone and a Pixel C tablet.  See below for more details.

<h1>File changes:</h1>

app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Provide a placeholder initialization file as part of a manager pattern.

app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- Major refactoring that simplifies the onCreate() code and moves fragment management into the new panel manager class.

app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- New manager charged with managing the fragments used in the chat and game panels.  This includes initial placeholder code for dealing with tablet form factor devices.