### PR TITLE
Wrap up the "no groups" screen

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
@@ -77,7 +77,7 @@ public class RoomsFragment extends Fragment {
 
         FloatingActionButton fab = (FloatingActionButton) result.findViewById(R.id.rooms_fab);
         View menu = result.findViewById(R.id.rooms_fab_menu);
-        View content = result.findViewById(R.id.rooms_content);
+        View content = result.findViewById(R.id.rooms_none);
         FabManager.instance.init(fab, content, menu);
 
         return result;

--- a/app/src/main/res/layout/fragment_rooms.xml
+++ b/app/src/main/res/layout/fragment_rooms.xml
@@ -59,39 +59,65 @@ http://www.gnu.org/licenses
         app:fabSize="normal"
         tools:visibility="visible"/>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/rooms_content"
-        android:orientation="vertical"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
-
-        <com.google.android.gms.ads.AdView
-            android:id="@+id/adView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            ads:adSize="BANNER"
-            ads:adUnitId="@string/banner_ad_unit_id"/>
-
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/rooms_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:visibility="gone"/>
-
-        <TextView
+    <!-- The main content for the rooms pane is either an ad view
+         followed by a list of expandable groups or an intro screen
+         for Users with no groups. -->
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:id="@+id/rooms_message"
-            android:padding="24dp"
-            android:textAlignment="center"
-            android:textSize="24sp"
-            android:text="@string/no_rooms_message_text"
-            tools:text="Placeholder message ... updated at runtime."
-            tools:visibility="visible"/>
-    </LinearLayout>
+            android:id="@+id/rooms_main"
+            android:orientation="vertical"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:visibility="gone">
+
+            <com.google.android.gms.ads.AdView
+                android:id="@+id/adView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                ads:adSize="BANNER"
+                ads:adUnitId="@string/banner_ad_unit_id"/>
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/rooms_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/rooms_none"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            app:layout_constraintCenterX_toCenterX="parent"
+            app:layout_constraintCenterY_toCenterY="parent"
+            tools:visibility="visible">
+
+            <GridLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:useDefaultMargins="true"
+                android:columnOrderPreserved="true"
+                android:columnCount="2"
+                tools:ignore="ContentDescription">
+                <ImageView style="@style/RoomsIcon" android:tint="@color/colorRed" />
+                <ImageView style="@style/RoomsIcon" android:tint="@color/colorBlue" />
+                <ImageView style="@style/RoomsIcon" android:tint="@color/colorGray" />
+                <ImageView style="@style/RoomsIcon" android:tint="@color/colorGreen" />
+            </GridLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/rooms_message"
+                android:padding="24dp"
+                android:text="@string/no_rooms_message_text"
+                android:textAlignment="center"
+                android:textSize="24sp"
+                tools:text="Placeholder message ... updated at runtime."
+                tools:visibility="visible" />
+        </LinearLayout>
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,8 @@
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#0288D1</color>
     <color name="colorAccent">#8707ff</color>
+    <color name="colorRed">#d50000</color>
+    <color name="colorBlue">#3f51b5</color>
+    <color name="colorGreen">#00c853</color>
+    <color name="colorGray">#616161</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,5 +55,4 @@
     <string name="winner_tie">Tie!</string>
     <string name="winner_x">X Wins!</string>
     <string name="xValue">X</string>
-    <string name="no_rooms_message_text">There are currently no rooms available.  GameChat is much more fun with rooms.  Use the + button to create one.</string>
 </resources>

--- a/app/src/main/res/values/strings_room_pane.xml
+++ b/app/src/main/res/values/strings_room_pane.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="no_rooms_message_text">You currently have no groups.  Add groups to invite family and friends!  Use the + button to create one.  Meanwhile play games by your self to enjoy your alone time.</string>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -64,4 +64,9 @@ http://www.gnu.org/licenses
         <item name="android:tint">@color/colorPrimaryDark</item>
     </style>
 
+    <style name="RoomsIcon">
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:src">@drawable/ic_casino_black_24dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
<h1>Rationale:</h1>

The Rooms fragment provides special handling when there are no groups to provide rooms to display.  This commit fleshes out that handling and should be considered ready for a professional graphic designer to review.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java

- Identify the "no groups" layout as the content screen by default.

modified:   app/src/main/res/layout/fragment_rooms.xml

- Overhaul the rooms layout to clearly separate the "no groups" layout from the "main" layout.

modified:   app/src/main/res/values/colors.xml

- Add colors to make the rooms grid vibrant.

modified:   app/src/main/res/values/strings.xml

- Move the "no groups" message to it's own resource file, where it is exected to be joined by others soon.

modified:   app/src/main/res/values/styles.xml

- Add a style for the rooms icon in the grid.

new file:   app/src/main/res/values/strings_room_pane.xml

- Start putting string resources into clearly identified resource files.