### PR TITLE
Fix some nasty chat group list bugs.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
@@ -25,7 +25,7 @@ public class FABTest extends BaseTest {
     /** Ensure that all items in the FAB Menu are present. */
     @Test public void testFABMenuPresent() {
         // Open up the FAB menu
-        onView(withId(R.id.rooms_fab))
+        onView(withId(R.id.groupsFab))
                 .check(matches(isDisplayed()))
                 .perform(click());
         // Ensure that the speed dial Indicators are all visible.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
@@ -33,7 +33,7 @@ import static com.pajato.android.gamechat.chat.FabManager.State.opened;
 
 /** Provide a singleton to manage the rooms panel fab button. */
 public enum FabManager {
-    room(R.id.rooms_fab, R.id.rooms_fab_menu),
+    room(R.id.groupsFab, R.id.rooms_fab_menu),
     game(R.id.games_fab, R.id.games_fab_menu);
 
     FabManager(final int fabId, final int fabMenuId) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  * @author Paul Michael Reilly
  */
-public class GroupListItem {
+public class GroupItem {
 
     // Public instance variables.
 
@@ -51,7 +51,7 @@ public class GroupListItem {
     // Public constructors.
 
     /** Build an instance for the given group. */
-    public GroupListItem(final String groupKey) {
+    public GroupItem(final String groupKey) {
         // TODO: flesh this out to populate the class using the Firebase data from the given group.
         // Use the group key to unpack a group's messages by walking the set of messages in
         // each room in the group.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListAdapter.java
@@ -31,8 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.chat.adapter.RoomsListItem.DATE_ITEM_TYPE;
-import static com.pajato.android.gamechat.chat.adapter.RoomsListItem.GROUP_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.GroupsListItem.DATE_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.GroupsListItem.GROUP_ITEM_TYPE;
 
 /**
  * Provide a recycler view adapter to handle showing a list of rooms with messages to view based on
@@ -40,14 +40,14 @@ import static com.pajato.android.gamechat.chat.adapter.RoomsListItem.GROUP_ITEM_
  *
  * @author Paul Michael Reilly
  */
-public class RoomsListAdapter extends RecyclerView.Adapter<ViewHolder> {
+public class GroupsListAdapter extends RecyclerView.Adapter<ViewHolder> {
 
-    private List<RoomsListItem> mList = new ArrayList<>();
+    private List<GroupsListItem> mList = new ArrayList<>();
 
     // Public instance methods.
 
     /** Add items to the adapter's main list. */
-    public void addItems(final List<RoomsListItem> items) {
+    public void addItems(final List<GroupsListItem> items) {
         // Add all the items after clearing the current ones.
         mList.addAll(items);
         notifyDataSetChanged();
@@ -72,7 +72,7 @@ public class RoomsListAdapter extends RecyclerView.Adapter<ViewHolder> {
 
     /** Populate the widgets for the item at the given position. */
     @Override public void onBindViewHolder(ViewHolder holder, int position) {
-        RoomsListItem item = mList.get(position);
+        GroupsListItem item = mList.get(position);
         if (item != null) {
             switch (item.type) {
                 case DATE_ITEM_TYPE:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListItem.java
@@ -23,7 +23,7 @@ package com.pajato.android.gamechat.chat.adapter;
  *
  * @author Paul Michael Reilly
  */
-public class RoomsListItem {
+public class GroupsListItem {
 
     // Public constants.
 
@@ -52,7 +52,7 @@ public class RoomsListItem {
     // Public constructors.
 
     /** Build an instance for a given group list item. */
-    public RoomsListItem(final GroupListItem item) {
+    public GroupsListItem(final GroupItem item) {
         type = GROUP_ITEM_TYPE;
         name = item.name;
         newCount = item.newMessageCount;
@@ -60,7 +60,7 @@ public class RoomsListItem {
     }
 
     /** Build an instance for a given date header item. */
-    public RoomsListItem(final DateHeaderItem item) {
+    public GroupsListItem(final DateHeaderItem item) {
         type = DATE_ITEM_TYPE;
         nameResourceId = item.getNameResourceId();
         // TODO: flesh this out to encapsulate enough information to build the corresponding view.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
@@ -34,13 +34,13 @@ import java.util.Map;
     public String name;
 
     /** The creation timestamp. */
-    private long createTime;
+    public long createTime;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The group member account identifiers. */
-    private List<String> memberIdList;
+    public List<String> memberIdList;
 
     /** Build an empty args constructor for the database. */
     public Group() {}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @IgnoreExtraProperties public class Message {
 
     /** The group owner/creator. */
-    private String owner;
+    public String owner;
 
     /** The group name. */
     public String name;
@@ -38,7 +38,7 @@ import java.util.Map;
     public long createTime;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The message text. */
     public String text;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -29,16 +29,16 @@ import java.util.Map;
 @IgnoreExtraProperties public class Room {
 
     /** The group owner/creator. */
-    private String owner;
+    public String owner;
 
     /** The group name. */
     public String name;
 
     /** The creation timestamp. */
-    private long createTime;
+    public long createTime;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The room type, one of "public", "private" or "me". */
     public String type;

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -207,19 +207,25 @@ public class MainActivity extends AppCompatActivity
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         NavigationManager.instance.init(this, toolbar);
+        processAccount(null);
+        EventBusManager.instance.register(this);
     }
 
     /** Handle an account state change by updating the navigation drawer header. */
     @Subscribe public void accountStateChanged(final AccountStateChangeEvent event) {
         // Due to a "bug" in Android, using XML to configure the navigation header current profile
         // click handler does not work.  Instead we do it here programmatically.
+        processAccount(event.account);
+    }
+
+    /** Process a given account. */
+    private void processAccount(final Account account) {
         NavigationView navView = (NavigationView) findViewById(R.id.nav_view);
         View header = navView.getHeaderView(0) != null ? navView.getHeaderView(0) : navView.inflateHeaderView(R.layout.nav_header_main);
         View layout = header.findViewById(R.id.currentProfile);
         if (layout != null) layout.setOnClickListener(this);
 
         // If there is an account, set up the navigation drawer header accordingly.
-        Account account = event.account;
         if (account != null) {
             // There is an account.  Set it up in the header.
             NavigationManager.instance.setAccount(account, header);

--- a/app/src/main/res/layout/fragment_groups.xml
+++ b/app/src/main/res/layout/fragment_groups.xml
@@ -43,13 +43,11 @@ http://www.gnu.org/licenses
             android:id="@+id/adView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="4dp"
-            ads:adSize="BANNER"
+            ads:adSize="SMART_BANNER"
             ads:adUnitId="@string/banner_ad_unit_id"/>
 
         <android.support.v7.widget.RecyclerView
-            android:id="@+id/rooms_list"
+            android:id="@+id/groupsList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginBottom="32dp"/>
@@ -96,7 +94,7 @@ http://www.gnu.org/licenses
     <LinearLayout style="@style/FabMenu"
                   android:id="@+id/rooms_fab_menu"
                   app:layout_constraintRight_toRightOf="parent"
-                  app:layout_constraintBottom_toTopOf="@+id/rooms_fab">
+                  app:layout_constraintBottom_toTopOf="@+id/groupsFab">
         <LinearLayout style="@style/FabMenuItem"
                       android:id="@+id/joinRoomMenuItem">
             <Button style="@style/FabMenuButton"
@@ -132,7 +130,7 @@ http://www.gnu.org/licenses
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
         android:gravity="bottom|start"
-        android:id="@+id/rooms_fab"
+        android:id="@+id/groupsFab"
         android:src="@drawable/ic_add_white_24dp"
         android:onClick="onClick"
         app:layout_constraintRight_toRightOf="parent"


### PR DESCRIPTION
<h1>Rationale:</h1>

There were a number of issues with the group list, including:

- The source code confusingly used "room" when it generally meant "group".
- When the app backgrounded and then foregrounded new messages would arrive that had aleady been seen giving rise to incorrect new messages.
- The sign in process would hang after a fresh install.
- Firebase model class fields either protected or private were silently not updated.

This commit fixes those issues.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Reuse existing Firebase event handlers.
- Apply RNF to method ordering.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- Lots of renaming for the rooms -> groups reality.
- Reuse cached Firebase event listeners.
- Filter out already seen new messages.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/GroupsFragment.java

- Lost of cosmetic room -> group renaming to reflect reality.
- onCreateView(): Split off initialization code to a procedural abstration.
- showContent(): Add a layout parameter.
- onMessageListChange(): Apply RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- Make all fields public so that Firebase's use of reflection will update the data correctly.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- Ensure that listeners are disconnected from Firebase during lifecycle events (Pause) but are reconnected from a cache, if possible, during Resume.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- Make sure that the navigation header is setup properly when there is no signed in user.

modified:   app/src/main/res/layout/fragment_groups.xml

- Make the ad view more consistent with common practice.

modified:   app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
renamed:    app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupListItem.java -> app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
renamed:    app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomsListAdapter.java -> app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListAdapter.java
renamed:    app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomsListItem.java -> app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupsListItem.java

- To better reflect reality.