### PR TITLE
Changing Initial Screen + Fab

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
@@ -32,13 +32,21 @@ import static com.pajato.android.gamechat.chat.FabManager.State.opened;
 
 
 /** Provide a singleton to manage the rooms panel fab button. */
-enum FabManager {
-    instance;
+public enum FabManager {
+    room(R.id.rooms_fab, R.id.rooms_fab_menu),
+    game(R.id.games_fab, R.id.games_fab_menu);
+
+    FabManager(final int fabId, final int fabMenuId) {
+        mFabId = fabId;
+        mFabMenuId = fabMenuId;
+    }
 
     /** Provide FAB state constants. */
     enum State {opened, closed}
 
     // Private class constants.
+    int mFabId;
+    int mFabMenuId;
 
     // Private instance variables.
 
@@ -53,8 +61,8 @@ enum FabManager {
         // correct initial state.
         Account account = AccountManager.instance.getCurrentAccount();
         List<String> groups = account != null ? account.groupIdList : null;
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(R.id.rooms_fab);
-        View menu = layout.findViewById(R.id.rooms_fab_menu);
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        View menu = layout.findViewById(mFabMenuId);
         fab.setTag(R.integer.fabStateKey, opened);
         mMenuMap.put(fab.getId(), menu);
         dismissMenu(fab);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/RoomsFragment.java
@@ -79,13 +79,13 @@ public class RoomsFragment extends BaseFragment {
         switch (value) {
         case R.id.rooms_fab:
             // It is a rooms fab button.  Toggle the state.
-            FabManager.instance.toggle((FloatingActionButton) event.getView());
+            FabManager.room.toggle((FloatingActionButton) event.getView());
             break;
         case R.id.addGroupButton:
         case R.id.addGroupMenuItem:
             // Dismiss the FAB menu, and start up the add group activity.
             View view = getActivity().findViewById(R.id.rooms_fab);
-            FabManager.instance.dismissMenu((FloatingActionButton) view);
+            FabManager.room.dismissMenu((FloatingActionButton) view);
             Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
             startActivity(intent);
             break;
@@ -107,7 +107,7 @@ public class RoomsFragment extends BaseFragment {
         initAdView(layout);
         initRoomsList(layout);
         EventBusManager.instance.register(this);
-        FabManager.instance.init(layout);
+        FabManager.room.init(layout);
         ChatManager.instance.init();
 
         return layout;

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -147,21 +147,17 @@ public enum GameManager {
         switch(fragmentIndex) {
             default:
                 break;
-            case GameManager.TTT_LOCAL_INDEX:
-                ((LocalTTTFragment) GameManager.instance.getFragment(GameManager.TTT_LOCAL_INDEX))
-                        .messageHandler(msg);
+            case TTT_LOCAL_INDEX:
+                ((LocalTTTFragment) getFragment(TTT_LOCAL_INDEX)).messageHandler(msg);
                 break;
-            case GameManager.TTT_ONLINE_INDEX:
-                ((TTTFragment) GameManager.instance.getFragment(GameManager.TTT_ONLINE_INDEX))
-                        .messageHandler(msg);
+            case TTT_ONLINE_INDEX:
+                ((TTTFragment) getFragment(TTT_ONLINE_INDEX)).messageHandler(msg);
                 break;
-            case GameManager.CHECKERS_INDEX:
-                ((CheckersFragment) GameManager.instance.getFragment(GameManager.CHECKERS_INDEX))
-                        .messageHandler(msg);
+            case CHECKERS_INDEX:
+                ((CheckersFragment) getFragment(CHECKERS_INDEX)).messageHandler(msg);
                 break;
-            case GameManager.CHESS_INDEX:
-                ((ChessFragment) GameManager.instance.getFragment(GameManager.CHESS_INDEX))
-                        .messageHandler(msg);
+            case CHESS_INDEX:
+                ((ChessFragment) getFragment(CHESS_INDEX)).messageHandler(msg);
         }
     }
 
@@ -207,38 +203,47 @@ public enum GameManager {
      */
     public boolean setCurrentFragment(final int fragmentIndex, final FragmentActivity context,
                                       final String msg) {
-        if(fragmentIndex < TOTAL_FRAGMENTS && fragmentIndex > -1) {
-            if (fragmentIndex != getCurrentFragmentIndex()) {
-                if(fragmentList[fragmentIndex] == null) {
-                    switch(fragmentIndex) {
-                        case SETTINGS_INDEX: fragmentList[SETTINGS_INDEX] = new SettingsFragment();
-                            break;
-                        case TTT_LOCAL_INDEX: fragmentList[TTT_LOCAL_INDEX] = new LocalTTTFragment();
-                            break;
-                        case TTT_ONLINE_INDEX: fragmentList[TTT_ONLINE_INDEX] = new TTTFragment();
-                            break;
-                        case CHECKERS_INDEX: fragmentList[CHECKERS_INDEX] = new CheckersFragment();
-                            break;
-                        case CHESS_INDEX: fragmentList[CHESS_INDEX] = new ChessFragment();
-                            break;
-                    }
+        // Ensure we're not taking any requests we can't fill.
+        if(fragmentIndex < TOTAL_FRAGMENTS && fragmentIndex > -1 &&
+                fragmentIndex != getCurrentFragmentIndex()) {
+            // If our fragment doesn't exist yet, construct it.
+            if(fragmentList[fragmentIndex] == null) {
+                switch(fragmentIndex) {
+                    case SETTINGS_INDEX:
+                        fragmentList[SETTINGS_INDEX] = new SettingsFragment();
+                        break;
+                    case TTT_LOCAL_INDEX:
+                        fragmentList[TTT_LOCAL_INDEX] = new LocalTTTFragment();
+                        break;
+                    case TTT_ONLINE_INDEX:
+                        fragmentList[TTT_ONLINE_INDEX] = new TTTFragment();
+                        break;
+                    case CHECKERS_INDEX:
+                        fragmentList[CHECKERS_INDEX] = new CheckersFragment();
+                        break;
+                    case CHESS_INDEX:
+                        fragmentList[CHESS_INDEX] = new ChessFragment();
+                        break;
                 }
-                // Set up the new fragment in our fragment container.
-                currentFragment = fragmentIndex;
                 fragmentList[fragmentIndex].setArguments(context.getIntent().getExtras());
-                if(msg != null) {
-                    Bundle newGame = new Bundle();
-                    newGame.putString(GAME_KEY, msg);
-                    fragmentList[fragmentIndex].setArguments(newGame);
-                }
-                context.getSupportFragmentManager().beginTransaction()
-                        .replace(R.id.game_pane_fragment_container, fragmentList[fragmentIndex])
-                        .commit();
-                return true;
-            } else if(msg != null) {
-                sendMessage(msg, fragmentIndex);
-                return true;
             }
+            // Set up the new fragment in our fragment container.
+            currentFragment = fragmentIndex;
+            if(msg != null) {
+                Bundle newGame = new Bundle();
+                newGame.putString(GAME_KEY, msg);
+                fragmentList[fragmentIndex].setArguments(newGame);
+            }
+
+            // Initiate the transition between fragments.
+            context.getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.game_pane_fragment_container, fragmentList[fragmentIndex])
+                    .commit();
+            return true;
+
+        } else if(msg != null) {
+            sendMessage(msg, fragmentIndex);
+            return true;
         }
         return false;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
@@ -18,14 +18,40 @@
 package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
+import android.support.design.widget.FloatingActionButton;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.FabManager;
+import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.EventBusManager;
 import com.pajato.android.gamechat.fragment.BaseFragment;
 
+import org.greenrobot.eventbus.Subscribe;
+
 public class InitialFragment extends BaseFragment {
+
+    private FloatingActionButton mFab;
+
+    /** Process a given button click event looking for one on the rooms fab button. */
+    @Subscribe public void buttonClickHandler(final ClickEvent event) {
+        int v = event.getView() != null ? event.getView().getId() : 0;
+
+        if(v == R.id.init_ttt || v == R.id.init_ttt_button) {
+            GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
+                    getString(R.string.new_game_ttt));
+        } else if (v == R.id.init_checkers || v == R.id.init_checkers_button) {
+            GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
+                    getString(R.string.new_game_checkers));
+        } else if (v == R.id.init_chess || v == R.id.init_chess_button) {
+            GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
+                    getString(R.string.new_game_chess));
+        } else if (v == R.id.games_fab) {
+            FabManager.game.toggle(mFab);
+        }
+    }
 
     @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
                                        Bundle savedInstanceState) {
@@ -33,38 +59,10 @@ public class InitialFragment extends BaseFragment {
         setHasOptionsMenu(true);
         View layout = inflater.inflate(R.layout.fragment_initial, container, false);
 
-        // Handle Tic-Tac-Toe games.
-        View ttt = layout.findViewById(R.id.init_ttt);
-        ttt.setOnClickListener(new ClickHandler());
-        View tttButton = layout.findViewById(R.id.init_ttt_button);
-        tttButton.setOnClickListener(new ClickHandler());
-
-        // Handle Checkers Games.
-        View checkers = layout.findViewById(R.id.init_checkers);
-        checkers.setOnClickListener(new ClickHandler());
-        View checkersButton = layout.findViewById(R.id.init_checkers_button);
-        checkersButton.setOnClickListener(new ClickHandler());
-
-        View chess = layout.findViewById(R.id.init_chess);
-        chess.setOnClickListener(new ClickHandler());
-        View chessButton = layout.findViewById(R.id.init_chess_button);
-        chessButton.setOnClickListener(new ClickHandler());
-
+        EventBusManager.instance.register(this);
+        FabManager.game.init(layout);
+        mFab = (FloatingActionButton) layout.findViewById(R.id.games_fab);
         return layout;
     }
 
-    private class ClickHandler implements View.OnClickListener {
-        @Override public void onClick(View v) {
-            if(v.getId() == R.id.init_ttt || v.getId() == R.id.init_ttt_button) {
-                GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
-                        getString(R.string.new_game_ttt));
-            } else if (v.getId() == R.id.init_checkers || v.getId() == R.id.init_checkers_button) {
-                GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
-                        getString(R.string.new_game_checkers));
-            } else if (v.getId() == R.id.init_chess || v.getId() == R.id.init_chess_button) {
-                GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
-                        getString(R.string.new_game_chess));
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -1,6 +1,7 @@
 package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -49,37 +50,7 @@ public class SettingsFragment extends BaseFragment {
         final Spinner userChoices = (Spinner) main.findViewById(R.id.settings_user_spinner);
 
         // We want different users to appear in the user spinner when a different group is chosen.
-        //TODO: Find a procedural way to generate these arrays once accounts are implemented.
-        //TODO: Find a better way to handle isValidUser.
-        groupChoices.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                ArrayAdapter<CharSequence> userAdapter;
-                // If the group spinner has chosen the family group, show the family members.
-                if(position == 1) {
-                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
-                            R.array.family_group, android.R.layout.simple_spinner_item);
-                    userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-                    isValidUser = true;
-                // If the group spinner has chosen the work group, show the work members.
-                } else if (position == 2) {
-                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
-                            R.array.work_group, android.R.layout.simple_spinner_item);
-                    userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-                    isValidUser = true;
-                // Otherwise, a group has not been chosen, so show an empty group.
-                } else {
-                    userAdapter = ArrayAdapter.createFromResource(getActivity(),
-                            R.array.empty_group, android.R.layout.simple_spinner_item);
-                    isValidUser = false;
-                }
-                userChoices.setAdapter(userAdapter);
-            }
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-
-            }
-        });
+        groupChoices.setOnItemSelectedListener(new UserSelector(userChoices));
 
         // Setup the references to the game option buttons.
         mLocal = (ImageButton) main.findViewById(R.id.settings_local_button);
@@ -98,6 +69,25 @@ public class SettingsFragment extends BaseFragment {
             setupChess();
         }
         return main;
+    }
+
+    /** Handle the back button after the view has been created. */
+    @Override public void onViewCreated(final View view, final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        if(this.getView() != null) {
+            this.getView().setFocusableInTouchMode(true);
+            this.getView().requestFocus();
+            this.getView().setOnKeyListener(new View.OnKeyListener() {
+                @Override public boolean onKey(View v, int keyCode, KeyEvent event) {
+                    if (keyCode == KeyEvent.KEYCODE_BACK) {
+                        GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
+                        return true;
+                    }
+                    return false;
+                }
+            });
+        }
     }
 
     /**
@@ -157,4 +147,41 @@ public class SettingsFragment extends BaseFragment {
         });
     }
 
+    private class UserSelector implements AdapterView.OnItemSelectedListener {
+        private Spinner mSpinner;
+
+        UserSelector(final Spinner userChoices) {
+            mSpinner = userChoices;
+        }
+
+        //TODO: Find a procedural way to generate these arrays once accounts are implemented.
+        //TODO: Find a better way to handle isValidUser.
+        @Override public void onItemSelected(final AdapterView<?> parent, final View view,
+                                             final int position, final long id) {
+            ArrayAdapter<CharSequence> userAdapter;
+            // If the group spinner has chosen the family group, show the family members.
+            if(position == 1) {
+                userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                        R.array.family_group, android.R.layout.simple_spinner_item);
+                userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                isValidUser = true;
+                // If the group spinner has chosen the work group, show the work members.
+            } else if (position == 2) {
+                userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                        R.array.work_group, android.R.layout.simple_spinner_item);
+                userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                isValidUser = true;
+                // Otherwise, a group has not been chosen, so show an empty group.
+            } else {
+                userAdapter = ArrayAdapter.createFromResource(getActivity(),
+                        R.array.empty_group, android.R.layout.simple_spinner_item);
+                isValidUser = false;
+            }
+            mSpinner.setAdapter(userAdapter);
+        }
+        @Override
+        public void onNothingSelected(AdapterView<?> parent) {
+
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_initial.xml
+++ b/app/src/main/res/layout/fragment_initial.xml
@@ -2,111 +2,84 @@
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/init_panel">
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_launcher"
-        android:contentDescription="@string/app_name"
-        android:id="@+id/gamechat_logo"
-
-        app:layout_constraintTop_toTopOf="@id/init_panel"
-        app:layout_constraintLeft_toLeftOf="@id/init_panel"
-        android:layout_marginTop="80dp"
-        android:layout_marginStart="32dp"/>
-
     <TextView
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/new_game"
-        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
-        android:id="@+id/init_title"
+        android:id="@+id/game_message"
+        android:padding="24dp"
+        android:text="@string/NoRoomsMessageText"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        tools:text="Placeholder message ... updated at runtime."
+        tools:visibility="visible" />
 
-        app:layout_constraintTop_toTopOf="@id/gamechat_logo"
-        app:layout_constraintLeft_toRightOf="@id/gamechat_logo"
-        android:layout_marginStart="32dp"/>
+    <LinearLayout style="@style/FabMenu"
+        android:id="@+id/games_fab_menu"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/games_fab">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintTop_toBottomOf="@id/gamechat_logo"
-        app:layout_constraintLeft_toLeftOf="@id/init_panel"
-        app:layout_constraintRight_toRightOf="@id/init_panel"
-        android:layout_marginTop="32dp">
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/init_ttt"
+            android:gravity="end">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/play_choose_game"
-            android:textSize="28sp"/>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginStart="16dp">
-            <ImageButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+            <Button style="@style/FabMenuButton"
                 android:id="@+id/init_ttt_button"
-                android:src="@drawable/ic_launcher"
-                android:contentDescription="@string/play_ttt"/>
+                android:text="@string/play_ttt"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/init_ttt"
-                android:text="@string/play_ttt"
-                android:textSize="20sp"
-                android:layout_marginTop="20dp"/>
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/play_ttt"
+                android:src="@drawable/ic_casino_black_24dp"/>
 
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginStart="16dp">
-            <ImageButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/init_checkers"
+            android:gravity="end">
+
+            <Button style="@style/FabMenuButton"
                 android:id="@+id/init_checkers_button"
-                android:src="@drawable/ic_launcher"
-                android:contentDescription="@string/play_checkers"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/init_checkers"
-                android:text="@string/play_checkers"
-                android:textSize="20sp"
-                android:layout_marginTop="20dp"/>
+                android:text="@string/play_checkers"/>
+
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/play_checkers"
+                android:src="@drawable/ic_casino_black_24dp"/>
+
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginStart="16dp">
-            <ImageButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/init_chess"
+            android:gravity="end">
+
+            <Button style="@style/FabMenuButton"
                 android:id="@+id/init_chess_button"
-                android:src="@drawable/ic_launcher"
-                android:contentDescription="@string/play_chess"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/init_chess"
-                android:text="@string/play_chess"
-                android:textSize="20sp"
-                android:layout_marginTop="20dp"/>
+                android:text="@string/play_chess"/>
+
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/play_chess"
+                android:src="@drawable/ic_group_add_black_24dp"/>
+
         </LinearLayout>
 
     </LinearLayout>
+
+    <android.support.design.widget.FloatingActionButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="bottom|start"
+        android:id="@+id/games_fab"
+        android:src="@drawable/ic_add_white_24dp"
+        android:onClick="onClick"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:fabSize="normal"
+        tools:visibility="visible"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_rooms.xml
+++ b/app/src/main/res/layout/fragment_rooms.xml
@@ -23,53 +23,6 @@ http://www.gnu.org/licenses
     android:layout_height="match_parent"
     android:id="@+id/rooms_pane">
 
-    <LinearLayout style="@style/FabMenu"
-        android:id="@+id/rooms_fab_menu"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/rooms_fab">
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/joinRoomMenuItem">
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/joinRoomButton"
-                android:text="@string/JoinRoom" />
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/JoinRoomDescription"
-                android:src="@drawable/ic_casino_black_24dp" />
-        </LinearLayout>
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/addRoomMenuItem">
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/addRoomButton"
-                android:text="@string/AddRoom" />
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/AddRoomDescription"
-                android:src="@drawable/ic_casino_black_24dp" />
-        </LinearLayout>
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/addGroupMenuItem">
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/addGroupButton"
-                android:text="@string/AddGroup" />
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/AddGroupDescription"
-                android:src="@drawable/ic_group_add_black_24dp" />
-        </LinearLayout>
-    </LinearLayout>
-
-    <android.support.design.widget.FloatingActionButton
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:gravity="bottom|start"
-        android:id="@+id/rooms_fab"
-        android:src="@drawable/ic_add_white_24dp"
-        android:onClick="onClick"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:fabSize="normal"
-        tools:visibility="visible"/>
-
     <!-- The main content for the rooms pane is either an ad view
          followed by a list of expandable groups or an intro screen
          for Users with no groups. -->
@@ -136,4 +89,52 @@ http://www.gnu.org/licenses
                 tools:text="Placeholder message ... updated at runtime."
                 tools:visibility="visible" />
         </LinearLayout>
+
+    <LinearLayout style="@style/FabMenu"
+        android:id="@+id/rooms_fab_menu"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/rooms_fab">
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/joinRoomMenuItem">
+            <Button style="@style/FabMenuButton"
+                android:id="@+id/joinRoomButton"
+                android:text="@string/JoinRoom" />
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/JoinRoomDescription"
+                android:src="@drawable/ic_casino_black_24dp" />
+        </LinearLayout>
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/addRoomMenuItem">
+            <Button style="@style/FabMenuButton"
+                android:id="@+id/addRoomButton"
+                android:text="@string/AddRoom" />
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/AddRoomDescription"
+                android:src="@drawable/ic_casino_black_24dp" />
+        </LinearLayout>
+        <LinearLayout style="@style/FabMenuItem"
+            android:id="@+id/addGroupMenuItem">
+            <Button style="@style/FabMenuButton"
+                android:id="@+id/addGroupButton"
+                android:text="@string/AddGroup" />
+            <ImageView style="@style/FabMenuIcon"
+                android:contentDescription="@string/AddGroupDescription"
+                android:src="@drawable/ic_group_add_black_24dp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <android.support.design.widget.FloatingActionButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="bottom|start"
+        android:id="@+id/rooms_fab"
+        android:src="@drawable/ic_add_white_24dp"
+        android:onClick="onClick"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:fabSize="normal"
+        tools:visibility="visible"/>
+
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
An update and improvement towards our endgame layout of using Floating Action Buttons to launch new games and new rooms. We also facilitate easy returning to the game-picking screen if the user clicks on the wrong game via the back button.

# Changed Files

## Java Files

### chat/FabManager
* Changed from one instance, *instance* to two, *room* and *game*. This is to facilitate the new Floating Action Button in **InitialFragment**

### chat/RoomsFragment
* Changed the FabManager references to be in accordance with the new instance name, *room*.

### game/GameManager
* Minor refactoring to simplify code and make it easier to read.
* Added a few comments.

### game/InitialFragment
* Now uses a Floating Action Button instead of taking up the whole screen. This is for future work, as our model for **InitialFragment**, or it’s equivalent in the future will likely be quite similar to **RoomsFragment**.
* Now uses the event bus to handle onClicks.

### game/SettingsFragment
* Now using the back button with this Fragment visible will to go back to the **InitialFragment**.
* Moved the in-line **AdapterView.OnItemSelectedListener** to be a private, nested class, called *UserSelector*. This eliminates some of the ugliness of trying to read the onCreateView method.

## XML Files

### fragment_initial.xml
* Removed the full-screen image view and text and replaced it with a conditional-setup that is reliant on the Floating Action Button.

### fragment_rooms.xml
* Reordered the XML objects so that the Floating Action Button and FAB Menu are on top of the rest of the information. The current order causes a problem with our KitKat devices where clicking on the Floating Action Button is not possible if there is any Group data.