### PR TITLE
Updated Tests for New Fab

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/CheckersTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/CheckersTest.java
@@ -40,6 +40,10 @@ public class CheckersTest extends BaseTest {
                 .perform(click());
 
         // Begin the process of starting a local checkers game
+        onView(withId(R.id.games_fab))
+                .check(matches(isDisplayed()))
+                .perform(click());
+
         onView(withId(R.id.init_checkers_button))
                 .check(matches(isDisplayed()))
                 .perform(click());

--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/ChessTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/ChessTest.java
@@ -36,6 +36,10 @@ public class ChessTest extends BaseTest {
                 .perform(click());
 
         // Begin the process of starting a local checkers game
+        onView(withId(R.id.games_fab))
+                .check(matches(isDisplayed()))
+                .perform(click());
+
         onView(withId(R.id.init_chess_button))
                 .check(matches(isDisplayed()))
                 .perform(click());

--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/GameTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/GameTest.java
@@ -31,6 +31,9 @@ public class GameTest extends BaseTest {
                 .check(matches(isDisplayed()));
         onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
+        onView(withId(R.id.games_fab))
+                .check(matches(isDisplayed()))
+                .perform(click());
     }
 
     /** Ensure that switching between two different game panels works properly */
@@ -108,7 +111,11 @@ public class GameTest extends BaseTest {
         onView(withText(R.string.new_game_init))
                 .check(matches(isDisplayed()))
                 .perform(click());
+        // Ensure the init panel is present and open the FAB
         onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
+        onView(withId(R.id.games_fab))
+                .check(matches(isDisplayed()))
+                .perform(click());
     }
 }


### PR DESCRIPTION
Very simple commit, just catching up with an oversight from friday where I committed changes to the InitialFragment without changing the tests accordingly. With this, now all the tests handle the FAB Button.

# Changed Files

## Test Files

### CheckersTest
* Changed the @Before method to open the fab button before choosing checkers. Because the IDs are reused, nothing else needs changing.

### ChessTest
* Changed the @Before method to open the fab button before choosing checkers. Because the IDs are reused, nothing else needs changing.

### GameTest
* Added opening the Fab to the @Before method. It is now also done at the end of the returnToInit method.