### PR TITLE
Add a sign out/sign in feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java
@@ -1,0 +1,20 @@
+package com.pajato.android.gamechat.account;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+
+/**
+ * Provides an account state change data model class.
+ *
+ * @author Paul Michael Reilly
+ */
+@AllArgsConstructor(suppressConstructorProperties = true)
+@Data
+public class AccountStateChangeEvent {
+
+    // Private instance variables
+
+    /** The changed account: if null the User signed out, if non-null the User signed in. */
+    private Account account;
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/event/ClickEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ClickEvent.java
@@ -17,11 +17,11 @@
 
 package com.pajato.android.gamechat.event;
 
-import android.view.View;
+import android.content.Context;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Provides a button click data model class.
@@ -30,10 +30,16 @@ import lombok.NonNull;
  */
 @RequiredArgsConstructor(suppressConstructorProperties = true)
 @Data
-public class ButtonClickEvent {
+public class ClickEvent {
 
     // Private instance variables
 
-    /** The view on which the button click occurred. */
-    @NonNull private View view;
+    /** The app context. */
+    @NonNull private Context context;
+
+    /** The value associated with the click event. */
+    @NonNull private int value;
+
+    /** The class name of the object that generated the event. */
+    @NonNull private String className;
 }

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -14,12 +14,12 @@ details.
 You should have received a copy of the GNU General Public License along with GameChat.  If not, see
 http://www.gnu.org/licenses
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/nav_header_height"
     android:background="@drawable/side_nav_bar"
-    android:gravity="bottom"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
@@ -27,26 +27,46 @@ http://www.gnu.org/licenses
     android:paddingTop="@dimen/activity_vertical_margin"
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
-    <ImageView
-        android:id="@+id/currentAccountIcon"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:src="@android:drawable/sym_def_app_icon"
-        tools:ignore="ContentDescription" />
+        android:orientation="horizontal">
+        <Button
+            android:id="@+id/signInOutButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_in"
+            android:onClick="buttonClick"/>
+    </LinearLayout>
 
-    <TextView
-        android:id="@+id/currentAccountDisplayName"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:text="@string/nav_header_label_android_studio"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
-
-    <TextView
-        android:id="@+id/currentAccountEmail"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/nav_header_label_android_studio_android_com" />
+        android:orientation="horizontal">
+        <ImageView
+            android:id="@+id/currentAccountIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/nav_header_vertical_spacing"
+            android:src="@android:drawable/sym_def_app_icon"
+            tools:ignore="ContentDescription" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/currentAccountDisplayName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/nav_header_vertical_spacing"
+                android:text="@string/nav_header_label_android_studio"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+            <TextView
+                android:id="@+id/currentAccountEmail"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/nav_header_label_android_studio_android_com" />
+        </LinearLayout>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/menu/drawer_footer.xml
+++ b/app/src/main/res/menu/drawer_footer.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/nav_sign_out"
-        android:title="@string/sign_out" />
+        android:id="@+id/nav_manage_accounts"
+        android:onClick="menuClick"
+        android:title="@string/manage_accounts" />
     <item
         android:id="@+id/nav_settings"
+        android:onClick="menuClick"
         android:icon="@drawable/ic_settings_black"
         android:title="@string/navigation_drawer_label_problems_settings" />
     <item
         android:id="@+id/nav_feedback"
         android:icon="@drawable/ic_help_black"
+        android:onClick="menuClick"
         android:title="@string/navigation_drawer_label_problems_feedback" />
     <item
         android:id="@+id/nav_learn"
+        android:tag="@integer/learnMore"
         android:icon="@drawable/ic_info_black"
+        android:onClick="menuClick"
         android:title="@string/navigation_drawer_label_problems_learn" />
 </menu>
-

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="feedback">0</integer>
+    <integer name="learnMore">1</integer>
+    <integer name="settings">2</integer>
+    <integer name="signIn">3</integer>
+    <integer name="signOut">4</integer>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,5 @@
     <string name="winner_tie">Tie!</string>
     <string name="winner_x">X Wins!</string>
     <string name="xValue">X</string>
+    <string name="manage_accounts">Manage Accounts</string>
 </resources>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit provides a first pass at account management by adding a sign in/sign out toggle button in the navigation view header panel.  A placeholder item in the foooter menu has been added to manage accounts.

<h1>File changes:</h1>

app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Add sign in/sign out support.
- Clean up some stale code.

app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java

- New file to model an account state change (sign in/sign out) event.

app/src/main/java/com/pajato/android/gamechat/event/ButtonClickEvent.java -> app/src/main/java/com/pajato/android/gamechat/event/ClickEvent.java

app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- Provide better support for distibuting button clicks and menu click.
- Update the nav header for sign in/sign out operations.

app/src/main/res/layout/nav_header_main.xml

- New layout to handle the sign in/sign out toggle button.

app/src/main/res/menu/drawer_footer.xml

- Remove the sign in and sign out menu items.
- Add a manage accounts menu item placeholder.

app/src/main/res/values/integers.xml

- Add values for button/menu click handling.

app/src/main/res/values/strings.xml

- Add a manage accounts menu label.