### PR TITLE
Fix a dependency crock in AS with JUnit

### DIFF
--- a/libraries/intro/build.gradle
+++ b/libraries/intro/build.gradle
@@ -71,8 +71,6 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    testCompile 'junit:junit:4.12'
 }
 
 // Per Firebase instructions this comes last.

--- a/libraries/signin/build.gradle
+++ b/libraries/signin/build.gradle
@@ -54,8 +54,6 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    testCompile 'junit:junit:4.12'
 }
 
 // Per Firebase instructions this comes last.


### PR DESCRIPTION
<h1>Rationale:</h1>

With the advent of moving the sign in and intro activities into Library Project modules, a crock surfaced whereby AS (2.2 Preview 7) could not resolve JUnit symbols such as Test, Rule, etc.  This crock turned out to be due to the library modules explicitly adding junit dependencies.  This commit removes those dependencies and the crock along with it.

<h1>File changes:</h1>

modified:   libraries/intro/build.gradle
modified:   libraries/signin/build.gradle

- Remove the extra junit and appcompat dependencies.