### PR TITLE
Chess Feature Implemented

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -395,10 +395,10 @@ public class CheckersFragment extends BaseFragment {
         // Handle capturing pieces.
         boolean finishedJumping = true;
         if(capturesPiece) {
-            int pieceCaptuedIndex = (indexClicked + highlightedIndex) / 2;
-            ImageButton capturedTile = (ImageButton) mBoard.getChildAt(pieceCaptuedIndex);
+            int pieceCapturedIndex = (indexClicked + highlightedIndex) / 2;
+            ImageButton capturedTile = (ImageButton) mBoard.getChildAt(pieceCapturedIndex);
             capturedTile.setImageResource(0);
-            mBoardMap.delete(pieceCaptuedIndex);
+            mBoardMap.delete(pieceCapturedIndex);
 
             // If there are no more jumps, change turns. If there is at least one jump left, don't.
             ArrayList<Integer> possibleJumps = new ArrayList<>();

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -1,0 +1,593 @@
+package com.pajato.android.gamechat.game;
+
+import android.content.DialogInterface;
+import android.graphics.PorterDuff;
+import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
+import android.util.SparseArray;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.GridLayout;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.fragment.BaseFragment;
+
+import java.util.ArrayList;
+import java.util.Scanner;
+
+/**
+ * A simple Chess game for use in GameChat.
+ *
+ * @author Bryan Scott
+ */
+public class ChessFragment extends BaseFragment {
+    public boolean mTurn;
+
+    // Board Management Objects
+    private GridLayout mBoard;
+    private SparseArray<ChessPiece> mBoardMap;
+    private ImageButton mHighlightedTile;
+    private boolean mIsHighlighted = false;
+    private View mLayout;
+    private ArrayList<Integer> mPossibleMoves;
+
+    // Castle Management Objects
+    private boolean mBlueQueenSidePawnHasMoved;
+    private boolean mBlueKingSidePawnHasMoved;
+    private boolean mBlueKingHasMoved;
+    private boolean mOtherQueenSidePawnHasMoved;
+    private boolean mOtherKingSidePawnHasMoved;
+    private boolean mOtherKingHasMoved;
+
+
+    @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                       Bundle savedInstanceState) {
+        mLayout = inflater.inflate(R.layout.fragment_checkers, container, false);
+        mBoard = (GridLayout) mLayout.findViewById(R.id.board);
+        mTurn = false;
+        onNewGame();
+
+        ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player_1_icon);
+        playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorPrimary),
+                PorterDuff.Mode.SRC_ATOP);
+
+        ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
+        playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorAccent),
+                PorterDuff.Mode.SRC_ATOP);
+
+        return mLayout;
+    }
+
+
+    /**
+     * A stand-in method that allows for creating a new game via game manager. Translates the
+     * messages sent by the event system and handles the individual clicks based on messages sent.
+     *
+     * @param msg the message to be handled.
+     */
+    public void messageHandler(final String msg) {
+        //TODO: Replace with the event bus system.
+        Scanner input = new Scanner(msg);
+        String player = input.nextLine();
+        String buttonTag = input.nextLine();
+        input.close();
+
+        if(buttonTag.equals(getString(R.string.new_game))) {
+            onNewGame();
+
+            int color;
+            if(player.equals("Purple")) {
+                color = ContextCompat.getColor(getContext(), R.color.colorAccent);
+                handleTurnChange();
+            } else {
+                player = "Blue";
+                color = ContextCompat.getColor(getContext(), R.color.colorPrimary);
+            }
+            GameManager.instance.generateSnackbar(mLayout, getString(R.string.new_game) + " "
+                    + player + "'s Turn!", color, false);
+        }
+
+    }
+
+    /**
+     * Handles a new game of checkers, resetting the board.
+     */
+    private void onNewGame() {
+        mBoard.removeAllViews();
+        mBoardMap = new SparseArray<>();
+        mBoardMap.clear();
+        mPossibleMoves = new ArrayList<>();
+        mPossibleMoves.clear();
+
+        // Reset the castling booleans.
+        mBlueQueenSidePawnHasMoved = false;
+        mBlueKingSidePawnHasMoved = false;
+        mBlueKingHasMoved = false;
+        mOtherQueenSidePawnHasMoved = false;
+        mOtherKingSidePawnHasMoved = false;
+        mOtherKingHasMoved = false;
+
+        // Go through and populate the GridLayout / Board.
+        for(int i = 0; i < 64; i++) {
+            ImageButton currentTile = new ImageButton(getContext());
+
+            // Set up the gridlayout params, so that each cell is functionally identical.
+            //TODO: Handle alternate resolutions in a better way.
+            GridLayout.LayoutParams param = new GridLayout.LayoutParams();
+            param.height = 90;
+            param.width = 90;
+            param.rightMargin = 0;
+            param.topMargin = 0;
+            param.setGravity(Gravity.CENTER);
+            param.rowSpec = GridLayout.spec(i / 8);
+            param.columnSpec = GridLayout.spec(i % 8);
+
+            // Set up the Tile-specific information.
+            currentTile.setLayoutParams(param);
+            currentTile.setTag(i);
+            handleTileBackground(i, currentTile);
+
+            // Handle the starting piece positions.
+            boolean containsNonBluePiece = i < 16;
+            boolean containsBluePiece = i > 47;
+            boolean containsPiece = containsBluePiece || containsNonBluePiece;
+            int team;
+            int color;
+
+            // If the tile is meant to contain a board piece at the start of play, give it a piece.
+            if(containsPiece) {
+                if(containsBluePiece) {
+                    team = ChessPiece.BLUE_TEAM;
+                    color = R.color.colorPrimary;
+                } else {
+                    team = ChessPiece.OTHER_TEAM;
+                    color = R.color.colorAccent;
+                }
+                switch(i) {
+                    default:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.PAWN, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.PAWN));
+                        break;
+                    case 0: case 7:
+                    case 56: case 63:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.ROOK, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.ROOK));
+                        break;
+                    case 1: case 6:
+                    case 57: case 62:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.KNIGHT, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.KNIGHT));
+                        break;
+                    case 2: case 5:
+                    case 58: case 61:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.BISHOP, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.BISHOP));
+                        break;
+                    case 3:
+                    case 59:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.QUEEN, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.QUEEN));
+                        break;
+                    case 4:
+                    case 60:
+                        mBoardMap.put(i, new ChessPiece(ChessPiece.KING, team));
+                        currentTile.setImageResource(ChessPiece.getDrawableFor(ChessPiece.KING));
+                }
+                currentTile.setColorFilter(ContextCompat.getColor(getContext(), color), PorterDuff.Mode.SRC_ATOP);
+            }
+            currentTile.setOnClickListener(new ChessClick());
+            mBoard.addView(currentTile);
+        }
+
+        handleTurnChange();
+    }
+
+    /**
+     * showPossibleMoves handles highlighting possible movement options of a clicked piece,
+     * then on a subsequent click it removes those highlights.
+     *
+     * @param indexClicked the index of the tile clicked.
+     */
+    private void showPossibleMoves(final int indexClicked) {
+        // If the game is over, we don't need to do anything.
+        if(checkFinished()) {
+            return;
+        }
+
+        int highlightedIndex = (int) mHighlightedTile.getTag();
+        findPossibleMoves(highlightedIndex, mPossibleMoves);
+
+        // If a highlighted tile exists, we remove the highlight on it and its movement options.
+        if(mIsHighlighted) {
+            handleTileBackground(highlightedIndex, mHighlightedTile);
+
+            for (int possiblePosition : mPossibleMoves) {
+                // If the tile clicked is one of the possible positions, and it's the correct
+                // turn/piece combination, the piece moves there.
+                if(indexClicked == possiblePosition) {
+                    boolean capturesPiece = (indexClicked > 9 + highlightedIndex) ||
+                            (indexClicked < highlightedIndex - 9);
+                    if(mTurn && (mBoardMap.get(highlightedIndex).getTeam() == ChessPiece.BLUE_TEAM)) {
+                        handleMovement(true, indexClicked, capturesPiece);
+                    } else if(!mTurn && (mBoardMap.get(highlightedIndex).getTeam() == ChessPiece.OTHER_TEAM)) {
+                        handleMovement(false, indexClicked, capturesPiece);
+                    }
+                }
+                handleTileBackground(possiblePosition, (ImageButton) mBoard.getChildAt(possiblePosition));
+            }
+            mHighlightedTile = null;
+
+            // Otherwise, we need to highlight the tile clicked and its potential move squares with red.
+        } else {
+            mHighlightedTile.setBackgroundColor(ContextCompat.getColor(getContext(),
+                    android.R.color.holo_red_dark));
+            for(int possiblePosition : mPossibleMoves) {
+                mBoard.getChildAt(possiblePosition).setBackgroundColor(ContextCompat
+                        .getColor(getContext(), android.R.color.holo_red_light));
+            }
+        }
+
+        mIsHighlighted = !mIsHighlighted;
+    }
+
+    /**
+     * Checks to see if the game is over or not by counting the number of blue / yellow pieces on
+     * the board. If there are zero of one type of pieces, then the other side wins.
+     *
+     * @return true if the game is over, false otherwise.
+     */
+    private boolean checkFinished() {
+        // Generate win conditions. If one side runs out of pieces, the other side wins.
+        int otherKing = 0;
+        int blueKing = 0;
+
+        for(int i = 0; i < 64; i++) {
+            ChessPiece tmp = mBoardMap.get(i, null);
+            if(tmp != null) {
+                if(tmp.getPiece() == ChessPiece.KING) {
+                    if(tmp.getTeam() == ChessPiece.BLUE_TEAM) {
+                        blueKing++;
+                    } else if (tmp.getTeam() == ChessPiece.OTHER_TEAM) {
+                        otherKing++;
+                    }
+                }
+            }
+        }
+        // Verify win conditions. If one passes, return true and generate an endgame snackbar.
+        if(otherKing == 0) {
+            GameManager.instance.generateSnackbar(mBoard, "Game Over! Blue Wins!",
+                    ContextCompat.getColor(getContext(), R.color.colorPrimary), true);
+            return true;
+        } else if (blueKing == 0) {
+            GameManager.instance.generateSnackbar(mBoard, "Game Over! Purple Wins!",
+                    ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void handleTileBackground(final int index, final ImageButton currentTile) {
+        // Handle the checkerboard positions.
+        boolean isEven = (index % 2 == 0);
+        boolean isOdd = (index % 2 == 1);
+        boolean evenRowEvenColumn = ((index / 8) % 2 == 0) && isEven;
+        boolean oddRowOddColumn = ((index / 8) % 2 == 1) && isOdd;
+
+        // Create the checkerboard pattern on the button backgrounds.
+        if(evenRowEvenColumn || oddRowOddColumn) {
+            currentTile.setBackgroundColor(ContextCompat.getColor(
+                    getContext(), android.R.color.white));
+        } else {
+            currentTile.setBackgroundColor(ContextCompat.getColor(
+                    getContext(), android.R.color.darker_gray));
+        }
+    }
+
+    /**
+     * Locates the possible moves of the piece that is about to be highlighted.
+     *
+     * @param highlightedIndex the index containing the highlighted piece.
+     */
+    private void findPossibleMoves(final int highlightedIndex, final ArrayList<Integer> possibleMoves) {
+        if(highlightedIndex < 0 || highlightedIndex > 64) {
+            return;
+        }
+
+        possibleMoves.clear();
+        int highlightedPieceType = mBoardMap.get(highlightedIndex).getPiece();
+
+        switch(highlightedPieceType) {
+            case ChessPiece.PAWN:
+                ChessPiece.getPawnThreatRange(possibleMoves, highlightedIndex, mBoardMap);
+                break;
+            case ChessPiece.ROOK:
+                ChessPiece.getRookThreatRange(possibleMoves, highlightedIndex, mBoardMap);
+                break;
+            case ChessPiece.KNIGHT:
+                ChessPiece.getKnightThreatRange(possibleMoves, highlightedIndex, mBoardMap);
+                break;
+            case ChessPiece.BISHOP:
+                ChessPiece.getBishopThreatRange(possibleMoves, highlightedIndex, mBoardMap);
+                break;
+            case ChessPiece.QUEEN:
+                ChessPiece.getQueenThreatRange(possibleMoves, highlightedIndex, mBoardMap);
+                break;
+            case ChessPiece.KING:
+                boolean[] castlingBooleans = {mBlueQueenSidePawnHasMoved, mBlueKingSidePawnHasMoved,
+                        mBlueKingHasMoved, mOtherQueenSidePawnHasMoved, mOtherKingSidePawnHasMoved,
+                        mOtherKingHasMoved};
+                ChessPiece.getKingThreatRange(possibleMoves, highlightedIndex, mBoardMap,
+                        castlingBooleans);
+                break;
+        }
+
+    }
+
+    /**
+     * Handles the movement of the pieces.
+     *
+     * @param player indicates the current player. True is blue, False is yellow.
+     * @param indexClicked the index of the clicked tile and the new position of the piece.
+     */
+    private void handleMovement(final boolean player, final int indexClicked,
+                                final boolean capturesPiece) {
+        // Reset the highlighted tile's image.
+        mHighlightedTile.setImageResource(0);
+        int highlightedIndex = (int) mHighlightedTile.getTag();
+        ChessPiece highlightedPiece = mBoardMap.get(highlightedIndex);
+
+        // Handle capturing pieces.
+        if(capturesPiece) {
+            ImageButton capturedTile = (ImageButton) mBoard.getChildAt(indexClicked);
+            capturedTile.setImageResource(0);
+            mBoardMap.delete(indexClicked);
+        }
+
+        // Check to see if our pawn can becomes another piece and put its value into the board map.
+        if(indexClicked < 8 && highlightedPiece.getPiece() == ChessPiece.PAWN &&
+                highlightedPiece.getTeam() == ChessPiece.BLUE_TEAM) {
+            promotePawn(indexClicked, ChessPiece.BLUE_TEAM);
+        } else if (indexClicked > 55 && highlightedPiece.getPiece() == ChessPiece.PAWN &&
+                highlightedPiece.getTeam() == ChessPiece.OTHER_TEAM) {
+            promotePawn(indexClicked, ChessPiece.OTHER_TEAM);
+        } else {
+            mBoardMap.put(indexClicked, highlightedPiece);
+
+            // Find the new tile and give it a piece.
+            ImageButton newLocation = (ImageButton) mBoard.getChildAt(indexClicked);
+            newLocation.setImageResource(ChessPiece.getDrawableFor(mBoardMap.get(indexClicked).getPiece()));
+
+            // Color the piece according to the player.
+            int color;
+            if(player) {
+                color = ContextCompat.getColor(getContext(), R.color.colorPrimary);
+            } else {
+                color = ContextCompat.getColor(getContext(), R.color.colorAccent);
+            }
+            newLocation.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        }
+
+        // Handle the movement of the Rook for Castling
+        boolean castlingKingSide = indexClicked == highlightedIndex + 2;
+        boolean castlingQueenSide = indexClicked == highlightedIndex - 3;
+        boolean isCastling = mBoardMap.get(highlightedIndex).getPiece() == ChessPiece.KING &&
+                (castlingKingSide || castlingQueenSide);
+        if(isCastling) {
+            int color;
+            int team;
+            // Handle the player-dependent pieces of the castle.
+            if(player) {
+                color = ContextCompat.getColor(getContext(), R.color.colorPrimary);
+                team = ChessPiece.BLUE_TEAM;
+            } else {
+                color = ContextCompat.getColor(getContext(), R.color.colorAccent);
+                team = ChessPiece.OTHER_TEAM;
+            }
+            int rookPrevIndex;
+            int rookFutureIndex;
+            // Handle the side-dependent pieces of the castle (king-side vs queen-side)
+            if(castlingKingSide) {
+                rookPrevIndex = highlightedIndex + 3;
+                rookFutureIndex = highlightedIndex + 1;
+            } else {
+                rookPrevIndex = highlightedIndex - 4;
+                rookFutureIndex = highlightedIndex - 2;
+            }
+
+            // Put a rook at the new rook position.
+            mBoardMap.put(rookFutureIndex, new ChessPiece(ChessPiece.ROOK, team));
+            ImageButton futureRook = (ImageButton) mBoard.getChildAt(rookFutureIndex);
+            futureRook.setImageResource(ChessPiece.getDrawableFor(ChessPiece.ROOK));
+            futureRook.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+
+            // Get rid of the old rook.
+            ImageButton previousRook = (ImageButton) mBoard.getChildAt(rookPrevIndex);
+            previousRook.setImageResource(0);
+            mBoardMap.delete(rookPrevIndex);
+        }
+
+        // Handle the Castling Booleans.
+        ChessPiece currentPiece = mBoardMap.get(highlightedIndex);
+        if(currentPiece.getPiece() == ChessPiece.KING) {
+            if(currentPiece.getTeam() == ChessPiece.BLUE_TEAM) {
+                mBlueKingHasMoved = true;
+            } else {
+                mOtherKingHasMoved = true;
+            }
+        } else if (currentPiece.getPiece() == ChessPiece.ROOK) {
+            if(currentPiece.getTeam() == ChessPiece.BLUE_TEAM) {
+                if(highlightedIndex == 0) {
+                    mBlueQueenSidePawnHasMoved = true;
+                } else if (highlightedIndex == 7) {
+                    mBlueKingSidePawnHasMoved = true;
+                }
+            } else {
+                if(highlightedIndex == 56) {
+                    mOtherQueenSidePawnHasMoved = true;
+                } else if (highlightedIndex == 63) {
+                    mOtherKingSidePawnHasMoved = true;
+                }
+            }
+        }
+
+        // Delete the piece's previous location and end the turn.
+        mBoardMap.delete(highlightedIndex);
+        handleTurnChange();
+        checkFinished();
+    }
+
+    /**
+     * Handles changing the turn and turn indicator.
+     */
+    private void handleTurnChange() {
+        mTurn = !mTurn;
+
+        // Handle the TextViews that serve as our turn indicator.
+        TextView playerOneLeft = (TextView) mLayout.findViewById(R.id.player_1_left_indicator);
+        TextView playerOneRight = (TextView) mLayout.findViewById(R.id.player_1_right_indicator);
+        TextView playerTwoLeft = (TextView) mLayout.findViewById(R.id.player_2_left_indicator);
+        TextView playerTwoRight = (TextView) mLayout.findViewById(R.id.player_2_right_indicator);
+
+        if(mTurn) {
+            playerOneLeft.setVisibility(View.VISIBLE);
+            playerOneRight.setVisibility(View.VISIBLE);
+            playerTwoLeft.setVisibility(View.INVISIBLE);
+            playerTwoRight.setVisibility(View.INVISIBLE);
+        } else {
+            playerOneLeft.setVisibility(View.INVISIBLE);
+            playerOneRight.setVisibility(View.INVISIBLE);
+            playerTwoLeft.setVisibility(View.VISIBLE);
+            playerTwoRight.setVisibility(View.VISIBLE);
+        }
+    }
+
+    /**
+     * Handles the promotion of pawns once they reach the end of the board.
+     *
+     * @param position the position of the pawn when it is promoted.
+     * @param team the team the pawn belongs to.
+     */
+    private void promotePawn(final int position, final int team) {
+        // Generate an AlertDialog via the AlertDialog Builder
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext());
+        alertDialogBuilder.setTitle("Promote Your Pawn:")
+                .setIcon(ChessPiece.getDrawableFor(ChessPiece.PAWN))
+                .setView(R.layout.pawn_dialog);
+        AlertDialog pawnChooser = alertDialogBuilder.create();
+        pawnChooser.show();
+
+        int color = (team == ChessPiece.BLUE_TEAM) ? ContextCompat.getColor(getContext(),
+                R.color.colorPrimary) : ContextCompat.getColor(getContext(), R.color.colorAccent);
+
+        // Change the Dialog's Icon color.
+        int alertIconId = getActivity().getResources().getIdentifier("android:id/icon", null, null);
+        ImageView alertIcon = (ImageView) pawnChooser.findViewById(alertIconId);
+        if(alertIcon != null) {
+            alertIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+        }
+        // Setup the Queen Listeners and change color appropriate to the team.
+        ImageView queenIcon = (ImageView) pawnChooser.findViewById(R.id.queen_icon);
+        TextView queenText = (TextView) pawnChooser.findViewById(R.id.queen_text);
+        if(queenIcon != null && queenText != null) {
+            queenIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            queenIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
+            queenText.setOnClickListener(new Promoter(position, team, pawnChooser));
+        }
+        // Do the same for bishop.
+        ImageView bishopIcon = (ImageView) pawnChooser.findViewById(R.id.bishop_icon);
+        TextView bishopText = (TextView) pawnChooser.findViewById(R.id.bishop_text);
+        if(bishopIcon != null && bishopText != null) {
+            bishopIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            bishopIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
+            bishopText.setOnClickListener(new Promoter(position, team, pawnChooser));
+        }
+        // And the same for knight.
+        ImageView knightIcon = (ImageView) pawnChooser.findViewById(R.id.knight_icon);
+        TextView knightText = (TextView) pawnChooser.findViewById(R.id.knight_text);
+        if(knightIcon != null && knightText != null) {
+            knightIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            knightIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
+            knightText.setOnClickListener(new Promoter(position, team, pawnChooser));
+        }
+        // And finally, the same for rook.
+        ImageView rookIcon = (ImageView) pawnChooser.findViewById(R.id.rook_icon);
+        TextView rookText = (TextView) pawnChooser.findViewById(R.id.rook_text);
+        if(rookIcon != null && rookText != null) {
+            rookIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
+            rookIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            rookText.setOnClickListener(new Promoter(position, team, pawnChooser));
+        }
+    }
+
+    private class Promoter implements View.OnClickListener {
+        AlertDialog mDialog;
+        int position;
+        int team;
+
+        Promoter(final int indexClicked, final int teamNumber, AlertDialog dialog) {
+            position = indexClicked;
+            team = teamNumber;
+            mDialog = dialog;
+        }
+
+        @Override public void onClick(final View v) {
+            int id = v.getId();
+            int pieceType;
+            switch (id) {
+                default:
+                case R.id.queen_icon:
+                case R.id.queen_text:
+                    pieceType = ChessPiece.QUEEN;
+                    break;
+                case R.id.bishop_icon:
+                case R.id.bishop_text:
+                    pieceType = ChessPiece.BISHOP;
+                    break;
+                case R.id.knight_icon:
+                case R.id.knight_text:
+                    pieceType = ChessPiece.KNIGHT;
+                    break;
+                case R.id.rook_icon:
+                case R.id.rook_text:
+                    pieceType = ChessPiece.ROOK;
+                    break;
+            }
+
+            mBoardMap.put(position, new ChessPiece(pieceType, team));
+            ImageButton promotedPieceTile = (ImageButton) mBoard.getChildAt(position);
+            promotedPieceTile.setImageResource(ChessPiece.getDrawableFor(pieceType));
+            boolean teamColor = team == ChessPiece.BLUE_TEAM;
+            int color = teamColor ? R.color.colorPrimary: R.color.colorAccent;
+            promotedPieceTile.setColorFilter(ContextCompat.getColor(getContext(), color),
+                    PorterDuff.Mode.SRC_ATOP);
+
+            mDialog.dismiss();
+        }
+    }
+
+    /**
+     * A View.OnClickListener that is called whenever a board tile is clicked.
+     */
+    private class ChessClick implements View.OnClickListener {
+        @Override public void onClick(final View v) {
+            int index = (int) v.getTag();
+            if(mHighlightedTile != null) {
+                showPossibleMoves(index);
+                mHighlightedTile = null;
+            } else {
+                if(mBoardMap.get(index, null) != null) {
+                    mHighlightedTile = (ImageButton) v;
+                    showPossibleMoves(index);
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessPiece.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessPiece.java
@@ -1,0 +1,504 @@
+package com.pajato.android.gamechat.game;
+
+import android.util.SparseArray;
+
+import com.pajato.android.gamechat.R;
+
+import java.util.ArrayList;
+
+/**
+ * A simple P.O.J.O. class that keeps track of a chess pieces type and the team it is on.
+ */
+class ChessPiece {
+    static final int KING = 0;
+    static final int QUEEN = 1;
+    static final int BISHOP = 2;
+    static final int KNIGHT = 3;
+    static final int ROOK = 4;
+    static final int PAWN = 5;
+
+    static final int BLUE_TEAM = 10;
+    static final int OTHER_TEAM = 20;
+
+    private int pieceId;
+    private int teamId;
+
+    ChessPiece(final int piece, final int team) {
+        this.pieceId = piece;
+        this.teamId = team;
+    }
+
+    int getPiece() {
+        return this.pieceId;
+    }
+
+    int getTeam() {
+        return this.teamId;
+    }
+
+    static int getDrawableFor(final int pieceType) {
+        int drawable;
+        switch(pieceType) {
+            case KING: drawable = R.drawable.ic_stars_black_36dp;
+                break;
+            case QUEEN: drawable = R.drawable.ic_games_white;
+                break;
+            case BISHOP: drawable = R.drawable.ic_info_black;
+                break;
+            case KNIGHT: drawable = R.drawable.ic_help_black;
+                break;
+            case ROOK: drawable = R.drawable.ic_settings_black;
+                break;
+            default:
+            case PAWN: drawable = R.drawable.ic_account_circle_black_36dp;
+                break;
+        }
+        return drawable;
+    }
+
+    // Threat Range Methods
+
+    /**
+     * Gets the "threat range" of the King. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. The King's movement is
+     * limited, and when the King of a side is captured, that side loses the game. A King can move
+     * in any direction, but only a single square away. A King may move into the space of another
+     * piece only if it is capturing that piece.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the King.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getKingThreatRange(final ArrayList<Integer> threatRange, final int highlightedIndex,
+                      final SparseArray<ChessPiece> boardMap, final boolean[] castlingBooleans) {
+        final boolean blueQueenSidePawnHasMoved = castlingBooleans[0];
+        final boolean blueKingSidePawnHasMoved = castlingBooleans[1];
+        final boolean blueKingHasMoved = castlingBooleans[2];
+        final boolean otherQueenSidePawnHasMoved = castlingBooleans[3];
+        final boolean otherKingSidePawnHasMoved = castlingBooleans[4];
+        final boolean otherKingHasMoved = castlingBooleans[5];
+
+        // Establish all possible movement options.
+        int left = highlightedIndex - 1;
+        int upLeft = highlightedIndex - 9;
+        int up = highlightedIndex - 8;
+        int upRight = highlightedIndex - 7;
+        int right = highlightedIndex + 1;
+        int down = highlightedIndex + 8;
+        int downRight = highlightedIndex + 9;
+        int downLeft = highlightedIndex + 7;
+
+        // Ensure we're obeying the margins of the board with our moves.
+        if(left % 8 == 7) left = -1;
+        if(upLeft % 8 == 7) upLeft = -1;
+        if(downLeft % 8 == 7) downLeft = -1;
+        if(right % 8 == 0) right = -1;
+        if(upRight % 8 == 0) upRight = -1;
+        if(downRight % 8 == 0) downRight = -1;
+
+        // Add our valid moves to the possible move pool.
+        int[] possibleMoves = {left, upLeft, up, upRight, right, downRight, down, downLeft};
+        for (int possibleMove : possibleMoves) {
+            if(possibleMove > -1 && possibleMove < 64) {
+                if(boardMap.get(possibleMove, null) == null) {
+                    threatRange.add(possibleMove);
+                } else if (boardMap.get(possibleMove).getTeam()
+                        != boardMap.get(highlightedIndex).getTeam()) {
+                    threatRange.add(possibleMove);
+                }
+            }
+        }
+
+        // Handle Castling for Blue
+        if(boardMap.get(highlightedIndex).getTeam() == ChessPiece.BLUE_TEAM && !blueKingHasMoved) {
+            // The more common Castling variant, "Queen-Side Castling" or "Short Castling"
+            boolean canCastleKingSide = highlightedIndex == 60 && !blueKingSidePawnHasMoved &&
+                    boardMap.get(highlightedIndex + 1, null) == null &&
+                    boardMap.get(highlightedIndex + 2, null) == null &&
+                    boardMap.get(highlightedIndex + 3, null) != null &&
+                    boardMap.get(highlightedIndex + 3).getPiece() == ChessPiece.ROOK;
+            if(canCastleKingSide) {
+                threatRange.add(highlightedIndex + 2);
+            }
+            // The less common Castling variant, "Queen-Side Castling" or "Long Castling"
+            boolean canCastleQueenSide = highlightedIndex == 60 && !blueQueenSidePawnHasMoved &&
+                    boardMap.get(highlightedIndex - 1, null) == null &&
+                    boardMap.get(highlightedIndex - 2, null) == null &&
+                    boardMap.get(highlightedIndex - 3, null) == null &&
+                    boardMap.get(highlightedIndex - 4, null) != null &&
+                    boardMap.get(highlightedIndex - 4).getPiece() == ChessPiece.ROOK;
+            if(canCastleQueenSide) {
+                threatRange.add(highlightedIndex - 3);
+            }
+        // Handle Castling for the other team
+        } else if (boardMap.get(highlightedIndex).getTeam() == ChessPiece.OTHER_TEAM && !otherKingHasMoved) {
+            boolean canCastleKingSide = highlightedIndex == 4 && !otherKingSidePawnHasMoved &&
+                    boardMap.get(highlightedIndex + 1, null) == null &&
+                    boardMap.get(highlightedIndex + 2, null) == null &&
+                    boardMap.get(highlightedIndex + 3, null) != null &&
+                    boardMap.get(highlightedIndex + 3).getPiece() == ChessPiece.ROOK;
+            if (canCastleKingSide) {
+                threatRange.add(highlightedIndex + 2);
+            }
+            // The less common Castling variant, "Queen-Side Castling" or "Long Castling"
+            boolean canCastleQueenSide = highlightedIndex == 4 && !otherQueenSidePawnHasMoved &&
+                    boardMap.get(highlightedIndex - 1, null) == null &&
+                    boardMap.get(highlightedIndex - 2, null) == null &&
+                    boardMap.get(highlightedIndex - 3, null) == null &&
+                    boardMap.get(highlightedIndex - 4, null) != null &&
+                    boardMap.get(highlightedIndex - 4).getPiece() == ChessPiece.ROOK;
+            if(canCastleQueenSide) {
+                threatRange.add(highlightedIndex - 3);
+            }
+        }
+    }
+
+    /**
+     * Gets the "threat range" of the Queen. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. In addition to all four
+     * diagonals (up/left, up/right, down/right, and down/left), Queens can move in the four
+     * cardinal directions (up, down, left, and right), but cannot move past other pieces. A queen
+     * may take the place of another piece if they are capturing. They functionally perform as a
+     * combination Rook-Bishop.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the Queen.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getQueenThreatRange(final ArrayList<Integer> threatRange, final int
+            highlightedIndex, final SparseArray<ChessPiece> boardMap) {
+        getRookThreatRange(threatRange, highlightedIndex, boardMap);
+        getBishopThreatRange(threatRange, highlightedIndex, boardMap);
+    }
+
+    /**
+     * Gets the "threat range" of the Bishop. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. Bishops can move across
+     * the diagonals (up/right, down/right, down/left, and up/right), but cannot move past other
+     * pieces. A bishop can take the place of another piece if they are capturing it.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the Bishop.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getBishopThreatRange(final ArrayList<Integer> threatRange, final int
+            highlightedIndex, final SparseArray<ChessPiece> boardMap) {
+        boolean upLeft = true;
+        boolean upRight = true;
+        boolean downRight = true;
+        boolean downLeft = true;
+
+        for(int i = 1; i < 8; i++) {
+            if (upLeft) {
+                // Stay within the edges of the board.
+                int upLeftIteration = highlightedIndex - (9 * i);
+                if (upLeftIteration % 8 != 7 && upLeftIteration > -1) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(upLeftIteration, null) == null) {
+                        threatRange.add(upLeftIteration);
+                        // If there's an enemy piece, we can go there but no further.
+                    } else if (boardMap.get(upLeftIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(upLeftIteration);
+                        upLeft = false;
+                        // Otherwise we're done.
+                    } else {
+                        upLeft = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    upLeft = false;
+                }
+            }
+            if (upRight) {
+                // Stay within the edges of the board.
+                int upRightIteration = highlightedIndex - (7 * i);
+                if (upRightIteration % 8 != 0 && upRightIteration > -1) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(upRightIteration, null) == null) {
+                        threatRange.add(upRightIteration);
+                        // If there's an enemy piece, we can go there but no further.
+                    } else if (boardMap.get(upRightIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(upRightIteration);
+                        upRight = false;
+                        // Otherwise we're done.
+                    } else {
+                        upRight = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    upRight = false;
+                }
+            }
+            if (downRight) {
+                // Stay within the edges of the board.
+                int downRightIteration = highlightedIndex + (9 * i);
+                if (downRightIteration % 8 != 0 && downRightIteration < 64) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(downRightIteration, null) == null) {
+                        threatRange.add(downRightIteration);
+                        // If there's an enemy piece, we can go there but no further.
+                    } else if (boardMap.get(downRightIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(downRightIteration);
+                        downRight = false;
+                        // Otherwise we're done.
+                    } else {
+                        downRight = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    downRight = false;
+                }
+            }
+            if (downLeft) {
+                // Stay within the edges of the board.
+                int downLeftIteration = highlightedIndex + (7 * i);
+                if (downLeftIteration % 8 != 7 && downLeftIteration < 64) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(downLeftIteration, null) == null) {
+                        threatRange.add(downLeftIteration);
+                        // If there's an enemy piece, we can go there but no further.
+                    } else if (boardMap.get(downLeftIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(downLeftIteration);
+                        downLeft = false;
+                        // Otherwise we're done.
+                    } else {
+                        downLeft = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    downLeft = false;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Gets the "threat range" of the Pawn. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. Pawns can move forward
+     * if there is no piece ahead of them, and diagonally forward if they are capturing a piece.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the pawn.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getPawnThreatRange(final ArrayList<Integer> threatRange, final int
+            highlightedIndex, final SparseArray<ChessPiece> boardMap) {
+        // Pawns move differently depending on the team they are on.
+        if(boardMap.get(highlightedIndex).getTeam() == ChessPiece.BLUE_TEAM) {
+            int upLeft = highlightedIndex - 9;
+            int upRight = highlightedIndex - 7;
+            int up = highlightedIndex - 8;
+
+            // Pawns can move two squares forward if they are in their starting position.
+            if(highlightedIndex > 47 && highlightedIndex < 56) {
+                int upUp = highlightedIndex -  16;
+                if(boardMap.get(upUp, null) == null && boardMap.get(up, null) == null) {
+                    threatRange.add(upUp);
+                }
+            }
+
+            // Pawns can move diagonally forward only if they are capturing a piece.
+            if(boardMap.get(upLeft, null) != null && upLeft % 8 != 7
+                    && boardMap.get(upLeft).getTeam() == ChessPiece.OTHER_TEAM) {
+                threatRange.add(upLeft);
+            }
+            if(boardMap.get(upRight, null) != null && upRight % 8 != 0
+                    && boardMap.get(upRight).getTeam() == ChessPiece.OTHER_TEAM) {
+                threatRange.add(upRight);
+            }
+            // Pawns can move forward only if they are not being blocked.
+            if(boardMap.get(up, null) == null && up > -1) {
+                threatRange.add(up);
+            }
+        } else {
+            int downRight = highlightedIndex + 9;
+            int downLeft = highlightedIndex + 7;
+            int down = highlightedIndex + 8;
+
+            // Pawns can move two squares forward if they are in their starting position.
+            if(highlightedIndex > 7 && highlightedIndex < 16) {
+                int downDown = highlightedIndex + 16;
+                if(boardMap.get(downDown, null) == null && boardMap.get(down, null) == null) {
+                    threatRange.add(downDown);
+                }
+            }
+
+            // Pawns can move diagonally forward only if they are capturing a piece.
+            if(boardMap.get(downRight, null) != null && downRight % 8 != 0
+                    && boardMap.get(downRight).getTeam() == ChessPiece.BLUE_TEAM) {
+                threatRange.add(downRight);
+            }
+            if(boardMap.get(downLeft, null) != null && downRight % 8 != 7
+                    && boardMap.get(downLeft).getTeam() == ChessPiece.BLUE_TEAM) {
+                threatRange.add(downLeft);
+            }
+            // Pawns can move forward only if they are not being blocked.
+            if(boardMap.get(down, null) == null && down < 64) {
+                threatRange.add(down);
+            }
+        }
+    }
+
+    /**
+     * Gets the "threat range" of the Knight. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. Knights must move in an
+     * L shape: two squares in one direction and one in another. They can jump other pieces.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the knight piece.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getKnightThreatRange(final ArrayList<Integer> threatRange, final int
+            highlightedIndex, final SparseArray<ChessPiece> boardMap) {
+        // Establish all possible movement options.
+        int upUpLeft = highlightedIndex - 17;
+        int upUpRight = highlightedIndex - 15;
+        int rightRightUp = highlightedIndex - 6;
+        int rightRightDown = highlightedIndex + 10;
+        int downDownRight = highlightedIndex + 17;
+        int downDownLeft = highlightedIndex + 15;
+        int leftLeftDown = highlightedIndex + 6;
+        int leftLeftUp = highlightedIndex - 10;
+
+        // Ensure we obey the sides of the board when we set up our movement options.
+        if(upUpLeft % 8 == 7) upUpLeft = -1;
+        if(upUpRight % 8 == 0) upUpRight = -1;
+        if (rightRightUp % 8 == 0 || rightRightUp % 8 == 1) rightRightUp = -1;
+        if (rightRightDown % 8 == 0 || rightRightDown % 8 == 1) rightRightDown = -1;
+        if (downDownRight % 8 == 0) downDownRight = -1;
+        if (downDownLeft % 8 == 7) downDownLeft = -1;
+        if (leftLeftDown % 8 == 7 || leftLeftDown % 8 == 6) leftLeftDown = -1;
+        if (leftLeftUp % 8 == 7 || leftLeftUp % 8 == 6) leftLeftUp = -1;
+
+        int[] possibleMoves = {upUpLeft, upUpRight, rightRightUp, rightRightDown, downDownRight,
+                downDownLeft, leftLeftDown, leftLeftUp};
+
+        // Add valid moves to the movement option pool.
+        for (int possibleMove : possibleMoves) {
+            if (possibleMove > -1 && possibleMove < 64) {
+                if (boardMap.get(possibleMove, null) == null) {
+                    threatRange.add(possibleMove);
+                } else if (boardMap.get(possibleMove).getTeam() != boardMap.get(highlightedIndex).getTeam()) {
+                    threatRange.add(possibleMove);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Gets the "threat range" of the Rook. A "threat range" is the full possible amount of
+     * locations a piece can enter without breaking the rules of chess. Rooks can move in the
+     * four cardinal directions (up, down, left, and right), but cannot move past other pieces. A
+     * rook can take the place of another piece only if it is capturing that piece.
+     *
+     * @param threatRange the ArrayList that contains the threat range of the rook piece.
+     * @param highlightedIndex the index of the current piece.
+     * @param boardMap a HashMap representing the board and the pieces located within.
+     */
+    static void getRookThreatRange(final ArrayList<Integer> threatRange, final int
+            highlightedIndex, final SparseArray<ChessPiece> boardMap) {
+        // Set up our condition variables.
+        boolean left = true;
+        boolean right = true;
+        boolean up = true;
+        boolean down = true;
+        // Rooks can move at any distance, so we need to take the full board size into account.
+        for(int i = 1; i < 8; i++) {
+            // Calculates how far we can go left. Other pieces and the board's edge are barriers
+            if (left) {
+                int leftIteration = highlightedIndex - i;
+                // Stay within the edges of the board.
+                if (leftIteration % 8 != 7 && leftIteration > -1) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(leftIteration, null) == null) {
+                        threatRange.add(leftIteration);
+                        // If there's an enemy piece, we can go there but no further.
+                    } else if (boardMap.get(leftIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(leftIteration);
+                        left = false;
+                        // Otherwise we're done.
+                    } else {
+                        left = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    left = false;
+                }
+            }
+            // Calculates how far we can go right. Other pieces and the board's edge are barriers
+            if (right) {
+                int rightIteration = highlightedIndex + i;
+                // Stay within the edges of the board.
+                if (rightIteration % 8 != 0 && rightIteration < 64) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if(boardMap.get(rightIteration, null) == null) {
+                        threatRange.add(rightIteration);
+                        // If there's an enemy piece, a rook can go there but no further.
+                    } else if (boardMap.get(rightIteration).getTeam() !=
+                            boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(rightIteration);
+                        right = false;
+                        // Otherwise we're done.
+                    } else {
+                        right = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    right = false;
+                }
+            }
+            // Calculates how far we can go up. Other pieces and the board's edge are barriers.
+            if (up) {
+                int upIteration = highlightedIndex - (8 * i);
+                // Stay within the edges of the board.
+                if (upIteration > -1) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(upIteration, null) == null) {
+                        threatRange.add(upIteration);
+                        // If there's an enemy piece, a rook can go there but no further.
+                    } else if (boardMap.get(upIteration).getTeam()
+                            != boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(upIteration);
+                        up = false;
+                        // Otherwise we're done.
+                    } else {
+                        up = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    up = false;
+                }
+            }
+            // Calculates how far we can go down. Other pieces and the board's edge are barriers
+            if (down) {
+                int downIteration = highlightedIndex + (8 * i);
+                // Stay within the edges of the board.
+                if(downIteration < 64) {
+                    // If there's no piece, a rook can go there and keep going.
+                    if (boardMap.get(downIteration, null) == null) {
+                        threatRange.add(downIteration);
+                        // If there's an enemy piece, a rook can go there but no further.
+                    } else if (boardMap.get(downIteration).getTeam()
+                            != boardMap.get(highlightedIndex).getTeam()) {
+                        threatRange.add(downIteration);
+                        down = false;
+                        // Otherwise we're done.
+                    } else {
+                        down = false;
+                    }
+                    // If we're past the board's edge, stop.
+                } else {
+                    down = false;
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -87,7 +87,7 @@ public class GameFragment extends BaseFragment {
                 GameManager.instance.sendNewGame(GameManager.CHECKERS_INDEX, getActivity(), msg);
                 break;
             case R.id.options_menu_new_chess:
-                GameManager.instance.sendNewGame(GameManager.CHESS_INDEX, getActivity());
+                GameManager.instance.sendNewGame(GameManager.CHESS_INDEX, getActivity(), msg);
                 break;
         }
         return super.onOptionsItemSelected(item);
@@ -132,6 +132,10 @@ public class GameFragment extends BaseFragment {
                 return ((CheckersFragment) GameManager.instance
                         .getFragment(GameManager.CHECKERS_INDEX))
                         .mTurn ? "Blue" : "Yellow";
+            case GameManager.CHESS_INDEX:
+                return ((ChessFragment) GameManager.instance
+                        .getFragment(GameManager.CHESS_INDEX))
+                        .mTurn ? "Blue" : "Purple";
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -155,6 +155,9 @@ public enum GameManager {
                 ((CheckersFragment) GameManager.instance.getFragment(GameManager.CHECKERS_INDEX))
                         .messageHandler(msg);
                 break;
+            case GameManager.CHESS_INDEX:
+                ((ChessFragment) GameManager.instance.getFragment(GameManager.CHESS_INDEX))
+                        .messageHandler(msg);
         }
     }
 
@@ -200,7 +203,7 @@ public enum GameManager {
      */
     public boolean setCurrentFragment(final int fragmentIndex, final FragmentActivity context,
                                       final String msg) {
-        if(fragmentIndex <= CHECKERS_INDEX && fragmentIndex > -1) {
+        if(fragmentIndex < TOTAL_FRAGMENTS && fragmentIndex > -1) {
             if (fragmentIndex != getCurrentFragmentIndex()) {
                 if(fragmentList[fragmentIndex] == null) {
                     switch(fragmentIndex) {
@@ -212,7 +215,7 @@ public enum GameManager {
                             break;
                         case CHECKERS_INDEX: fragmentList[CHECKERS_INDEX] = new CheckersFragment();
                             break;
-                        case CHESS_INDEX: //fragmentList[CHESS_INDEX] = new ChessFragment();
+                        case CHESS_INDEX: fragmentList[CHESS_INDEX] = new ChessFragment();
                             break;
                     }
                 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
@@ -45,6 +45,11 @@ public class InitialFragment extends BaseFragment {
         View checkersButton = layout.findViewById(R.id.init_checkers_button);
         checkersButton.setOnClickListener(new ClickHandler());
 
+        View chess = layout.findViewById(R.id.init_chess);
+        chess.setOnClickListener(new ClickHandler());
+        View chessButton = layout.findViewById(R.id.init_chess_button);
+        chessButton.setOnClickListener(new ClickHandler());
+
         return layout;
     }
 
@@ -56,6 +61,9 @@ public class InitialFragment extends BaseFragment {
             } else if (v.getId() == R.id.init_checkers || v.getId() == R.id.init_checkers_button) {
                 GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
                         getString(R.string.new_game_checkers));
+            } else if (v.getId() == R.id.init_chess || v.getId() == R.id.init_chess_button) {
+                GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
+                        getString(R.string.new_game_chess));
             }
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -93,6 +93,9 @@ public class SettingsFragment extends BaseFragment {
         } else if(game.equals(getString(R.string.new_game_checkers))) {
             title.setText(R.string.playing_checkers);
             setupCheckers();
+        } else if(game.equals(getString(R.string.new_game_chess))) {
+            title.setText(R.string.playing_chess);
+            setupChess();
         }
         return main;
     }
@@ -139,6 +142,17 @@ public class SettingsFragment extends BaseFragment {
         mComputer.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {
                 //GameManager.instance.sendNewGame(GameManager.CHECKERS_COMPUTER_INDEX, getActivity());
+            }
+        });
+    }
+
+    /**
+     * Setup the Chess game creation invitation onClicks for Local, Online, and Computer games.
+     */
+    private void setupChess() {
+        mLocal.setOnClickListener(new View.OnClickListener(){
+            @Override public void onClick(View v) {
+                GameManager.instance.sendNewGame(GameManager.CHESS_INDEX, getActivity());
             }
         });
     }

--- a/app/src/main/res/layout/pawn_dialog.xml
+++ b/app/src/main/res/layout/pawn_dialog.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:id="@+id/pawn_promotion_window">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@android:color/white"
+        android:id="@+id/dividing_line_0"
+
+        android:layout_marginTop="8dp"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/queen_text"
+        android:text="@string/chess_promotion_queen"
+        android:textSize="20sp"
+
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toTopOf="@id/dividing_line_0"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"/>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_games_white"
+        android:id="@+id/queen_icon"
+        android:contentDescription="@string/chess_promotion_queen"
+        android:layout_marginEnd="16dp"
+
+        app:layout_constraintRight_toLeftOf="@id/queen_text"
+        app:layout_constraintTop_toTopOf="@id/queen_text"
+        app:layout_constraintBottom_toBottomOf="@id/queen_text"/>
+
+    <View
+        android:layout_width="140dp"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray"
+        android:id="@+id/dividing_line_1"
+
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="30dp"
+        app:layout_constraintTop_toBottomOf="@id/queen_text"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/bishop_text"
+        android:text="@string/chess_promotion_bishop"
+        android:textSize="20sp"
+
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/dividing_line_1"
+        app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_info_black"
+        android:id="@+id/bishop_icon"
+        android:contentDescription="@string/chess_promotion_bishop"
+        android:layout_marginEnd="16dp"
+
+        app:layout_constraintTop_toTopOf="@id/bishop_text"
+        app:layout_constraintBottom_toBottomOf="@id/bishop_text"
+        app:layout_constraintRight_toLeftOf="@id/bishop_text"/>
+
+    <View
+        android:layout_width="140dp"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray"
+        android:id="@+id/dividing_line_2"
+
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="30dp"
+        app:layout_constraintTop_toBottomOf="@id/bishop_text"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/knight_text"
+        android:text="@string/chess_promotion_knight"
+        android:textSize="20sp"
+
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/dividing_line_2"
+        app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_help_black"
+        android:id="@+id/knight_icon"
+        android:contentDescription="@string/chess_promotion_knight"
+        android:layout_marginEnd="16dp"
+
+        app:layout_constraintRight_toLeftOf="@id/knight_text"
+        app:layout_constraintTop_toTopOf="@id/knight_text"
+        app:layout_constraintBottom_toBottomOf="@id/knight_text"/>
+
+    <View
+        android:layout_width="140dp"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray"
+        android:id="@+id/dividing_line_3"
+
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="30dp"
+        app:layout_constraintTop_toBottomOf="@id/knight_text"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/rook_text"
+        android:text="@string/chess_promotion_rook"
+        android:textSize="20sp"
+
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/dividing_line_3"
+        app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_settings_black"
+        android:id="@+id/rook_icon"
+        android:contentDescription="@string/chess_promotion_rook"
+        android:layout_marginEnd="16dp"
+
+        app:layout_constraintTop_toTopOf="@id/rook_text"
+        app:layout_constraintBottom_toBottomOf="@id/rook_text"
+        app:layout_constraintRight_toLeftOf="@id/rook_text"/>
+
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray"
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/rook_text"
+        app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
+        app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
+
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,10 @@
     <string name="arrow_right"><![CDATA[>]]></string>
     <string name="banner_ad_unit_id" translatable="false">ca-app-pub-3940256099942544/6300978111</string>
     <string name="chat">Chat</string>
+    <string name="chess_promotion_bishop">Bishop</string>
+    <string name="chess_promotion_knight">Knight</string>
+    <string name="chess_promotion_queen">Queen</string>
+    <string name="chess_promotion_rook">Rook</string>
     <string name="choose_group">Choose a Group:</string>
     <string name="choose_user">Choose a User:</string>
     <string name="game">Game</string>
@@ -46,6 +50,7 @@
     <string name="play_ttt">Play Tic-Tac-Toe!</string>
     <string name="playing">Playing…</string>
     <string name="playing_checkers">Playing Checkers!</string>
+    <string name="playing_chess">Playing Chess!</string>
     <string name="playing_ttt">Playing Tic-Tac-Toe!</string>
     <string name="rooms">Rooms</string>
     <string name="send">SEND</string>


### PR DESCRIPTION
The trifecta of our first draft games is now done! As with Checkers, Chess is only implemented locally. The traditional rules of Chess are implemented, including the double-pawn move, castling, and pawn promotion.

# Changed Files

## Java Files

### CheckersFragment
* Fixed a typo in a variable name.

### GameFragment
* Added support for chess’ new game functionality, and getting the current turn from a chess game.

### GameManager
* Added further support for chess’ new game functionality.

### InitialFragment
* The chess button now properly launches the **SettingsFragment** with proper title.

### SettingsFragment
* Now properly launches local chess games.

## XML Files

### strings.xml
* Added strings for the pawn promotion menu and the **SettingsFragment**

# New Files

## Java Files

### ChessFragment
* The main component of the chess game. This class does the the UI work for the game, and manages the data that represents the board and positions of the pieces.

### ChessPiece
* A utility class for **ChessFragment**, a ChessPiece is composed of a piece id and team id. The piece id indicates the type of piece we’re working with (e.g., pawn, king, queen, etc) and the team id indicates the side of the board the piece belongs to (blue or purple).
* Also stores data for individual chess piece types including algorithms that detect their possible movement options and related drawables.

## XML Files

### pawn_dialog
* A layout for the **AlertDialog** that appears when a player promotes a pawn. As is customary with chess rules, any of the non-king and non-pawn pieces may be chosen.