### PR TITLE
Board Size Flexibility

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -104,10 +104,11 @@ public class CheckersFragment extends BaseFragment {
             ImageButton currentTile = new ImageButton(getContext());
 
             // Set up the gridlayout params, so that each cell is functionally identical.
-            //TODO: Handle alternate resolutions in a better way.
+            int screenWidth = getActivity().findViewById(R.id.game_pane_fragment_container).getWidth();
+            int pieceSideLength = screenWidth / 8;
             GridLayout.LayoutParams param = new GridLayout.LayoutParams();
-            param.height = 90;
-            param.width = 90;
+            param.height = pieceSideLength;
+            param.width = pieceSideLength;
             param.rightMargin = 0;
             param.topMargin = 0;
             param.setGravity(Gravity.CENTER);

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -1,6 +1,5 @@
 package com.pajato.android.gamechat.game;
 
-import android.content.DialogInterface;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
@@ -118,10 +117,11 @@ public class ChessFragment extends BaseFragment {
             ImageButton currentTile = new ImageButton(getContext());
 
             // Set up the gridlayout params, so that each cell is functionally identical.
-            //TODO: Handle alternate resolutions in a better way.
+            int screenWidth = getActivity().findViewById(R.id.game_pane_fragment_container).getWidth();
+            int pieceSideLength = screenWidth / 8;
             GridLayout.LayoutParams param = new GridLayout.LayoutParams();
-            param.height = 90;
-            param.width = 90;
+            param.height = pieceSideLength;
+            param.width = pieceSideLength;
             param.rightMargin = 0;
             param.topMargin = 0;
             param.setGravity(Gravity.CENTER);
@@ -273,6 +273,14 @@ public class ChessFragment extends BaseFragment {
         }
     }
 
+    /**
+     * A utility method that facilitates keeping the board's checker pattern in place throughout the
+     * highlighting and de-higlighting process. It accepts a tile and sets its background to white
+     * or dark grey, depending on its location in the board.
+     *
+     * @param index the index of the tile, used to determine the color of the background.
+     * @param currentTile the tile whose color we are changing.
+     */
     private void handleTileBackground(final int index, final ImageButton currentTile) {
         // Handle the checkerboard positions.
         boolean isEven = (index % 2 == 0);

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -97,6 +97,10 @@ public enum GameManager {
                         msg = (((CheckersFragment) getFragment(CHECKERS_INDEX)).mTurn ?
                                 "Blue" : "Yellow") + "\n" + "New Game";
                         sendMessage(msg, CHECKERS_INDEX);
+                    } else if (getCurrentFragmentIndex() == CHESS_INDEX) {
+                        msg = (((ChessFragment) getFragment(CHESS_INDEX)).mTurn ? "Blue" : "Purple")
+                                + "\n" + "New Game";
+                        sendMessage(msg, CHESS_INDEX);
                     }
                 }
             });

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.2.0-beta2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'
 


### PR DESCRIPTION
A very small commit fix, this allows the board size to fill the given space on the screen provided to the game fragment, rather than being hard-coded to a specific size and therefore leaving a great deal of space underutilized on higher-resolution devices. Now the board is adjusted at runtime to fit the size of the **GameFragment**.

# Changed Files

## CheckersFragment
 * Now scales the board properly for alternate resolution sizes.

## ChessFragment
 * Now scales the board properly for alternate resolution sizes.

## GameManager
 * Now correctly launches a new game of Chess when the overflow menu or end game snackbar is used.

## build.gradle
 * Updated the gradle build tool to the newer version.