### PR TITLE
Online and Local Play for Tic-Tac-Toe

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
@@ -73,7 +73,7 @@ public class FABTest {
                 .perform(click());
         onView(withId(R.id.game_pane_fragment_container))
                 .check(matches(isDisplayed()));
-        onView(withId(R.id.settings_panel))
+        onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/androidTest/java/com/pajato/android/gamechat/GameTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/GameTest.java
@@ -31,7 +31,7 @@ public class GameTest {
         // Move to the game pane and ensure that we are starting on the settings panel.
         onView(withId(R.id.toolbar_game_icon))
                 .perform(click());
-        onView(withId(R.id.settings_panel))
+        onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
         // Open the action bar overflow menu, then initiate a new TTT game. Ensure it functions.
         openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
@@ -45,7 +45,7 @@ public class GameTest {
         onView(withText(R.string.new_game_settings))
                 .check(matches(isDisplayed()))
                 .perform(click());
-        onView(withId(R.id.settings_panel))
+        onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
     }
 
@@ -56,10 +56,10 @@ public class GameTest {
                 .perform(click());
         onView(withId(R.id.game_pane_fragment_container))
                 .check(matches(isDisplayed()));
-        onView(withId(R.id.settings_panel))
+        onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
         // Click on the new Tic-Tac-Toe game section
-        onView(withId(R.id.settings_ttt))
+        onView(withId(R.id.init_ttt))
                 .check(matches(isDisplayed()))
                 .perform(click());
         onView(withId(R.id.ttt_panel))

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -441,12 +441,12 @@ public class ChatFragment extends BaseFragment
                     // Start a new Tic-Tac-Toe game
                     case R.id.fab_ttt:
                         if(viewPager != null) { viewPager.setCurrentItem(PaneManager.GAME_INDEX); }
-                        GameManager.instance.sendNewGame(GameManager.TTT_INDEX, getActivity());
+                        GameManager.instance.sendNewGame(GameManager.TTT_L_INDEX, getActivity());
                         break;
                     // Navigate to the Game Settings panel
                     case R.id.fab_new_game:
                         if(viewPager != null) { viewPager.setCurrentItem(PaneManager.GAME_INDEX); }
-                        GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity());
+                        GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
                     default:
                         break;
                 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -15,7 +15,7 @@
  * see http://www.gnu.org/licenses
  */
 
-package com.pajato.android.gamechat.fragment;
+package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
@@ -27,7 +27,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.game.GameManager;
+import com.pajato.android.gamechat.fragment.BaseFragment;
 import com.pajato.android.gamechat.main.PaneManager;
 
 /**
@@ -35,7 +35,7 @@ import com.pajato.android.gamechat.main.PaneManager;
  *
  * @author Bryan Scott
  */
-public class GameFragment extends BaseFragment{
+public class GameFragment extends BaseFragment {
 
     public GameFragment() {
         // Required empty public constructor
@@ -71,13 +71,17 @@ public class GameFragment extends BaseFragment{
                 break;
             // Otherwise, we can initiate a new game based on which game was chosen.
             case R.id.new_game_settings:
-                GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity());
+                GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
                 break;
             case R.id.new_game_ttt:
-                GameManager.instance.sendNewGame(GameManager.TTT_INDEX, getActivity(), msg);
-                break;
+                if(GameManager.instance.getCurrentFragmentIndex() == GameManager.TTT_L_INDEX) {
+                    GameManager.instance.sendNewGame(GameManager.TTT_L_INDEX, getActivity(), msg);
+                } else if (GameManager.instance.getCurrentFragmentIndex() == GameManager.TTT_O_INDEX) {
+                    GameManager.instance.sendNewGame(GameManager.TTT_O_INDEX, getActivity(), msg);
+                }
+                    break;
             case R.id.new_game_checkers:
-                GameManager.instance.sendNewGame(GameManager.CHECKERS_INDEX, getActivity());
+                GameManager.instance.sendNewGame(GameManager.TTT_O_INDEX, getActivity());
                 break;
             case R.id.new_game_chess:
                 GameManager.instance.sendNewGame(GameManager.CHESS_INDEX, getActivity());
@@ -108,16 +112,17 @@ public class GameFragment extends BaseFragment{
     private String getTurn() {
         switch(GameManager.instance.getCurrentFragmentIndex()) {
             default:
+            // These two cases should never be called in an impactful way.
+            case GameManager.INIT_INDEX:
+                return null;
             case GameManager.SETTINGS_INDEX:
-                // This should never be called in an impactful way.
                 return null;
-            case GameManager.TTT_INDEX:
-                return ((TTTFragment) GameManager.instance.getFragment(GameManager.TTT_INDEX))
+            case GameManager.TTT_L_INDEX:
+                return ((LocalTTTFragment) GameManager.instance.getFragment(GameManager.TTT_L_INDEX))
                         .mTurn ? getString(R.string.xValue) : getString(R.string.oValue);
-            case GameManager.CHECKERS_INDEX:
-                return null;
-            case GameManager.CHESS_INDEX:
-                return null;
+            case GameManager.TTT_O_INDEX:
+                return ((TTTFragment) GameManager.instance.getFragment(GameManager.TTT_O_INDEX))
+                    .mTurn ? getString(R.string.xValue) : getString(R.string.oValue);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
@@ -15,7 +15,7 @@
  * see http://www.gnu.org/licenses
  */
 
-package com.pajato.android.gamechat.fragment;
+package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -26,31 +26,33 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.game.GameManager;
+import com.pajato.android.gamechat.fragment.BaseFragment;
 
-public class SettingsFragment extends BaseFragment{
+public class InitialFragment extends BaseFragment {
 
     @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
                                        Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         setHasOptionsMenu(true);
-        return inflater.inflate(R.layout.fragment_settings, container, false);
+        return inflater.inflate(R.layout.fragment_initial, container, false);
     }
 
     @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater menuInflater) {
         super.onCreateOptionsMenu(menu, menuInflater);
 
-        View ttt = getActivity().findViewById(R.id.settings_ttt);
+        View ttt = getActivity().findViewById(R.id.init_ttt);
         ttt.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 switch(v.getId()) {
-                    case R.id.settings_ttt:
-                        GameManager.instance.sendNewGame(GameManager.TTT_INDEX, getActivity());
+                    case R.id.init_ttt_button:
+                    case R.id.init_ttt:
+                        GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
+                                getString(R.string.new_game_ttt));
                         break;
-                    case R.id.settings_checkers:
+                    case R.id.init_checkers:
                         break;
-                    case R.id.settings_chess:
+                    case R.id.init_chess:
                         break;
                 }
             }

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -1,0 +1,267 @@
+package com.pajato.android.gamechat.game;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.fragment.BaseFragment;
+
+import java.util.Scanner;
+
+public class LocalTTTFragment extends BaseFragment {
+    private static final String TAG = TTTFragment.class.getSimpleName();
+    // Keeps track of the Turn user. True = Player 1, False = Player 2.
+    public boolean mTurn;
+
+    // Player piece strings
+    private String mXValue;
+    private String mOValue;
+    private String mSpace;
+
+    // Board management objects
+    private View mBoard;
+    private int turnCount;
+
+    public LocalTTTFragment() {
+
+    }
+
+    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
+                                       final Bundle savedInstanceState) {
+        // Initialize Member Variables
+        mBoard = inflater.inflate(R.layout.fragment_ttt, container, false);
+        mTurn = true;
+        mXValue = getString(R.string.xValue);
+        mOValue = getString(R.string.oValue);
+        mSpace = getString(R.string.spaceValue);
+        turnCount = 0;
+
+        return mBoard;
+    }
+
+    /**
+     * Translates the messages sent by the event system and handles the individual clicks
+     * based on messages sent.
+     *
+     * @param msg the message to be handled.
+     */
+    public void messageHandler(final String msg) {
+        //TODO: Modify this when an implemented event handling system is implemented.
+        Scanner input = new Scanner(msg);
+        String player = input.nextLine();
+        String buttonTag = input.nextLine();
+        input.close();
+
+        // Call appropriate methods for each button.
+        if(buttonTag.equals(getString(R.string.new_game))) {
+            handleNewGame();
+        } else {
+            handleTileClick(player, buttonTag);
+        }
+    }
+
+    /**
+     * Evaluates the state of the board, determining if there are three in a row of either X or O.
+     *
+     * @return false if a player has won or if the full number of turns has occurred, true otherwise
+     */
+    private boolean checkNotFinished() {
+        // First, we need to check on the buttons' states.
+        int[][] boardValues = evaluateBoard();
+
+        // Evaluate all possible lines of 3.
+        int topRow = boardValues[0][0] + boardValues[0][1] + boardValues[0][2];
+        int midRow = boardValues[1][0] + boardValues[1][1] + boardValues[1][2];
+        int botRow = boardValues[2][0] + boardValues[2][1] + boardValues[2][2];
+        int startCol = boardValues[0][0] + boardValues[1][0] + boardValues[2][0];
+        int centerCol = boardValues[0][1] + boardValues[1][1] + boardValues[2][1];
+        int endCol = boardValues[0][2] + boardValues[1][2] + boardValues[2][2];
+        int leftDiag = boardValues[0][0] + boardValues[1][1] + boardValues[2][2];
+        int rightDiag = boardValues[2][0] + boardValues[1][1] + boardValues [0][2];
+
+        // If any lines of 3 are equal to 3, X wins.
+        boolean xWins = (topRow == 3 || midRow == 3 || botRow == 3 || startCol == 3
+                || centerCol == 3 || endCol == 3 || leftDiag == 3 || rightDiag == 3);
+        // If any lines of 3 are equal to 6, O wins.
+        boolean oWins = (topRow == 6 || midRow == 6 || botRow == 6 || startCol == 6
+                || centerCol == 6 || endCol == 6 || leftDiag == 6 || rightDiag == 6);
+
+        // If we have a win condition, reveal the winning messages.
+        if(xWins || oWins || turnCount >= 9) {
+            //Setup the winner TextView and snackbar messages.
+            TextView Winner = (TextView) super.getActivity().findViewById(R.id.winner);
+            Winner.setText(getText(R.string.spaceValue));
+            Winner.setVisibility(View.VISIBLE);
+            // If there is a winner, output winning messages and ensure that the appropriat
+            // player's icon has been highlighted.
+            if(xWins) {
+                Winner.setText(R.string.winner_x);
+                handlePlayerIcons(true);
+                GameManager.instance.generateSnackbar(mBoard, "Player 1 (" + mXValue + ") Wins!",
+                        ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
+            } else if (oWins) {
+                Winner.setText(R.string.winner_o);
+                handlePlayerIcons(false);
+                GameManager.instance.generateSnackbar(mBoard, "Player 2 (" + mOValue + ") Wins!",
+                        ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
+                // If no one has won, the turn timer has run out. End the game.
+                } else {
+                // Reveal Tie Messages
+                Winner.setText(R.string.winner_tie);
+                GameManager.instance.generateSnackbar(mBoard, "It's a Tie!", -1, true);
+            }
+            return false;
+        }
+        // If none of the conditions are met, the game has not yet ended, and we can continue it.
+        return true;
+    }
+
+    /**
+     * Evaluates the current state of the individual tiles of the board and stores them as a HashMap
+     * in the Firebase Database.
+     */
+    private int[][] evaluateBoard() {
+        int[][] boardValues = new int[3][3];
+        // Go through all the buttons.
+        for(int i = 0; i < 3; i++) {
+            for(int j = 0; j < 3; j++) {
+                Button currTile = (Button) mBoard.findViewWithTag("button" + Integer.toString(i) + Integer.toString(j));
+                String tileValue = currTile.getText().toString();
+
+                // Assign each possible state for each tile as a value. The only possible values
+                // of each row (that indicate and endgame state) are 3 in a row of X or O. There
+                // is no way to get a value of 3 without getting 3 Xs, and there's no way to get a
+                // value of 6 without getting 3 Os.
+                // If there's an X in this button, store a 1
+
+                if(tileValue.equals(mXValue)) {
+                    boardValues[i][j] = 1;
+                    // If there's an O in this button, store a 2
+                } else if (tileValue.equals(mOValue)) {
+                    boardValues[i][j] = 2;
+                    // Otherwise, there's a space. -5 was chosen arbitrarily to keep row values unique.
+                } else {
+                    boardValues[i][j] = -5;
+                }
+            }
+        }
+        return boardValues;
+    }
+
+    /**
+     * Returns a string enumerating the player, depending on the current turn.
+     *
+     * @return R.string.xValue or R.string.oValue, depending on whose turn it is.
+     */
+    private String getTurn(boolean turnIndicator) {
+        if(turnIndicator) {
+            return mXValue;
+        } else {
+            return mOValue;
+        }
+    }
+
+    /**
+     * A method that handles the management of a the turn indicators. If it is a player's turn,
+     * their icon is increased in size, changed to the accented color, and emphasized with auxiliary
+     * text views. The other player's icon decreases in size, is turned a dark color, and is no
+     * longer emphasized.
+     *
+     * @param turn differentiates between the turn. true = Player 1's turn, false = Player 2's turn.
+     */
+    protected void handlePlayerIcons(boolean turn) {
+        final float LARGE = 60.0f;
+        final float SMALL = 45.0f;
+        // Collect all the pertinent textViews.
+        TextView p1 = (TextView) getActivity().findViewById(R.id.player_1_icon);
+        TextView p2 = (TextView) getActivity().findViewById(R.id.player_2_icon);
+        TextView p1left = (TextView) getActivity().findViewById(R.id.player_1_left_indicator);
+        TextView p1right = (TextView) getActivity().findViewById(R.id.player_1_right_indicator);
+        TextView p2left = (TextView) getActivity().findViewById(R.id.player_2_left_indicator);
+        TextView p2right = (TextView) getActivity().findViewById(R.id.player_2_right_indicator);
+
+        if(turn) {
+            // If it's player 1's turn, make their icon bigger and accented...
+            p1.setTextSize(TypedValue.COMPLEX_UNIT_SP, LARGE);
+            p1.setTextColor(ContextCompat.getColor(getActivity(), R.color.colorAccent));
+            p1left.setVisibility(View.VISIBLE);
+            p1right.setVisibility(View.VISIBLE);
+
+            // and de-emphasize player 2's icon.
+            p2.setTextSize(TypedValue.COMPLEX_UNIT_SP, SMALL);
+            p2.setTextColor(ContextCompat.getColor(getActivity(), R.color.colorPrimaryDark));
+            p2left.setVisibility(View.INVISIBLE);
+            p2right.setVisibility(View.INVISIBLE);
+
+        } else {
+            // If it's player 2's turn, make their icon bigger and accented...
+            p1.setTextSize(TypedValue.COMPLEX_UNIT_SP, SMALL);
+            p1.setTextColor(ContextCompat.getColor(getActivity(), R.color.colorPrimaryDark));
+            p1left.setVisibility(View.INVISIBLE);
+            p1right.setVisibility(View.INVISIBLE);
+
+            // and de-emphasize player 1's icon.
+            p2.setTextSize(TypedValue.COMPLEX_UNIT_SP, LARGE);
+            p2.setTextColor(ContextCompat.getColor(getActivity(), R.color.colorAccent));
+            p2left.setVisibility(View.VISIBLE);
+            p2right.setVisibility(View.VISIBLE);
+        }
+    }
+
+    /**
+     * Empties the instructions, board tiles, and outputs a new game message.
+     */
+    private void handleNewGame() {
+        // Hide our winning messages and ensure the turn display is working properly.
+        turnCount = 0;
+        TextView Winner = (TextView) super.getActivity().findViewById(R.id.winner);
+        Winner.setVisibility(View.INVISIBLE);
+        handlePlayerIcons(mTurn);
+
+        // Set values for each tile to empty.
+        ((Button) mBoard.findViewWithTag("button00")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button01")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button02")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button10")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button11")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button12")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button20")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button21")).setText(mSpace);
+        ((Button) mBoard.findViewWithTag("button22")).setText(mSpace);
+        // Output New Game Messages
+
+        String newTurn = "New Game! Player " + (mTurn
+                ? "1 ( " + mXValue + ")"
+                : "2 (" + mOValue + ")") + "'s Turn";
+        GameManager.instance.generateSnackbar(mBoard, newTurn, ContextCompat.getColor(getActivity(),
+                R.color.colorPrimaryDark), false);
+        checkNotFinished();
+    }
+
+    /**
+     * Assigns a value to a button without text, either X or O, depending on the player whose
+     * turn it is.
+     *
+     * @param player the player who initiated the click.
+     * @param buttonTag the tag of the button clicked.
+     */
+    private void handleTileClick(String player, String buttonTag) {
+        Button b = (Button) mBoard.findViewWithTag(buttonTag);
+        // Only updates the tile if the current value is empty and the game has not finished yet.
+        if (b.getText().toString().equals(getString(R.string.spaceValue)) && checkNotFinished()) {
+            b.setText(getTurn(mTurn));
+            mTurn = !mTurn;
+            turnCount++;
+            handlePlayerIcons(mTurn);
+            checkNotFinished();
+        }
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -1,0 +1,113 @@
+package com.pajato.android.gamechat.game;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.fragment.BaseFragment;
+
+public class SettingsFragment extends BaseFragment {
+
+    private String game;
+    private View mMain;
+    private boolean isValidUser = false;
+
+    public SettingsFragment() {
+
+    }
+
+    @Override public void setArguments(Bundle args) {
+        if(args != null && args.containsKey(GameManager.GAME_KEY)) {
+            game = args.getString(GameManager.GAME_KEY);
+        }
+        super.setArguments(args);
+    }
+
+    @Override public View onCreateView(LayoutInflater layoutInflater, ViewGroup container,
+                                       Bundle savedInstanceState) {
+        mMain = layoutInflater.inflate(R.layout.fragment_settings, container, false);
+        TextView title = (TextView) mMain.findViewById(R.id.settings_title);
+
+        // Setup the group choice spinner and adapter.
+        Spinner groupChoices = (Spinner) mMain.findViewById(R.id.settings_group_spinner);
+        ArrayAdapter<CharSequence> groupAdapter = ArrayAdapter.createFromResource(getActivity(),
+                R.array.groups, android.R.layout.simple_spinner_item);
+        groupAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        groupChoices.setAdapter(groupAdapter);
+
+        // Setup the user choices spinner
+        final Spinner userChoices = (Spinner) mMain.findViewById(R.id.settings_user_spinner);
+
+        // We want different users to appear in the user spinner when a different group is chosen.
+        //TODO: Find a procedural way to generate these arrays once accounts are implemented.
+        //TODO: Find a better way to handle isValidUser.
+        groupChoices.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                ArrayAdapter<CharSequence> userAdapter;
+                // If the group spinner has chosen the family group, show the family members.
+                if(position == 1) {
+                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                            R.array.family_group, android.R.layout.simple_spinner_item);
+                    userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                    isValidUser = true;
+                // If the group spinner has chosen the work group, show the work members.
+                } else if (position == 2) {
+                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                            R.array.work_group, android.R.layout.simple_spinner_item);
+                    userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                    isValidUser = true;
+                // Otherwise, a group has not been chosen, so show an empty group.
+                } else {
+                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                            R.array.empty_group, android.R.layout.simple_spinner_item);
+                    isValidUser = false;
+                }
+                userChoices.setAdapter(userAdapter);
+            }
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+
+            }
+        });
+
+        // Handle the game-specific portions of the layout.
+        if(game.equals(getString(R.string.new_game_ttt))) {
+            title.setText(R.string.playing_ttt);
+            setupTTT();
+        }
+        return mMain;
+    }
+
+    private void setupTTT() {
+        ImageButton local = (ImageButton) mMain.findViewById(R.id.ttt_local_button);
+        ImageButton online = (ImageButton) mMain.findViewById(R.id.ttt_online_button);
+        ImageButton computer = (ImageButton) mMain.findViewById(R.id.ttt_computer_button);
+
+        local.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                GameManager.instance.sendNewGame(GameManager.TTT_L_INDEX, getActivity());
+            }
+        });
+        online.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                if(isValidUser) {
+                    GameManager.instance.sendNewGame(GameManager.TTT_O_INDEX, getActivity());
+                }
+            }
+        });
+        computer.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                //GameManager.instance.sendNewGame(GameManager.TTT_C_INDEX, getActivity());
+            }
+        });
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -1,4 +1,4 @@
-package com.pajato.android.gamechat.fragment;
+package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -17,12 +17,17 @@ import com.firebase.client.FirebaseError;
 import com.firebase.client.GenericTypeIndicator;
 import com.firebase.client.ValueEventListener;
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.game.GameManager;
+import com.pajato.android.gamechat.fragment.BaseFragment;
 
 import java.util.HashMap;
 import java.util.Scanner;
 
-public class TTTFragment extends Fragment {
+/**
+ * A Tic-Tac-Toe game that stores its current state on Firebase, allowing for cross-device play.
+ *
+ * @author Bryan Scott
+ */
+public class TTTFragment extends BaseFragment {
 
     private static final String TAG = TTTFragment.class.getSimpleName();
     private static final String FIREBASE_URL = "https://gamechat-1271.firebaseio.com/boards/ticTacToe";
@@ -96,6 +101,7 @@ public class TTTFragment extends Fragment {
         String player = input.nextLine();
         String buttonTag = input.nextLine();
         input.close();
+
         // Call appropriate methods for each button.
         if(buttonTag.equals(getString(R.string.new_game))) {
             handleNewGame();
@@ -118,11 +124,9 @@ public class TTTFragment extends Fragment {
         int topRow = boardValues[0][0] + boardValues[0][1] + boardValues[0][2];
         int midRow = boardValues[1][0] + boardValues[1][1] + boardValues[1][2];
         int botRow = boardValues[2][0] + boardValues[2][1] + boardValues[2][2];
-
         int startCol = boardValues[0][0] + boardValues[1][0] + boardValues[2][0];
         int centerCol = boardValues[0][1] + boardValues[1][1] + boardValues[2][1];
         int endCol = boardValues[0][2] + boardValues[1][2] + boardValues[2][2];
-
         int leftDiag = boardValues[0][0] + boardValues[1][1] + boardValues[2][2];
         int rightDiag = boardValues[2][0] + boardValues[1][1] + boardValues [0][2];
 
@@ -325,7 +329,7 @@ public class TTTFragment extends Fragment {
         // If the board map is size 1, we know that there is only the turn stored in it, and send a
         // new game out.
         if(mBoardMap.size() == 1) {
-            GameManager.instance.sendNewGame(GameManager.TTT_INDEX, getActivity(),
+            GameManager.instance.sendNewGame(GameManager.TTT_O_INDEX, getActivity(),
                     getTurn(mTurn) + "\n" + getString(R.string.new_game));
         // Otherwise, we'll need to comb through the board and replace the remaining pieces.
         } else {

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.ChatFragment;
 import com.pajato.android.gamechat.chat.RoomsFragment;
-import com.pajato.android.gamechat.fragment.GameFragment;
+import com.pajato.android.gamechat.game.GameFragment;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/res/layout/activity_fragments.xml
+++ b/app/src/main/res/layout/activity_fragments.xml
@@ -19,8 +19,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/page_monitor"
         android:orientation="horizontal"
-        android:layout_gravity="bottom|center_horizontal"
-        android:layout_marginBottom="26dp">
+        android:layout_gravity="bottom|center_horizontal">
 
         <TextView
             android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -39,6 +39,7 @@ http://www.gnu.org/licenses
             android:layout_centerHorizontal="true"
             android:layout_alignParentTop="true"
             android:paddingBottom="8dp"
+            android:layout_marginTop="44dp"
             ads:adSize="BANNER"
             ads:adUnitId="@string/banner_ad_unit_id">
         </com.google.android.gms.ads.AdView>
@@ -56,7 +57,8 @@ http://www.gnu.org/licenses
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentStart="true"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:layout_marginBottom="8dp">
 
             <EditText
                 android:id="@+id/messageEditText"

--- a/app/src/main/res/layout/fragment_initial.xml
+++ b/app/src/main/res/layout/fragment_initial.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/init_panel">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_launcher"
+        android:contentDescription="@string/app_name"
+        android:id="@+id/gamechat_logo"
+
+        app:layout_constraintTop_toTopOf="@id/init_panel"
+        app:layout_constraintLeft_toLeftOf="@id/init_panel"
+        android:layout_marginTop="80dp"
+        android:layout_marginLeft="32dp"
+        android:layout_marginStart="32dp"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/new_game"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+        android:id="@+id/init_title"
+
+        app:layout_constraintTop_toTopOf="@id/gamechat_logo"
+        app:layout_constraintLeft_toRightOf="@id/gamechat_logo"
+        android:layout_marginStart="32dp"
+        android:layout_marginLeft="32dp"/>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/gamechat_logo"
+        app:layout_constraintLeft_toLeftOf="@id/init_panel"
+        app:layout_constraintRight_toRightOf="@id/init_panel"
+        android:layout_marginTop="32dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/play_choose_game"
+            android:textSize="28sp"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:id="@+id/init_ttt"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/init_ttt_button"
+                android:src="@drawable/ic_launcher"
+                android:contentDescription="@string/new_game_ttt"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/play_ttt"
+                android:textSize="20sp"
+                android:layout_marginTop="20dp"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:id="@+id/init_checkers"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_launcher"
+                android:contentDescription="@string/new_game_checkers"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/play_checkers"
+                android:textSize="20sp"
+                android:layout_marginTop="20dp"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:id="@+id/init_chess"
+            android:layout_marginLeft="16dp"
+            android:layout_marginStart="16dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_launcher"
+                android:contentDescription="@string/new_game_chess"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/play_chess"
+                android:textSize="20sp"
+                android:layout_marginTop="20dp"/>
+        </LinearLayout>
+
+    </LinearLayout>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -7,88 +7,124 @@
     android:layout_height="match_parent"
     android:id="@+id/settings_panel">
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_launcher"
-        android:contentDescription="@string/app_name"
-        android:id="@+id/gamechat_logo"
-
-        app:layout_constraintTop_toTopOf="@id/settings_panel"
-        app:layout_constraintLeft_toLeftOf="@id/settings_panel"
-        android:layout_marginTop="80dp"
-        android:layout_marginStart="32dp"/>
-
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/new_game"
-        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
         android:id="@+id/settings_title"
-
-        app:layout_constraintTop_toTopOf="@id/gamechat_logo"
-        app:layout_constraintLeft_toRightOf="@id/gamechat_logo"
-        android:layout_marginStart="32dp"/>
+        android:text="@string/playing"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Display1"
+        android:layout_marginTop="64dp"
+        app:layout_constraintTop_toTopOf="@id/settings_panel"
+        app:layout_constraintLeft_toLeftOf="@id/settings_panel"
+        app:layout_constraintRight_toRightOf="@id/settings_panel"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintTop_toBottomOf="@id/gamechat_logo"
-        app:layout_constraintLeft_toLeftOf="@id/settings_panel"
         app:layout_constraintRight_toRightOf="@id/settings_panel"
-        android:layout_marginTop="32dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/play_choose_game"
-            android:textSize="28sp"
-            android:layout_marginBottom="16dp"/>
+        app:layout_constraintLeft_toLeftOf="@id/settings_panel"
+        app:layout_constraintTop_toBottomOf="@+id/settings_title">
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_margin="8dp"
-            android:id="@+id/settings_ttt">
+            android:layout_marginTop="12dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/ttt_online_button"
+                android:src="@drawable/ic_launcher"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/play_ttt"
+                android:text="@string/play_another_user"
                 android:textSize="20sp"
-                android:layout_margin="8dp"
-                android:drawableStart="@drawable/ic_launcher"/>
+                android:layout_marginTop="20dp"/>
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_margin="8dp"
-            android:id="@+id/settings_checkers">
+            android:layout_marginTop="8dp"
+            android:layout_marginLeft="32dp"
+            android:layout_marginStart="32dp">
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/play_checkers"
-                android:textSize="20sp"
-                android:layout_margin="8dp"
-                android:drawableStart="@drawable/ic_launcher"/>
+                android:textSize="18sp"
+                android:text="@string/choose_group"/>
+            <Spinner
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/settings_group_spinner"/>
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginLeft="32dp"
+            android:layout_marginStart="32dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="18sp"
+                android:text="@string/choose_user"/>
+            <Spinner
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/settings_user_spinner"/>
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_margin="8dp"
-            android:id="@+id/settings_chess">
+            android:layout_marginTop="12dp" >
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/ttt_local_button"
+                android:src="@drawable/ic_launcher"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/play_chess"
+                android:text="@string/play_locally"
                 android:textSize="20sp"
-                android:layout_margin="8dp"
-                android:drawableStart="@drawable/ic_launcher"/>
+                android:layout_marginTop="20dp"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/ttt_computer_button"
+                android:src="@drawable/ic_launcher"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/play_computer"
+                android:textSize="20sp"
+                android:layout_marginTop="20dp"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp">
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/ttt_invite_button"
+                android:src="@drawable/ic_launcher"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/invite_new_user"
+                android:textSize="20sp"
+                android:layout_marginTop="20dp"/>
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="groups">
+        <item></item>
+        <item>Family</item>
+        <item>Work</item>
+    </string-array>
+
+    <string-array name="family_group">
+        <item>Mom</item>
+        <item>Dad</item>
+        <item>Grandpa</item>
+        <item>Grandma</item>
+        <item>Bro</item>
+        <item>Cousin</item>
+        <item>etc…</item>
+    </string-array>
+
+    <string-array name="work_group">
+        <item>CEO</item>
+        <item>Boss</item>
+        <item>Manager</item>
+        <item>Coworker</item>
+        <item>HR Rep</item>
+        <item>etc…</item>
+    </string-array>
+
+    <string-array name="empty_group"/>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="arrow_right"><![CDATA[>]]></string>
     <string name="banner_ad_unit_id" translatable="false">ca-app-pub-3940256099942544/6300978111</string>
     <string name="chat">Chat</string>
+    <string name="choose_group">Choose a Group:</string>
+    <string name="choose_user">Choose a User:</string>
     <string name="game">Game</string>
     <string name="intro_chat_message">Public private secure messaging with any GameChat user</string>
     <string name="intro_chat_title">Chat</string>
@@ -14,6 +16,7 @@
     <string name="intro_levels_message">Relaxed games for teaching and learning as well as competiitve levels for serious players</string>
     <string name="intro_levels_title">Levels</string>
     <string name="intro_page_circle">\u25CF</string>
+    <string name="invite_new_user">Invite a New User!</string>
     <string name="members">Members</string>
     <string name="nav_header_label_android_studio">Android Studio</string>
     <string name="nav_header_label_android_studio_android_com">android.studio@android.com</string>
@@ -35,10 +38,15 @@
     <string name="new_game_ttt">New Game (Tic-Tac-Toe)</string>
     <string name="oValue">O</string>
     <string name="play_again">Play Again!</string>
+    <string name="play_another_user">Play with Another User!</string>
     <string name="play_checkers">Play Checkers!</string>
     <string name="play_chess">Play Chess!</string>
     <string name="play_choose_game">Select a Game to Play!</string>
+    <string name="play_computer">Play against the Computer!</string>
+    <string name="play_locally">Play Locally with a Friend!</string>
     <string name="play_ttt">Play Tic-Tac-Toe!</string>
+    <string name="playing">Playing…</string>
+    <string name="playing_ttt">Playing Tic-Tac-Toe!</string>
     <string name="register">Register</string>
     <string name="register_button_text">Sign in to your account or register a new one to have fun with friends and family.</string>
     <string name="rooms">Rooms</string>


### PR DESCRIPTION
With the newest slew of changes, the user is now able to choose between playing a local game and playing a game for which the progress is stored on firebase.

# Changed Files

## Java Files

### ChatFragment.java
* Some of the **GameManager**’s fragment index numbers have changed, which is reflected here.

### GameFragment.java
* The options menu now handles both types of Tic-Tac-Toe games.
* Moved to the **game** package.

### GameManager.java
* Now handles the two different Tic-Tac-Toe games appropriately.
* Fragment indices have been changed to incorporate the new initial fragment and the divergence of Tic-Tac-Toe games.

### PaneManager.java
* **GameFragment** import has been updated to reflect its new package.

### SettingsFragment.java
* Completely overhauled, as its previous iteration’s role has been handed over to **InitialFragment**. The new role of, and also the original concept for SettingsFragment is to be handing out “invitations” to Experience that is being created.
* Now shows four different options: Playing Locally, Playing against another user (online), playing against the computer (to be implemented), and inviting a new user to GameChat (to be implemented).
* The “Playing with Another User” option allows for the choice of groups, then the choice of users in the group. Currently this is done using placeholder string arrays in the **res/values/arrays.xml** file. It will need to be changed to be procedurally generated, based on the groups the user is in.
* Moved to the **game** package.

### TTTFragment.java
* Moved to the **game** package.

## XML Files

### layout/activity_fragments.xml
* The **ViewPager**’s indicator TextViews no longer have a bottom margin, as it was overlapping with the chat input.

### fragment_chat.xml
* The AdView now has a top margin so that it will actually be visible (as opposed to being hidden behind the app bar).
* The chat input now has a slight bottom margin to avoid overlapping with the **ViewPager** indicator.

### fragment_settings.xml
* Much like the **SettingsFragment** java class, its layout has been totally overhauled. It now contains options that facilitate invitations to other users, or allow local play of the game you chose in **InitialFragment**.
* Spinners are currently utilized to allow group and user choices for invites to online games.

### strings.xml
* A number of new strings are needed for the new layouts. They have been added and alphabetized.

## Test Files
* Only minor renaming has changed in the test files, a result of Android Studio's Refactor feature. Testing has **NOT** been implemented for the new features, and currently remains in limbo until a way to automate the sign-in procedure is successfully implemented.

# New Files

## Java Files

### InitialFragment.java
* Similar to the previous iteration of **SettingsFragment**, the **InitialFragment** is the new “start-up” screen for the Experience side of GameChat.
* Currently it allows for the creation of a Tic-Tac-Toe game. Upon selection you will be redirected to the new **SettingsFragment**

### LocalTTTFragment.java
* A simpler version of the TTTFragment that does not bother with accessing Firebase.
* Currently shares very similar methods with the standard TTTFragment. I will be looking into trying to simplify this in the future.

## XML Files

### fragment_initial.xml
* The layout for our new **InitialFragment** that allows for selecting the type of game you would like to play (e.g., Tic-Tac-Toe, chess, checkers).

### values/arrays.xml
* Contains string arrays for the spinners in **fragment_initial**.