### PR TITLE
Add a new group to Firebase.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/Account.java
@@ -17,49 +17,61 @@
 
 package com.pajato.android.gamechat.account;
 
-import android.net.Uri;
+import com.google.firebase.database.Exclude;
+import com.google.firebase.database.IgnoreExtraProperties;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import lombok.Data;
 
 /**
- * Provides an account data model class.
+ * Provides an account data model tailored to Firebase.
  *
  * @author Paul Michael Reilly
  */
-@Data public class Account {
-    private static final String KEY_ACCOUNT_TOKEN = "keyAccountToken";
+@IgnoreExtraProperties
+public class Account {
 
-    /** The logcat tag constant. */
-    private static final String TAG = Account.class.getSimpleName();
+    // Public instance variables
 
-    // Activity request codes.
-    private static final int ACCOUNTS_PERMISSION_REQUEST = 1;
-    private static final int ACCOUNT_SETUP_REQUEST = 2;
+    /** The account id, the backend push key. */
+    public String accountId;
 
-    // Private instance variables
-
-    /** The account id, usually an email address or a phone number. */
-    private String accountId;
+    /** The account email. */
+    public String accountEmail;
 
     /** The account icon, a URL. */
-    private Uri accountUrl;
+    public String accountUrl;
 
     /** The account display name, usually something like "Fred C. Jones". */
-    private String displayName;
+    public String displayName;
 
     /** The account token, an access key supplied by the provider. */
-    private String token;
+    public String token;
 
     /** The account provider name, a string like "Facebook". */
-    private String providerName;
+    public String providerName;
 
     /** The account provider id, a string like "google.com". */
-    private String providerId;
+    public String providerId;
 
-    /** The account avatars. The key is the name, the value is a URL for the image. */
-    private Map<String, Uri> avatarMap = new ConcurrentHashMap<>();
+    /** A list of group ids the account can access. */
+    public List<String> groupIdList = new ArrayList<>();
 
+    // Public instance methods.
+
+    /** Generate the map of data to persist into Firebase. */
+    @Exclude public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("accountId", accountId);
+        result.put("accountEmail", accountEmail);
+        result.put("accountUrl", accountUrl);
+        result.put("displayName", displayName);
+        result.put("providerName", providerName);
+        result.put("providerId", providerId);
+        result.put("groupIdList", groupIdList);
+
+        return result;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
@@ -14,12 +14,12 @@
  * You should have received a copy of the GNU General Public License along with GameChat. If not,
  * see <http://www.gnu.org/licenses/>.
  */
+
 package com.pajato.android.gamechat.account;
 
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.util.SparseArray;
 
 import com.google.firebase.auth.FirebaseAuth;
@@ -31,7 +31,8 @@ import com.pajato.android.gamechat.signin.SignInActivity;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages the account related aspects of the GameChat application.  These include setting up the
@@ -50,54 +51,47 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
 
     // Private class constants
 
-    /** The logcat logger tag. */
-    private static final String TAG = AccountManager.class.getSimpleName();
-
     // Private instance variables
 
     /** The account repository associating mulitple account id strings with the cloud account. */
-    private ConcurrentHashMap<String, Account> mAccountMap = new ConcurrentHashMap<>();
+    private Map<String, Account> mAccountMap = new HashMap<>();
 
     /** The array of click keys.  The ... */
     private SparseArray<Actions> mActionMap = new SparseArray<>();
 
     // Public instance methods
 
-    /** Deal with authentication changes like sign in and sign out */
+    /** Retrun the account for the current User, null if there is no signed in User. */
+    public Account getCurrentAccount() {
+        // Obtain the account key from the logged in Firebase User to use to lookup the account in
+        // the account map.  If the account is not in the map, load it using the Firebase User data.
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        String uid = user != null ? user.getUid() : null;
+        Account account = uid != null && mAccountMap.containsKey(uid) ? mAccountMap.get(uid) : null;
+        return uid == null || account != null ? account : getAccount(user);
+    }
+
+    /** Deal with authentication backend changes: sign in and sign out */
     @Override public void onAuthStateChanged(@NonNull final FirebaseAuth auth) {
+        // Determine if the User is signed in or out.
         FirebaseUser user = auth.getCurrentUser();
-        Account account = null;
-        if (user != null) {
-            // User is signed in.  Add this account.
-            Log.d(TAG, "onAuthStateChanged:signed_in:" + user.getUid());
-            account = getAccount(user);
-            /* The currently active account ID. */
-            String activeAccountId = account.getAccountId();
-            mAccountMap.put(activeAccountId, account);
-        } else {
-            // User is signed out
-            Log.d(TAG, "onAuthStateChanged:signed_out");
-        }
+        Account account = user != null ? getCurrentAccount() : null;
         EventBus.getDefault().post(new AccountStateChangeEvent(account));
     }
 
     /** Initialize the account manager. */
     public void init() {
-        // Build a sparse array of click key values.
+        // Build a sparse array associating auth events by resource id (User clicked in a sign in or
+        // sign out button) with an auth action.
         mActionMap.put(R.id.signIn, Actions.signIn);
         mActionMap.put(R.id.signOut, Actions.signOut);
     }
 
     /** Register the component during lifecycle resume events. */
     public void register() {
+        // Deal with auth sign in and sign out events by propagating them to EventBus subscribers.
         EventBus.getDefault().register(this);
-        // Deal with auth events in the listener.
         FirebaseAuth.getInstance().addAuthStateListener(this);
-    }
-
-    /** Register a given account and provider ids. */
-    public void register(final String accountId) {
-        // Perform the Firebase authentication thing using the given ids.
     }
 
     /** Unregister the component during lifecycle pause events. */
@@ -106,26 +100,12 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         FirebaseAuth.getInstance().removeAuthStateListener(this);
     }
 
-    /** Handle a sign in or sign out operation. */
+    /** Handle a sign in or sign out button click. */
     @Subscribe public void processClick(final ClickEvent event) {
         // Case on the view's tag content.
         Actions action = mActionMap.get(event.getValue());
         if (action != null) {
-            switch (action) {
-                case signIn:
-                    // Invoke the sign in process.
-                    Context context = event.getContext();
-                    Intent intent = new Intent(context, SignInActivity.class);
-                    intent.putExtra("signin", true);
-                    context.startActivity(intent);
-                    break;
-                case signOut:
-                    // Have Firebase log out the user.
-                    FirebaseAuth.getInstance().signOut();
-                    break;
-                default:
-                    break;
-            }
+            processAction(event, action);
         }
     }
 
@@ -135,11 +115,34 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     private Account getAccount(final FirebaseUser user) {
         // Create and persist an account for the user.
         Account result = new Account();
-        result.setAccountId(user.getEmail());
-        result.setAccountUrl(user.getPhotoUrl());
-        result.setDisplayName(user.getDisplayName());
-        result.setProviderId(user.getProviderId());
+        result.accountId = user.getUid();
+        result.accountEmail = user.getEmail();
+        result.accountUrl = user.getPhotoUrl() != null ? user.getPhotoUrl().toString() : null;
+        result.displayName = user.getDisplayName();
+        result.providerId = user.getProviderId();
+        result.providerName = "tbd";
+        mAccountMap.put(result.accountId, result);
+
         return result;
+    }
+
+    /** Process a given action by providing handling for the relevant cases. */
+    private void processAction(final ClickEvent event, final Actions action) {
+        switch (action) {
+            case signIn:
+                // Invoke the sign in activity to kick off a Firebase auth event.
+                Context context = event.getContext();
+                Intent intent = new Intent(context, SignInActivity.class);
+                intent.putExtra("signin", true);
+                context.startActivity(intent);
+                break;
+            case signOut:
+                // Have Firebase log out the user.
+                FirebaseAuth.getInstance().signOut();
+                break;
+            default:
+                break;
+        }
     }
 
     // Private classes

--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java
@@ -1,20 +1,36 @@
-package com.pajato.android.gamechat.account;
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.account;
 
 /**
  * Provides an account state change data model class.
  *
  * @author Paul Michael Reilly
  */
-@AllArgsConstructor(suppressConstructorProperties = true)
-@Data
 public class AccountStateChangeEvent {
 
-    // Private instance variables
+    // Public instance variables
 
     /** The changed account: if null the User signed out, if non-null the User signed in. */
-    private Account account;
+    public Account account;
 
+    /** Build the instance. */
+    public AccountStateChangeEvent(final Account account) {
+        this.account = account;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.chat;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
@@ -34,12 +33,19 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.account.Account;
+import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.EventUtils;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Provide a main activity to manage the UI for adding a group.
@@ -54,11 +60,26 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
     /** The logcat tag constant. */
     private static final String TAG = AddGroupActivity.class.getSimpleName();
 
+    // Private instance variables.
+
+    /** The group which will ostensibly be persisted on the back end. */
+    private Group mGroup;
+
     // Public instance methods
 
-    /** Process a button click on a given view by posting a button click event. */
-    public void onClick(final View view) {
-        EventUtils.post(this, view);
+    /** Handle group add button clicks by processing them. */
+    @Subscribe public void buttonClickHandler(final ClickEvent event) {
+        int value = event.getValue();
+        switch (value) {
+            case R.id.saveGroupButton:
+                // Process the group (validate and persist it) and be done with the activity.
+                processGroup();
+                finish();
+                break;
+            default:
+                // Ignore everything else.
+                break;
+        }
     }
 
     /** Process a button click on a given view by posting a button click event. */
@@ -69,6 +90,16 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
         EventBus.getDefault().post(new ClickEvent(this, value, null, item, className));
     }
 
+    /** Handle a back button press by cancelling out of the activity. */
+    @Override public void onBackPressed() {
+        finish();
+    }
+
+    /** Process a button click on a given view by posting a button click event. */
+    public void onClick(final View view) {
+        EventUtils.post(this, view);
+    }
+
     /** Post the options menu on demand. */
     public boolean onCreateOptionsMenu(final Menu menu) {
         MenuInflater inflater = getMenuInflater();
@@ -76,41 +107,23 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
         return true;
     }
 
-    /** Process a given button click event by logging it. */
-    @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        String format = "Button click event on type: {%s} with value {%d}.";
-        int value = event.getValue();
-        Log.v(TAG, String.format(format, event.getClassName(), value));
-
-        // Process the sign in and sign out button clicks.
-        switch (value) {
-            case R.id.saveGroupButton:
-                // Process the form and write the new group to Firebase.
-                finish();
-                break;
-            default:
-                // Ignore everything else.
-                break;
+    /** Handle a clear button click on the toolbar by canceling the activity. */
+    @Override public boolean onOptionsItemSelected(MenuItem menuItem) {
+        if (menuItem.getItemId() == android.R.id.home) {
+            finish();
         }
-    }
-
-    /** Handle a back button press by cancelling out of the activity. */
-    @Override public void onBackPressed() {
-        finish();
+        return super.onOptionsItemSelected(menuItem);
     }
 
     // Protected instance methods
 
-    /**
-     * Set up the app per the characteristics of the running device.
-     *
-     * @see android.app.Activity#onCreate(Bundle)
-     */
+    /** Set up the UI to create a new group defined by the User. */
     @Override protected void onCreate(Bundle savedInstanceState) {
-        // Allow superclasses to initialize using the saved state and determine if there has been a
-        // fresh install on this device and proceed accordingly.
+        // Render the form and initialize for the new group.
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_group_add);
+        mGroup = new Group();
+        mGroup.ownerId = AccountManager.instance.getCurrentAccount().accountId;
         init();
     }
 
@@ -132,38 +145,49 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
 
     // Private instance methods.
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem menuItem) {
-        if (menuItem.getItemId() == android.R.id.home) {
-            finish();
-        }
-        return super.onOptionsItemSelected(menuItem);
-    }
-
     /** Initialize the main activity. */
     private void init() {
-        // Set up the app components: toolbar, navigation drawer and edit text.
+        // Set up the toolbar to support a cancel button in the "home" position and ensure that all
+        // is well.
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         toolbar.setNavigationIcon(R.drawable.ic_clear_black_24dp);
         toolbar.setNavigationOnClickListener(this);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
+        if (actionBar == null) {
+            // All is not well.  Log the issue and abort.
+            Log.e(TAG, "An action bar is not available for the add group activity!  Aborting.");
+            finish();
+        } else {
+            // All is well.  Finish setting up the toolbar and the group name edit field.
             actionBar.setDisplayShowHomeEnabled(true);
             EditText text = (EditText) findViewById(R.id.groupNameText);
             TextView button = (TextView) toolbar.findViewById(R.id.saveGroupButton);
-            text.addTextChangedListener(new TextChangeHandler(this, text, button));
+            text.addTextChangedListener(new TextChangeHandler(this, text, button, mGroup));
         }
+
+        // TODO: Set up the member invitation list for this group.
+    }
+
+    /** Process a newly created group by saving it to Firebase. */
+    private void processGroup() {
+        // Persist the Group to the backend.
+        DatabaseReference database = FirebaseDatabase.getInstance().getReference();
+        Account account = AccountManager.instance.getCurrentAccount();
+        String key = database.child("groups").push().getKey();
+        account.groupIdList.add(key);
+        Map<String, Object> childUpdates = new HashMap<>();
+        childUpdates.put("/groups/" + key, mGroup.toMap());
+        childUpdates.put("/accounts/" + mGroup.ownerId, account.toMap());
+        database.updateChildren(childUpdates);
     }
 
     // Private classes.
 
+    /** Provide a handler to accumulate the group name. */
     private class TextChangeHandler implements TextWatcher {
 
         // Private class constants.
-
-        /** The logcat tag. */
-        private final String TAG = this.getClass().getSimpleName();
 
         // Private instance variables.
 
@@ -179,13 +203,16 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
         /** The text color for an enabled save button. */
         private int mEnabledColor;
 
+        /** The group to be added to the backend. */
+        private Group mGroup;
+
         // Public constructor.
 
-        /** Build a text change handler to manage a given save button. */
-        TextChangeHandler(Context context, final EditText text, final TextView button) {
+        /** Build a text change handler to manage a given edit text field, save button and group. */
+        TextChangeHandler(Context context, final EditText text, final TextView button, final Group group) {
             mEditText = text;
             mSaveButton = button;
-            Resources res = context.getResources();
+            mGroup = group;
             mDisabledColor = button.getCurrentTextColor();
             mEnabledColor = ContextCompat.getColor(context, R.color.colorPrimaryDark);
         }
@@ -198,11 +225,12 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
                 mSaveButton.setTextColor(mDisabledColor);
                 mSaveButton.setEnabled(false);
             } else {
-                if (isUnique()) {
-                    // Render the save button enabled with the primary dark color.
-                    mSaveButton.setEnabled(true);
-                    mSaveButton.setTextColor(mEnabledColor);
-                }
+                // TODO: determine if the group name is unique.
+                // Render the save button enabled with the primary dark color and update the
+                // group.
+                mSaveButton.setEnabled(true);
+                mSaveButton.setTextColor(mEnabledColor);
+                mGroup.name = mEditText.getText().toString();
             }
         }
 
@@ -211,12 +239,6 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
 
         @Override public void onTextChanged(final CharSequence s, final int start, final int before,
                                             final int count) {
-        }
-
-        /** Determine if the current group name is unique. */
-        private boolean isUnique() {
-            // TODO: enhance for v2
-            return true;
         }
 
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/Group.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/Group.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.chat;
+
+import com.google.firebase.database.Exclude;
+import com.google.firebase.database.IgnoreExtraProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@IgnoreExtraProperties
+public class Group {
+
+    /** The group owner's account id. */
+    public String ownerId;
+
+    /** The group name. */
+    public String name;
+
+    /** The group member account ids. */
+    public List<String> memberIds = new ArrayList<>();
+
+    /** The list of rooms in the group. */
+    // Todo: public List<Room> = new ArrayList<>();
+
+    /** The default constructor. */
+    public Group() {}
+
+    /** Build a default Group. */
+    public Group(final String ownerId, final String name) {
+        this.ownerId = ownerId;
+        this.name = name;
+    }
+
+    @Exclude
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("ownerId", ownerId);
+        result.put("name", name);
+        result.put("memberIds", memberIds);
+
+        return result;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -215,7 +215,7 @@ public class MainActivity extends AppCompatActivity
         if (layout != null) layout.setOnClickListener(this);
 
         // If there is an account, set up the navigation drawer header accordingly.
-        Account account = event.getAccount();
+        Account account = event.account;
         if (account != null) {
             // There is an account.  Set it up in the header.
             NavigationManager.instance.setAccount(account, header);

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -81,7 +81,7 @@ enum NavigationManager {
         loadAccountIcon(account, header);
         setDisplayName(account, header);
         TextView email = (TextView) header.findViewById(R.id.currentAccountEmail);
-        email.setText(account.getAccountId());
+        email.setText(account.accountEmail);
     }
 
     /** Set up the navigation header to show the sign in button. */
@@ -155,12 +155,12 @@ enum NavigationManager {
     private void loadAccountIcon(final Account account, final View header) {
         // Determine if there is an image to be loaded.
         ImageView icon = (ImageView) header.findViewById(R.id.currentAccountIcon);
-        Uri imageUri = account.getAccountUrl();
+        Uri imageUri = Uri.parse(account.accountUrl);
         if (imageUri != null) {
             // There is an image to load.  Use Glide to do the heavy lifting.
-            icon.setImageURI(account.getAccountUrl());
+            icon.setImageURI(imageUri);
             Glide.with(header.getContext())
-                .load(account.getAccountUrl())
+                .load(account.accountUrl)
                 .transform(new CircleTransform(header.getContext()))
                 .into(icon);
         } else {
@@ -174,11 +174,11 @@ enum NavigationManager {
     /** Load the display name, if available, using a placeholder otherwise. */
     private void setDisplayName(final Account account, final View header) {
         // Determine if there is a display name to use.
-        String name = account.getDisplayName();
+        String name = account.displayName;
         if (name == null) {
             // There is no display name, use a conjured name based on the email address, i.e. the
             // username part of the email address with an initial cap.
-            name = account.getAccountId();
+            name = account.accountEmail;
             int index = name.indexOf('@');
             name = name.substring(0, index);
             name = Character.toUpperCase(name.charAt(0)) + name.substring(1);


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit achieves the goal of adding mulitple new groups to Firebase such that the group keys are added to the User account profile.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/Account.java
modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountStateChangeEvent.java

- Convert from a Lombok model to a Firebase data model.

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Ensure that the newly created groups are posted to the User's account profile.
- Set up the notion of a current account obtained from the account map.
- Remove some AS warnings.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- Add code to update the group on Firebase.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- Use the flatter data model (public field access vs getter methods).

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- Adapt the User icon to be a string rather than a URI.

new file:   app/src/main/java/com/pajato/android/gamechat/chat/Group.java

- Model the group using a Firebase model style.