### PR TITLE
Fix build and lint issues.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
@@ -25,13 +25,13 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 public class ApplicationTest extends BaseTest {
     /** Ensure that the rooms panel is being displayed. */
     @Test public void testChatPaneIsVisible() {
-        onView(withId(R.id.rooms_pane))
+        onView(withId(R.id.chatPane))
                 .check(matches(isDisplayed()));
     }
 
     /** Ensure that the chat panel is being displayed. */
     @Test public void testGamePaneIsVisible() {
-        onView(withId(R.id.rooms_pane))
+        onView(withId(R.id.chatPane))
                 .check(matches(isDisplayed()))
                 .perform(swipeLeft());
         onView(withId(R.id.game_pane_fragment_container))
@@ -41,7 +41,7 @@ public class ApplicationTest extends BaseTest {
     /** Ensure that the toolbar buttons are displayed and function. */
     @Test public void testActionButtons() {
         // Ensure the search button is there
-        onView(withId(R.id.toolbar_search_icon))
+        onView(withId(R.id.search))
                 .check(matches(isDisplayed()));
         // Ensure the game button is there. Click on it, and ensure it navigates to the game pane.
         onView(withId(R.id.toolbar_game_icon))
@@ -53,7 +53,7 @@ public class ApplicationTest extends BaseTest {
         onView(withId(R.id.toolbar_chat_icon))
                 .check(matches(isDisplayed()))
                 .perform(click());
-        onView(withId(R.id.rooms_pane))
+        onView(withId(R.id.chatPane))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
@@ -74,7 +74,7 @@ public enum FabManager {
     public void toggle(final FloatingActionButton fab, final View contentView) {
         // Determine if the fab view STATE tag has a valid state value and the content view exists.
         Object payload = fab.getTag(R.integer.fabStateKey);
-        if (payload instanceof State && contentView != null) {
+        if (payload instanceof State) {
             // It does.  Toggle it by casing on the value to show and hide the relevant views.
             State value = (State) payload;
             switch (value) {
@@ -82,14 +82,14 @@ public enum FabManager {
                     // The FAB is showing X and menu is visible.  Set the icon to +, close the
                     // menu and undim the frame.
                     dismissMenu(fab);
-                    contentView.setVisibility(View.VISIBLE);
+                    if (contentView != null) contentView.setVisibility(View.VISIBLE);
                     break;
                 case closed:
                     // The FAB is showing + and the menu is not visible.  Set the icon to X and open
                     // the menu.
                     fab.setImageResource(R.drawable.ic_clear_white_24dp);
                     fab.setTag(R.integer.fabStateKey, opened);
-                    contentView.setVisibility(View.GONE);
+                    if (contentView != null) contentView.setVisibility(View.GONE);
                     View menu = mMenuMap.get(fab.getId());
                     menu.setVisibility(View.VISIBLE);
                     break;

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -108,7 +108,7 @@ public class GameFragment extends BaseFragment {
             backgroundDimmer.setVisibility(View.GONE);
         // If the click is on the fab, we have to handle if it's open or closed.
         } else if (viewId == R.id.games_fab) {
-            FabManager.game.toggle(fab);
+            FabManager.game.toggle(fab, null);
             if(backgroundDimmer.getVisibility() == View.VISIBLE) {
                 backgroundDimmer.setVisibility(View.GONE);
             } else {

--- a/app/src/main/res/layout/fragment_chat_groups.xml
+++ b/app/src/main/res/layout/fragment_chat_groups.xml
@@ -21,11 +21,11 @@ http://www.gnu.org/licenses
     xmlns:ads="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/chatPane">
 
-    <!-- The main content for the rooms pane is either an ad view
-         followed by a list of expandable groups or an intro screen
-         for Users with no groups. -->
+    <!-- The main content for the chat pane is an ad view followed by a list of expandable chat
+         items.  -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_chat_rooms.xml
+++ b/app/src/main/res/layout/fragment_chat_rooms.xml
@@ -28,11 +28,6 @@ http://www.gnu.org/licenses
     android:id="@+id/roomListContent"
     android:orientation="vertical">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="testing ... testnig"/>
     <com.google.android.gms.ads.AdView
         android:id="@+id/adView"
         android:layout_width="match_parent"
@@ -47,4 +42,3 @@ http://www.gnu.org/licenses
         android:layout_marginBottom="32dp"
         android:tag="@integer/roomList"/>
 </LinearLayout>
-

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <FrameLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,6 @@
     <string name="play_another_user_desc">Play with Another User button image</string>
     <string name="play_checkers">Play Checkers!</string>
     <string name="play_chess">Play Chess!</string>
-    <string name="play_choose_game">Select a Game to Play!</string>
     <string name="play_computer">Play against the Computer!</string>
     <string name="play_computer_desc">Play against the Computer image button</string>
     <string name="play_locally">Play Locally with a Friend!</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

Yesterday's rush effort to provide code to work on the fragment chaining problems was a tad too rushed and introduced build errors and uncovered some lint problems introduced recently.  This commit fixes those issues.  Still unfixed is connected test breakage that has more to do with sequencing of accounts (gamechattester) onto Firebase than real code issues.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/ApplicationTest.java
modified:   app/src/main/res/layout/fragment_chat_groups.xml

- Reintroduce the lost chat panel id.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- toggle(): Accept a null second argument as a temporary fix until dimming is working in both the chat and game sides.

modified:   app/src/main/res/layout/fragment_chat_rooms.xml

- Remove one-time development testing code.

modified:   app/src/main/res/layout/fragment_game.xml

- Remove some cruft generating a lint error.

modified:   app/src/main/res/values/strings.xml

- Remove an unused string.