### PR TITLE
Fix the broken ApplicationTest tests.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
@@ -45,15 +45,15 @@ public class ApplicationTest {
         // Do nothing initially.
     }
 
-    /** Ensure that the chat panel is being displayed. */
+    /** Ensure that the rooms panel is being displayed. */
     @Test public void testChatPaneIsVisible() {
-        onView(withId(R.id.chat_pane))
+        onView(withId(R.id.rooms_pane))
                 .check(matches(isDisplayed()));
     }
 
     /** Ensure that the chat panel is being displayed. */
     @Test public void testGamePaneIsVisible() {
-        onView(withId(R.id.chat_pane))
+        onView(withId(R.id.rooms_pane))
                 .check(matches(isDisplayed()))
                 .perform(swipeLeft());
         onView(withId(R.id.game_pane_fragment_container))
@@ -75,7 +75,7 @@ public class ApplicationTest {
         onView(withId(R.id.toolbar_chat_icon))
                 .check(matches(isDisplayed()))
                 .perform(click());
-        onView(withId(R.id.chat_pane))
+        onView(withId(R.id.rooms_pane))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -447,6 +447,7 @@ public class ChatFragment extends BaseFragment
                     case R.id.fab_new_game:
                         if(viewPager != null) { viewPager.setCurrentItem(PaneManager.GAME_INDEX); }
                         GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
+                        break;
                     default:
                         break;
                 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
@@ -19,29 +19,121 @@ package com.pajato.android.gamechat.chat;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.game.GameManager;
+import com.pajato.android.gamechat.main.PaneManager;
 
+import io.github.yavski.fabspeeddial.FabSpeedDial;
+import io.github.yavski.fabspeeddial.SimpleMenuListenerAdapter;
 
-public class RoomsFragment extends Fragment{
+/**
+ * Provide a fragment to handle the display of the rooms available to the current user.
+ *
+ * @author Paul Michael Reilly
+ */
+public class RoomsFragment extends Fragment {
 
-    public RoomsFragment() {
-        // Required empty public constructor
+    // Public instance variables.
+
+    /** Show an ad at the top of the view. */
+    private AdView mAdView;
+
+    /** Handle the setup for the rooms panel. */
+    @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                       Bundle savedInstanceState) {
+        // Enable the options menu, layout the fragment and set up the ad view.
+        setHasOptionsMenu(true);
+        View result = inflater.inflate(R.layout.fragment_rooms, container, false);
+        mAdView = (AdView) result.findViewById(R.id.adView);
+        AdRequest adRequest = new AdRequest.Builder().build();
+        mAdView.loadAd(adRequest);
+        return result;
     }
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    /** Post the chat options menu on demand. */
+    @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater menuInflater) {
+        menuInflater.inflate(R.menu.chat_menu, menu);
+        initFabListener();
     }
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_rooms, container, false);
+    /** Handle an options menu choice. */
+    @Override public boolean onOptionsItemSelected(final MenuItem item) {
+        switch (item.getItemId()) {
+        case R.id.toolbar_game_icon:
+            // Show the game panel.
+            ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+            if(viewPager != null) {
+                viewPager.setCurrentItem(PaneManager.GAME_INDEX);
+            }
+            break;
+        case R.id.toolbar_search_icon:
+            // TODO: Handle a seach in the rooms panel by fast scrolling to room.
+            break;
+        default:
+            break;
+
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the ad. */
+    @Override public void onPause() {
+        if (mAdView != null) {
+            mAdView.pause();
+        }
+        super.onPause();
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the ad. */
+    @Override public void onResume() {
+        super.onResume();
+        if (mAdView != null) {
+            mAdView.resume();
+        }
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the ad. */
+    @Override public void onDestroy() {
+        if (mAdView != null) {
+            mAdView.destroy();
+        }
+        super.onDestroy();
+    }
+
+    /** Setup the chat functions provided by the FAB button. */
+    private void initFabListener() {
+        // Set up the FAB speed dial menu.
+        FabSpeedDial fab = (FabSpeedDial) getActivity().findViewById(R.id.fab_speed_dial);
+        fab.setMenuListener(new SimpleMenuListenerAdapter() {
+            @Override
+            public boolean onMenuItemSelected(MenuItem menuItem) {
+                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+                switch(menuItem.getItemId()) {
+                    // Start a new Tic-Tac-Toe game
+                    case R.id.fab_ttt:
+                        if(viewPager != null) { viewPager.setCurrentItem(PaneManager.GAME_INDEX); }
+                        GameManager.instance.sendNewGame(GameManager.TTT_LOCAL_INDEX, getActivity());
+                        break;
+                    // Navigate to the Game Settings panel
+                    case R.id.fab_new_game:
+                        if(viewPager != null) { viewPager.setCurrentItem(PaneManager.GAME_INDEX); }
+                        GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
+                    default:
+                        break;
+                }
+                return false;
+            }
+        });
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -91,9 +91,10 @@ public class MainActivity extends AppCompatActivity
                 break;
         }    }
 
+    /** Handle a back button press. */
     @Override public void onBackPressed() {
-        NavigationManager.instance.closeDrawerIfOpen(this);
-        super.onBackPressed();
+        // If the navigation drawer is open, close it, otherwise let the system deal with it.
+        if (!NavigationManager.instance.closeDrawerIfOpen(this)) super.onBackPressed();
     }
 
     /** Process a navigation menu item click by posting a click event. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -101,11 +101,14 @@ public enum NavigationManager {
     }
 
     /** Check for an open navigation drawer and close it if one is found. */
-    public void closeDrawerIfOpen(final Activity activity) {
+    public boolean closeDrawerIfOpen(final Activity activity) {
         DrawerLayout drawer = (DrawerLayout) activity.findViewById(R.id.drawer_layout);
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
+            return true;
         }
+
+        return false;
     }
 
     /**

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -66,7 +66,7 @@ public enum PaneManager {
         // Clear the current panes and determine if a paging layout is active.
         fragmentList.clear();
         titleList.clear();
-        titleList.add(context.getString(R.string.chat));
+        titleList.add(context.getString(R.string.rooms));
         titleList.add(context.getString(R.string.game));
         ViewPager viewPager = (ViewPager) context.findViewById(R.id.viewpager);
 

--- a/app/src/main/res/layout/fragment_rooms.xml
+++ b/app/src/main/res/layout/fragment_rooms.xml
@@ -14,23 +14,59 @@ details.
 You should have received a copy of the GNU General Public License along with GameChat.  If not, see
 http://www.gnu.org/licenses
 -->
-<LinearLayout
+<android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerInParent="true"
-    android:orientation="horizontal">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <TextView
+    <RelativeLayout
+        android:id="@+id/rooms_pane"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        tools:context="com.pajato.android.gamechat.chat.ChatFragment">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/messageRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/adView"
+            android:layout_above="@+id/linearLayout"/>
+
+        <com.google.android.gms.ads.AdView
+            android:id="@+id/adView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentTop="true"
+            android:paddingBottom="8dp"
+            android:layout_marginTop="44dp"
+            ads:adSize="BANNER"
+            ads:adUnitId="@string/banner_ad_unit_id">
+        </com.google.android.gms.ads.AdView>
+
+    </RelativeLayout>
+
+    <io.github.yavski.fabspeeddial.FabSpeedDial
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/rooms"
-        android:textSize="40sp"
-        android:textStyle="bold" />
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/tbd"
-        android:textSize="20sp"
-        android:textStyle="bold" />
-</LinearLayout>
+        app:fabGravity="bottom_end"
+        app:fabMenu="@menu/fab"
+        android:id="@+id/fab_speed_dial"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@android:drawable/ic_dialog_email"
+        app:layout_constraintBottom_toBottomOf="@+id/rooms_pane"
+        app:layout_constraintRight_toLeftOf="@+id/rooms_pane"
+        app:fabBackgroundTint="@color/colorAccent"
+        app:miniFabBackgroundTint="@color/colorAccent"
+        app:miniFabDrawableTint="@color/colorPrimaryDark"
+        app:miniFabTitleTextColor="@color/colorPrimaryDark"
+        android:visibility="invisible" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/chat_menu.xml
+++ b/app/src/main/res/menu/chat_menu.xml
@@ -3,15 +3,31 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:title="@string/game"
-        android:icon="@drawable/ic_games_white"
-        android:id="@+id/toolbar_game_icon"
-        android:orderInCategory="0"
-        app:showAsAction="ifRoom"/>
-    <item
         android:title="@string/spaceValue"
         android:icon="@drawable/ic_search_white"
         android:id="@+id/toolbar_search_icon"
+        android:orderInCategory="0"
+        app:showAsAction="ifRoom"/>
+    <item
+        android:title="@string/game"
+        android:icon="@drawable/ic_games_white"
+        android:id="@+id/toolbar_game_icon"
         android:orderInCategory="1"
         app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/nav_settings"
+        android:onClick="menuClick"
+        android:icon="@drawable/ic_settings_black"
+        android:title="@string/navigation_drawer_label_problems_settings" />
+    <item
+        android:id="@+id/nav_feedback"
+        android:icon="@drawable/ic_help_black"
+        android:onClick="menuClick"
+        android:title="@string/navigation_drawer_label_problems_feedback" />
+    <item
+        android:id="@+id/nav_learn"
+        android:tag="@integer/learnMore"
+        android:icon="@drawable/ic_info_black"
+        android:onClick="menuClick"
+        android:title="@string/navigation_drawer_label_problems_learn" />
 </menu>


### PR DESCRIPTION
<h1>Rationale:</h1>

Our excellent and thorough tests took a back seat to some UI sign in and intro activity rework recently, leaving  many tests failing.  This commit starts to get back to the "all tests pass before push" model.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- Change (mostly) chat panel references to rooms panel references.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- Cosmetic addition of a 'break' statement.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
modified:   app/src/main/res/layout/fragment_rooms.xml

- Initial fleshing out of this screen based on converting the placeholder code to code similar to the ChatFragment class.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- Handle a back button press by closing the navigation drawer if it is open and letting the system deal with it otherwise.

modified:   app/src/main/res/menu/chat_menu.xml

- Move to a more standard approach where Settings, Feedback, and Learn More menu items are to found in the overflow menu.