### PR TITLE
Apply miscellaneous fixes.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
@@ -245,9 +245,8 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
             String text = "Welcome to your own private group and room.  Enjoy!";
             List<String> unreadList = new ArrayList<>();
             unreadList.add(uid);
-            String displayName = account.displayName;
-            Message message = new Message(uid, displayName, key, timestamp, timestamp, text,
-                    "standard", unreadList);
+            Message message = new Message(uid, "GameChat", key, timestamp, timestamp, text,
+                    "system", unreadList);
             DatabaseManager.instance.updateChildren(database, path, key, message.toMap());
         }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseFragment.java
@@ -128,27 +128,26 @@ public class BaseFragment extends Fragment {
         super.onDetach();
     }
 
-    /** Manage the groups list UI every time a message change occurs. */
+    /** Manage the list UI every time a message change occurs. */
     @Subscribe public void onMessageListChange(final MessageListChangeEvent event) {
-        // Determine if the groups panel has been inflated.  It damned well should be.
+        // Determine if the fragment has a view and that it has a list type.
         View layout = getView();
-        if (layout != null) {
-            // It has.  Publish the joined rooms state using a Inbox by Google layout.
+        if (layout != null && mItemListType != null) {
+            // It has both.  Show the chat list, either groups, messages or rooms.
             RecyclerView listView = (RecyclerView) layout.findViewById(R.id.chatList);
             if (listView != null) {
                 // Obtain the data to be listed on the list view.
                 RecyclerView.Adapter adapter = listView.getAdapter();
                 if (adapter instanceof ChatListAdapter) {
-                    // TODO: parse the rooms to build a list of active room information.  For now,
-                    // inject dummy data into the list view adapter.
+                    // Inject the list items into the recycler view.
                     ChatListAdapter listAdapter = (ChatListAdapter) adapter;
+                    listView.setVisibility(View.GONE);
                     listAdapter.clearItems();
                     listAdapter.addItems(ChatListManager.instance.getList(mItemListType, mItem));
+                    listView.scrollToPosition(listAdapter.getItemCount() - 1);
                     listView.setVisibility(View.VISIBLE);
                 }
             }
-        } else {
-            Log.e(TAG, "The groups fragment layout does not exist yet!");
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
@@ -69,6 +69,14 @@ public enum ChatListManager {
         group, message, room
     }
 
+    // Public class constants.
+
+    /** The format used to generate the database path for the message list. */
+    public static final String MESSAGES_FORMAT = "/groups/%s/rooms/%s/messages/";
+
+    /** The format used to generate the database path for a particular message. */
+    public static final String UNREAD_LIST_FORMAT = MESSAGES_FORMAT + "%s/unreadList";
+
     // Private class constants.
 
     /** The format specifying the path to the rooms profile on Firebase. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -113,7 +113,7 @@ public class ShowGroupListFragment extends BaseFragment {
         mItemListType = ChatListManager.ChatListType.group;
         View layout = inflater.inflate(R.layout.fragment_chat_groups, container, false);
         initAdView(layout);
-        initGroupsList(layout);
+        initList(layout);
         EventBusManager.instance.register(this);
 
         return layout;
@@ -191,7 +191,7 @@ public class ShowGroupListFragment extends BaseFragment {
     // Private instance methods.
 
     /** Initialize the joined rooms list by setting up the recycler view. */
-    private void initGroupsList(@NonNull final View layout) {
+    private void initList(@NonNull final View layout) {
         // Initialize the recycler view.
         Context context = layout.getContext();
         LinearLayoutManager layoutManager = new LinearLayoutManager(context, VERTICAL, false);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
@@ -17,14 +17,21 @@
 
 package com.pajato.android.gamechat.chat.adapter;
 
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.database.DatabaseManager;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+
+import static com.pajato.android.gamechat.chat.ChatListManager.UNREAD_LIST_FORMAT;
 
 /**
  * Provide a POJO to encapsulate a message item to be added to a recycler view.
@@ -71,7 +78,12 @@ public class MessageItem {
             // The message is still marked new.  Change it to "seen" by removing the key and
             // persisting the message.
             unreadList.remove(accountId);
-            // TODO: persist the seen state.
+            DatabaseReference database = FirebaseDatabase.getInstance().getReference();
+            String key = message.messageKey;
+            String path = String.format(Locale.US, UNREAD_LIST_FORMAT, groupKey, roomKey, key);
+            Map<String, Object> unreadMap = new HashMap<>();
+            unreadMap.put("unreadList", unreadList);
+            DatabaseManager.instance.updateChildren(database, path, unreadMap);
         }
     }
 

--- a/app/src/main/res/layout/fragment_chat_messages.xml
+++ b/app/src/main/res/layout/fragment_chat_messages.xml
@@ -18,11 +18,9 @@ http://www.gnu.org/licenses
 <!-- The main content for the rooms pane is either an ad view
            followed by a list of expandable groups or an intro screen
          for Users with no groups. -->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:ads="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginBottom="32dp"


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit addresses a number of small issues:

- Removes stale code inherited from the Firebase friendly chat sample code.
- Make the messages list scroll to the bottom on new messages.
- Ensure that unseen messages get marked as seen.
- Change some names for consistency.
- Advertise "GameChat" as the owner of welcome messages.
- Fix some startup NPEs.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Change the welcome message owner name to "GameChat" and the message type to "system".

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseFragment.java

- onMessageListChange(): Fix a NPE caused by the ChatFragment not having an item type; enhance documentation; scroll to last item in the list.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java

- MESSAGES_FORMAT: New constant providing the path to the messages Firebase node.
- UNREAD_LIST_FORMAT: New constant providing the path to the message unreadList Firebase node.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java

- Name change: initGroupsList() -> initList() for consistency with other fragments.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java

- Lose the stale "friendly chat" detritus.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java

- MessageItem(): Deal wiht the unseen state persistence to Firebase.

modified:   app/src/main/res/layout/fragment_chat_messages.xml

- Remove the stale tools namespace declaration per AS recommendations.