### PR TITLE
Finish chat manager rework.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -19,9 +19,6 @@ package com.pajato.android.gamechat.chat;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -38,34 +35,17 @@ public class ChatFragment extends BaseFragment {
 
     // Public instance methods.
 
-    /** Create the chat menu. */
-    @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater menuInflater) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        menuInflater.inflate(R.menu.chat_menu, menu);
-    }
-
     /** Create the view to do essentially nothing. Things will happen in the onStart() method. */
     @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
                                        final Bundle savedInstanceState) {
         // Inflate the layout, and initialize the game manager.
-        View layout = inflater.inflate(R.layout.fragment_chat, container, false);
-        setHasOptionsMenu(true);
-        // TODO: defer this to onStart: GroupListManager.instance.init(getActivity());
-
-        return layout;
-    }
-
-    /** Deal with a selected chat menu option. */
-    @Override public boolean onOptionsItemSelected(final MenuItem item) {
-        // TODO: tbd
-
-        return false;
+        return inflater.inflate(R.layout.fragment_chat, container, false);
     }
 
     /** Kick off fragment processing by having the chat manager decide what to do. */
     @Override public void onStart() {
         super.onStart();
-        // Turn it over to the chat manager ...
-        // TODO: reveal the new GroupListManager.instance.init(getActivity()) when it is ready.
+        // Turn it over to the chat manager to decide how to proceed.
+        ChatManager.instance.init(this.getActivity());
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.chat;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.util.Log;
+import android.util.SparseArray;
+
+import com.pajato.android.gamechat.R;
+
+import java.util.Locale;
+
+import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showGroupList;
+
+/**
+ * Provides the interface to the database/back end, primarily Firebase.
+ *
+ * @author Paul Michael Reilly
+ */
+enum ChatManager {
+    instance;
+
+    /** Provide a set of enum constants to identify the chat related fragments. */
+    public enum ChatFragmentType {
+        showGroupList (ShowGroupListFragment.class);
+        //showRoomList (ShowRoomListFragment.class),
+        //showMessages (ShowMessagesFragment.class),
+        //showNewGroup (ShowNewGroupFragment.class),
+        //showNewRoom (ShowNewRoomFragment.class),
+        //showJoinRoom (ShowJoinRoomFragment.class),
+        //showNoJoinedRooms (ShowNoJoinedRoomsFragment.class),
+        //showNoAccount (ShowNoAccountFragment.class);
+
+        // Private instance variables.
+
+        /** The fragment class associated with this type. */
+        Class<? extends Fragment> fragmentClass;
+
+        /** Build in instance of the type with a given fragment class. */
+        ChatFragmentType(final Class<? extends Fragment> fragmentClass) {
+            this.fragmentClass = fragmentClass;
+        }
+
+    }
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = ChatManager.class.getSimpleName();
+
+    // Public instance methods.
+
+    /** The repository for fragments created on demand. */
+    private SparseArray<Fragment> mFragmentMap = new SparseArray<>();
+
+    /** Initialize the component. */
+    public void init(final FragmentActivity activity) {
+        // Create the fragment where the groups and rooms with messages to view will be summarized.
+        // These are derived from a User's joined rooms which are in turn derived from the groups
+        // which the User is a member.
+        replaceFragment(showGroupList, activity);
+    }
+
+    // Private instance methods.
+
+    /** Attach a drill down fragment identified by a type, creating that fragment as necessary. */
+    public void chainFragment(final ChatFragmentType type, final FragmentActivity context) {
+        // Determine if the replacement fragment has been attached yet.
+        Fragment fragment = getFragment(type);
+        if (fragment == null) return;
+
+        // Run the transaction to attach the fragment to the activity, adding a backstack.
+        context.getSupportFragmentManager().beginTransaction()
+            .replace(R.id.chatFragmentContainer, fragment)
+            .addToBackStack(null)
+            .commit();
+    }
+
+    /** Attach a fragment identified by a type, creating that fragment as necessary. */
+    public void replaceFragment(final ChatFragmentType type, final FragmentActivity context) {
+        // Determine if the replacement fragment has been attached yet.
+        Fragment fragment = getFragment(type);
+        if (fragment == null) return;
+
+        // Run the transaction to attach the fragment to the activity.
+        context.getSupportFragmentManager().beginTransaction()
+            .replace(R.id.chatFragmentContainer, fragment)
+            .commit();
+    }
+
+    // Private instance methods.
+
+    /** Obtain a fragment, if possible. */
+    private Fragment getFragment(final ChatFragmentType type) {
+        Fragment result = mFragmentMap.get(type.ordinal());
+        if (result == null) {
+            // The fragment has not been created yet.  Do so now, aborting if the fragment can not
+            // be created.
+            result = getFragmentInstance(type);
+        }
+
+        return result;
+    }
+
+    /** Return an instance for a given class, null if no such instance can be created. */
+    private Fragment getFragmentInstance(final ChatFragmentType type) {
+        // Create the fragment instance. Log any exceptions.
+        try {
+            Fragment result = type.fragmentClass.newInstance();
+            mFragmentMap.put(type.ordinal(), result);
+            return result;
+        } catch (InstantiationException | IllegalAccessException exc) {
+            String format = "Failed to create a fragment for the class: %s";
+            Log.e(TAG, String.format(Locale.US, format, type.fragmentClass.getSimpleName()), exc);
+        }
+
+        return null;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -28,7 +28,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.ShowGroupListFragment;
+import com.pajato.android.gamechat.chat.ChatFragment;
 import com.pajato.android.gamechat.game.GameFragment;
 
 import java.util.ArrayList;
@@ -58,13 +58,12 @@ public enum PaneManager {
 
     /** Initialize the two central panels in the app: chat and game/activity. */
     public void init(final AppCompatActivity context) {
-        // Clear the two main panels.
+        // Clear then add in the two main panels.
         fragmentList.clear();
         titleList.clear();
         titleList.add(context.getString(R.string.ChatTitle));
         titleList.add(context.getString(R.string.game));
-        // TODO: Use fragmentList.add(new ChatFragment()); instead of the show group list fragment.
-        fragmentList.add(new ShowGroupListFragment());
+        fragmentList.add(new ChatFragment());
         fragmentList.add(new GameFragment());
 
         // Determine if a paging layout is active.


### PR DESCRIPTION
<h1>Rationale:</h1>

With this commit, the chat manager class now acts like the game manager class and is setup to handle adding new fragments to replace or chain existing fragments.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- Simplify by removing the options menu support.
- Kick off the group list fragment using the chat manager.

modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- Use the new chat manager to replace itself to run the group list fragment.

new file:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- The newly minted chat manager consistent with the game manager.