### PR TITLE
Fix an AS introduced build error

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#0288D1</color>
-    <color name="colorAccent">#FFC107</color>
+    <color name="colorAccent">#8707ff</color>
 </resources>

--- a/libraries/intro/src/main/res/layout/activity_intro.xml
+++ b/libraries/intro/src/main/res/layout/activity_intro.xml
@@ -1,8 +1,26 @@
-<FrameLayout android:layout_width="match_parent"
-             android:layout_height="wrap_content"
-             xmlns:tools="http://schemas.android.com/tools"
-             android:background="#fafafa"
-             xmlns:android="http://schemas.android.com/apk/res/android">
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#fafafa">
 
     <FrameLayout
         android:layout_gravity="top"
@@ -54,23 +72,23 @@
             android:id="@+id/register_button"/>
 
         <LinearLayout
-            android:orientation="horizontal"
-            android:layout_marginTop="16dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp"
             android:gravity="center">
             <Button
+                style="@style/IntroTheme.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="16dp"
-                android:style="@style/Widget.AppCompat.Button.Colored"
                 android:onClick="doSignIn"
                 android:text="@string/sign_in"/>
             <Button
+                style="@style/IntroTheme.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
-                android:style="@style/Widget.AppCompat.Button.Colored"
                 android:onClick="doRegister"
                 android:text="@string/register"/>
         </LinearLayout>

--- a/libraries/intro/src/main/res/values/colors.xml
+++ b/libraries/intro/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="white">#ffffff</color>
+</resources>

--- a/libraries/intro/src/main/res/values/styles.xml
+++ b/libraries/intro/src/main/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="IntroTheme.Button" parent="Widget.AppCompat.Button.Colored">
+        <item name="android:textColor">@color/white</item>
+    </style>
+</resources>


### PR DESCRIPTION
<h1>Rationale:</h1>

Android Studio allows the developer to set a device and API level and view a layout on that device for that API level.  Doing this led to a false sense of security for the default device and API obtained on a fresh start.  This commit attempts to address that crock such that it does not matter which device and API level is currently selected.

<h1>File changes:</h1>

modified:   app/src/main/res/values/colors.xml

- Change the accent color to a preferable shade of purple rather than the ugly yellow.

modified:   libraries/intro/src/main/res/layout/activity_intro.xml

- Make a few cosmetic changes for copyright and standard attribute flow.
- Introduce a material design default button theme for the sign in and register buttons.

new file:   libraries/intro/src/main/res/values/colors.xml

- Provide a white color for the button text foreground.

new file:   libraries/intro/src/main/res/values/styles.xml

- Define the default sign in and register button theme/style.