### PR TITLE
Fix a backgrounding issue.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -17,18 +17,13 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.os.Bundle;
 import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
-import com.pajato.android.gamechat.event.EventBusManager;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -46,30 +41,30 @@ public class ChatFragment extends BaseFragment {
 
     // Public instance methods.
 
-    /** Handle a authentication event. */
+    /** Set the layout file, which specifies the chat FAB and the basic options menu. */
+    @Override public int getLayout() {return R.layout.fragment_chat;}
+
+    /** Handle a authentication change event by dealing with the fragment to display. */
     @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
-        // Register an active rooms change handler on the account, if there is an account,
-        // preferring a cached handler, if one is available.
+        // Log the event and determine if there is an active account.
+        logEvent("onAccountStateChange");
         if (event.account == null) {
             // There is no active account.  Show the no account fragment.
             ChatManager.instance.replaceFragment(showNoAccount, this.getActivity());
         } else {
-            // There is an active account.  Show a list of messages by room in the groups for which
-            // the account is a member.
-            ChatManager.instance.replaceFragment(showGroupList, this.getActivity());
+            // There is an active account.  Determine if a default fragment needs to be set up and,
+            // if so, show the group list, otherwise just let whatever fragment is running stay
+            // running.
+            ChatManager.ChatFragmentType type = ChatManager.instance.lastTypeShown;
+            if (type == null) ChatManager.instance.replaceFragment(showGroupList, getActivity());
         }
     }
 
     /** Create the view to do essentially nothing. Things will happen in the onStart() method. */
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
-        // Inflate the layout, and initialize the game manager.
+    @Override public void onInitialize() {
+        // Declare the use of the options menu and intialize the FAB and it's menu.
         setHasOptionsMenu(true);
-        View result = inflater.inflate(R.layout.fragment_chat, container, false);
-        FabManager.chat.init(result);
-        EventBusManager.instance.register(this);
-
-        return result;
+        FabManager.chat.init(mLayout, this.getTag());
     }
 
     /** Post the chat options menu on demand. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -57,10 +57,14 @@ enum ChatManager {
         }
 
     }
+
     // Private class constants.
 
     /** The logcat tag. */
     private static final String TAG = ChatManager.class.getSimpleName();
+
+
+    public ChatFragmentType lastTypeShown;
 
     // Public instance methods.
 
@@ -78,6 +82,7 @@ enum ChatManager {
 
         // Set the item on the fragment and run the transaction to attach the fragment to the
         // activity, adding a backstack.
+        lastTypeShown = type;
         setItem(fragment, item);
         context.getSupportFragmentManager().beginTransaction()
             .replace(R.id.chatFragmentContainer, fragment)

--- a/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
@@ -19,11 +19,17 @@ package com.pajato.android.gamechat.chat;
 
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
 
+import java.util.Locale;
+
+import static com.bumptech.glide.gifdecoder.GifHeaderParser.TAG;
 import static com.pajato.android.gamechat.chat.FabManager.State.opened;
 
 
@@ -43,15 +49,13 @@ public enum FabManager {
     // Private instance variables.
 
     /** The fab resource identifier. */
-    int mFabId;
+    private int mFabId;
 
     /** The fab menu resource identifier. */
-    int mFabMenuId;
+    private int mFabMenuId;
 
-    /** The fab view. */
-    private FloatingActionButton mFab;
-
-    // Private instance variables.
+    /** The tag used to find the main chat fragment, which spawns all others. */
+    private String mTag;
 
     /** The association of FAB button resource identifiers and their menu layout. */
     private SparseArray<View> mMenuMap = new SparseArray<>();
@@ -59,33 +63,71 @@ public enum FabManager {
     // Public instance methods
 
     /** Initialize the fab button. */
-    public void init(@NonNull final View layout) {
+    public void init(@NonNull final View layout, final String tag) {
         // Initialize the fab button state to opened and then toggle it to put the panel into the
         // correct initial state.
-        mFab = (FloatingActionButton) layout.findViewById(mFabId);
+        mTag = tag;
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         View menu = layout.findViewById(mFabMenuId);
-        mFab.setTag(R.integer.fabStateKey, opened);
-        mMenuMap.put(mFab.getId(), menu);
-        dismissMenu();
+        fab.setTag(R.integer.fabStateKey, opened);
+        mMenuMap.put(mFabId, menu);
+        dismissMenu(layout);
     }
 
-    /** Dismiss the menu associated with the given FAB button. */
-    public void dismissMenu() {
-        mFab.setImageResource(R.drawable.ic_add_white_24dp);
-        mFab.setTag(R.integer.fabStateKey, State.closed);
-        View menu = mMenuMap.get(mFab.getId());
+    /** Dismiss the menu associated with the given layout view. */
+    public void dismissMenu(@NonNull final View layout) {
+        // The fragment is accessible and the layout has been established.  Finish dismissing the
+        // fab menu.
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setImageResource(R.drawable.ic_add_white_24dp);
+        fab.setTag(R.integer.fabStateKey, State.closed);
+        View menu = mMenuMap.get(mFabId);
         menu.setVisibility(View.GONE);
     }
 
+    /** Dismiss the menu associated with the given FAB button. */
+    public void dismissMenu(@NonNull final Fragment fragment) {
+        // Determine if the chat fragment is accessible.  If not, abort.
+        View layout = getView(fragment);
+        if (layout != null) dismissMenu(layout);
+    }
+
+    /** Return the given fragment's layout view, if one exists, otherwise null. */
+    private View getView(@NonNull final Fragment fragment) {
+        // Determine if the given fragment has an associated fragment.
+        FragmentActivity activity = fragment.getActivity();
+        if (activity == null) {
+            // The fragment does not have an associated activity!.
+            String format = "The fragment {%s} does not have an attached activity!";
+            Log.e(TAG, String.format(Locale.US, format, fragment));
+            return null;
+        }
+
+        // Determine if the attached fragment has a view.  If so return the view, otherwise null.
+        Fragment chatFragment = activity.getSupportFragmentManager().findFragmentByTag(mTag);
+        return chatFragment != null ? chatFragment.getView() : null;
+    }
+
     /** Set the FAB visibility state. */
-    public void setState(final int state) {
-        mFab.setVisibility(state);
+    public void setState(@NonNull final Fragment fragment, final int state) {
+        View layout = getView(fragment);
+        if (layout == null) return;
+
+        // ...
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setVisibility(state);
     }
 
     /** Toggle the state of the FAB button. */
-    public void toggle(final View contentView) {
+    public void toggle(@NonNull final Fragment fragment) {
         // Determine if the fab view STATE tag has a valid state value and the content view exists.
-        Object payload = mFab.getTag(R.integer.fabStateKey);
+        View layout = getView(fragment);
+        if (layout == null) return;
+
+        // The layout view is valid.  Use it to toggle the fab state.
+        View contentView = fragment.getView();
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        Object payload = fab.getTag(R.integer.fabStateKey);
         if (payload instanceof State) {
             // It does.  Toggle it by casing on the value to show and hide the relevant views.
             State value = (State) payload;
@@ -93,16 +135,16 @@ public enum FabManager {
                 case opened:
                     // The FAB is showing X and menu is visible.  Set the icon to +, close the
                     // menu and undim the frame.
-                    dismissMenu();
+                    dismissMenu(layout);
                     if (contentView != null) contentView.setVisibility(View.VISIBLE);
                     break;
                 case closed:
                     // The FAB is showing + and the menu is not visible.  Set the icon to X and open
                     // the menu.
-                    mFab.setImageResource(R.drawable.ic_clear_white_24dp);
-                    mFab.setTag(R.integer.fabStateKey, opened);
+                    fab.setImageResource(R.drawable.ic_clear_white_24dp);
+                    fab.setTag(R.integer.fabStateKey, opened);
                     if (contentView != null) contentView.setVisibility(View.GONE);
-                    View menu = mMenuMap.get(mFab.getId());
+                    View menu = mMenuMap.get(mFabId);
                     menu.setVisibility(View.VISIBLE);
                     break;
             }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -19,25 +19,21 @@ package com.pajato.android.gamechat.chat;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.adapter.ChatListAdapter;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.EventBusManager;
 import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
 import com.pajato.android.gamechat.main.PaneManager;
 import com.pajato.android.gamechat.main.ProgressManager;
@@ -67,12 +63,12 @@ public class ShowGroupListFragment extends BaseFragment {
         switch (value) {
             case R.id.chatFab:
                 // It is a chat fab button.  Toggle the state.
-                FabManager.chat.toggle(getView());
+                FabManager.chat.toggle(this);
                 break;
             case R.id.addGroupButton:
             case R.id.addGroupMenuItem:
                 // Dismiss the FAB menu, and start up the add group activity.
-                FabManager.chat.dismissMenu();
+                FabManager.chat.dismissMenu(this);
                 Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
                 startActivity(intent);
                 break;
@@ -93,6 +89,9 @@ public class ShowGroupListFragment extends BaseFragment {
         }
     }
 
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_chat_groups;}
+
     /** Deal with the options menu by hiding the back button. */
     @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
         // Turn off the back option and turn on the search option.
@@ -100,19 +99,14 @@ public class ShowGroupListFragment extends BaseFragment {
     }
 
     /** Handle the setup for the groups panel. */
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
         // view and the listeners for backend data changes.
         setTitles(null, null);
         setHasOptionsMenu(true);
         mItemListType = ChatListManager.ChatListType.group;
-        View layout = inflater.inflate(R.layout.fragment_chat_groups, container, false);
-        initAdView(layout);
-        initList(layout);
-        EventBusManager.instance.register(this);
-
-        return layout;
+        initAdView(mLayout);
+        initList(mLayout);
     }
 
     /** Deal with a change in the joined rooms state. */
@@ -158,7 +152,7 @@ public class ShowGroupListFragment extends BaseFragment {
     /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
     @Override public void onResume() {
         // Turn on the FAB and shut down the progress bar.
-        FabManager.chat.setState(View.VISIBLE);
+        FabManager.chat.setState(this, View.VISIBLE);
         ProgressManager.instance.hide();
         super.onResume();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
@@ -18,21 +18,18 @@
 package com.pajato.android.gamechat.chat;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
+import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
-import android.widget.Toast;
 
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
@@ -90,16 +87,8 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
         }
     }
 
-    private void showFutureFeatureMessage(final int resourceId) {
-        // Post a toast message.
-        Context context = getContext();
-        String prefix = context.getString(resourceId);
-        String suffix = context.getString(R.string.FutureFeature);
-        CharSequence text = String.format(Locale.getDefault(), "%s %s", prefix, suffix);
-        int duration = Toast.LENGTH_LONG;
-        Toast toast = Toast.makeText(context, text, duration);
-        toast.show();
-    }
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_chat_messages;}
 
     /** Handle an account state change event by showing the no sign in message. */
     @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
@@ -127,21 +116,17 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
     }
 
     /** Handle the setup of the list of messages. */
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Inflate the layout for this fragment and initialize by setting the titles, declaring the
         // use of the options menu, removing the FAB button, fetching any remote configurations,
         // setting up the list of messages, setting up the edit text field and setting up the
         // database analytics.
-        View result = inflater.inflate(R.layout.fragment_chat_messages, container, false);
         setTitles(null, mItem.roomKey);
         setHasOptionsMenu(true);
         mItemListType = ChatListManager.ChatListType.message;
-        FabManager.chat.setState(View.GONE);
-        initList(result, ChatListManager.instance.getList(mItemListType, mItem), true);
-        initEditText(result);
-
-        return result;
+        FabManager.chat.setState(this, View.GONE);
+        initList(mLayout, ChatListManager.instance.getList(mItemListType, mItem), true);
+        initEditText(mLayout);
     }
 
     @Override public boolean onOptionsItemSelected(final MenuItem item) {
@@ -165,11 +150,18 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
     /** Deal with the fragment's lifecycle by managing the FAB. */
     @Override public void onResume() {
         // Turn off the FAB.
-        FabManager.chat.setState(View.GONE);
+        FabManager.chat.setState(this, View.GONE);
         super.onResume();
     }
 
     // Private instance methods.
+
+    /** Return the enveloping chat fragment layout using the saved tag value. */
+    private View getFragmentLayout() {
+        String tag = "chatFragment";
+        Fragment fragment = getActivity().getSupportFragmentManager().findFragmentByTag(tag);
+        return fragment.getView();
+    }
 
     /** Dismiss the virtual keyboard in response to a click on the given view. */
     private void hideSoftKeyBoard(final View view) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
@@ -17,12 +17,8 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.os.Bundle;
 import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
@@ -56,22 +52,21 @@ public class ShowNoAccountFragment extends BaseFragment {
         }
     }
 
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_chat_no_account;}
+
     /** Handle an account state change event by showing the no sign in message. */
     @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
         // TODO: handle an account becoming available by switching to the show group list fragment.
     }
 
     /** Handle the setup for the groups panel. */
-    @Override public View onCreateView(final LayoutInflater inflater,
-                                       final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
         // view and the listeners for backend data changes.
         //ProgressManager.instance.show(this.getContext());
         setHasOptionsMenu(true);
-        EventBusManager.instance.register(this);
         ProgressManager.instance.hide();
-        return inflater.inflate(R.layout.fragment_chat_no_account, container, false);
     }
 
     /** Handle an options menu choice. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java
@@ -17,12 +17,8 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.os.Bundle;
 import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -52,14 +48,13 @@ public class ShowNoJoinedRoomsFragment extends BaseFragment {
         }
     }
 
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_chat_no_joined_rooms;}
+
     /** Handle the setup for the groups panel. */
-    @Override public View onCreateView(final LayoutInflater inflater,
-                                       final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Show the no joined rooms message.
         setHasOptionsMenu(true);
-        EventBusManager.instance.register(this);
-        return inflater.inflate(R.layout.fragment_chat_no_joined_rooms, container, false);
     }
 
     /** Handle an options menu choice. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
@@ -18,24 +18,20 @@
 package com.pajato.android.gamechat.chat;
 
 import android.content.Intent;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.adapter.ChatListAdapter;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.EventBusManager;
 import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
 import com.pajato.android.gamechat.event.MessageListChangeEvent;
 import com.pajato.android.gamechat.main.PaneManager;
@@ -68,12 +64,12 @@ public class ShowRoomListFragment extends BaseFragment {
         switch (value) {
             case R.id.chatFab:
                 // It is a chat fab button.  Toggle the state.
-                FabManager.chat.toggle(getView());
+                FabManager.chat.toggle(this);
                 break;
             case R.id.addGroupButton:
             case R.id.addGroupMenuItem:
                 // Dismiss the FAB menu, and start up the add group activity.
-                FabManager.chat.dismissMenu();
+                FabManager.chat.dismissMenu(this);
                 Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
                 startActivity(intent);
                 break;
@@ -89,6 +85,9 @@ public class ShowRoomListFragment extends BaseFragment {
                 break;
         }
     }
+
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_chat_rooms;}
 
     /** Handle an account state change event by showing the no sign in message. */
     @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
@@ -112,18 +111,14 @@ public class ShowRoomListFragment extends BaseFragment {
     }
 
     /** Handle the setup for the groups panel. */
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Inflate the layout for this fragment and initialize by setting the titles, declaring the
         // use of the options menu, setting up the ad view and initializing the rooms handling.
-        View result = inflater.inflate(R.layout.fragment_chat_rooms, container, false);
         setTitles(mItem.groupKey, null);
         setHasOptionsMenu(true);
         mItemListType = ChatListManager.ChatListType.room;
-        initAdView(result);
-        initList(result, ChatListManager.instance.getList(mItemListType, mItem), false);
-
-        return result;
+        initAdView(mLayout);
+        initList(mLayout, ChatListManager.instance.getList(mItemListType, mItem), false);
     }
 
     /** Deal with a change in the joined rooms state. */
@@ -195,7 +190,7 @@ public class ShowRoomListFragment extends BaseFragment {
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
     @Override public void onResume() {
         // Turn off the FAB.
-        FabManager.chat.setState(View.VISIBLE);
+        FabManager.chat.setState(this, View.VISIBLE);
         super.onResume();
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -1,16 +1,13 @@
 package com.pajato.android.gamechat.game;
 
 import android.graphics.PorterDuff;
-import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.SparseIntArray;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.GridLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -44,9 +41,10 @@ public class CheckersFragment extends BaseFragment {
     private View mLayout;
     private ArrayList<Integer> mPossibleMoves;
 
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                             final Bundle savedInstanceState) {
-        mLayout = inflater.inflate(R.layout.fragment_checkers, container, false);
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_checkers;}
+
+    @Override public void onInitialize() {
         mBoard = (GridLayout) mLayout.findViewById(R.id.board);
         mTurn = true;
         onNewGame();
@@ -62,8 +60,6 @@ public class CheckersFragment extends BaseFragment {
         ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
         playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorAccent),
                 PorterDuff.Mode.SRC_ATOP);
-
-        return mLayout;
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -1,17 +1,14 @@
 package com.pajato.android.gamechat.game;
 
 import android.graphics.PorterDuff;
-import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.util.SparseArray;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.GridLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -36,7 +33,6 @@ public class ChessFragment extends BaseFragment {
     private SparseArray<ChessPiece> mBoardMap;
     private ImageButton mHighlightedTile;
     private boolean mIsHighlighted = false;
-    private View mLayout;
     private ArrayList<Integer> mPossibleMoves;
 
     // Castle Management Objects
@@ -47,11 +43,11 @@ public class ChessFragment extends BaseFragment {
     private boolean mSecondaryKingSideRookHasMoved;
     private boolean mSecondaryKingHasMoved;
 
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_checkers;}
 
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Setup the board and start a new game to create the board.
-        mLayout = inflater.inflate(R.layout.fragment_checkers, container, false);
         mBoard = (GridLayout) mLayout.findViewById(R.id.board);
         mTurn = false;
         onNewGame();
@@ -69,8 +65,6 @@ public class ChessFragment extends BaseFragment {
         ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
         playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorAccent),
                 PorterDuff.Mode.SRC_ATOP);
-
-        return mLayout;
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -17,20 +17,17 @@
 
 package com.pajato.android.gamechat.game;
 
-import android.os.Bundle;
 import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.BaseFragment;
 import com.pajato.android.gamechat.chat.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.EventBusManager;
-import com.pajato.android.gamechat.chat.BaseFragment;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -46,15 +43,15 @@ public class GameFragment extends BaseFragment {
         // Required empty public constructor
     }
 
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                             final Bundle savedInstanceState) {
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_game;}
+
+    @Override public void onInitialize() {
         // Inflate the layout, and initialize the various managers.
-        View layout = inflater.inflate(R.layout.fragment_game, container, false);
         setHasOptionsMenu(true);
         EventBusManager.instance.register(this);
         GameManager.instance.init(getActivity());
-        FabManager.game.init(layout);
-        return layout;
+        FabManager.game.init(mLayout, this.getTag());
     }
 
     @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater menuInflater) {
@@ -85,28 +82,28 @@ public class GameFragment extends BaseFragment {
         if(viewId == R.id.init_ttt || viewId == R.id.init_ttt_button) {
             GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
                     getString(R.string.new_game_ttt));
-            FabManager.game.dismissMenu();
+            FabManager.game.dismissMenu(this);
             backgroundDimmer.setVisibility(View.GONE);
         // Do it for checkers.
         } else if (viewId == R.id.init_checkers || viewId == R.id.init_checkers_button) {
             GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
                     getString(R.string.new_game_checkers));
-            FabManager.game.dismissMenu();
+            FabManager.game.dismissMenu(this);
             backgroundDimmer.setVisibility(View.GONE);
         // Do it for chess.
         } else if (viewId == R.id.init_chess || viewId == R.id.init_chess_button) {
             GameManager.instance.sendNewGame(GameManager.SETTINGS_INDEX, getActivity(),
                     getString(R.string.new_game_chess));
-            FabManager.game.dismissMenu();
+            FabManager.game.dismissMenu(this);
             backgroundDimmer.setVisibility(View.GONE);
         // And do it for the rooms option buttons.
         } else if (viewId == R.id.init_rooms || viewId == R.id.init_rooms_button) {
             GameManager.instance.sendNewGame(GameManager.INIT_INDEX, getActivity());
-            FabManager.game.dismissMenu();
+            FabManager.game.dismissMenu(this);
             backgroundDimmer.setVisibility(View.GONE);
         // If the click is on the fab, we have to handle if it's open or closed.
         } else if (viewId == R.id.games_fab) {
-            FabManager.game.toggle(null);
+            FabManager.game.toggle(this);
             if(backgroundDimmer.getVisibility() == View.VISIBLE) {
                 backgroundDimmer.setVisibility(View.GONE);
             } else {

--- a/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
@@ -17,10 +17,7 @@
 
 package com.pajato.android.gamechat.game;
 
-import android.os.Bundle;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
@@ -28,17 +25,17 @@ import com.pajato.android.gamechat.chat.BaseFragment;
 
 public class InitialFragment extends BaseFragment {
 
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_initial;}
+
+    @Override public void onInitialize() {
         // Inflate the layout for this fragment
         setHasOptionsMenu(true);
-        View layout = inflater.inflate(R.layout.fragment_initial, container, false);
         // Setup the No Rooms Message.
-        TextView message = (TextView) layout.findViewById(R.id.game_message);
+        TextView message = (TextView) mLayout.findViewById(R.id.game_message);
         message.setText(R.string.NoRoomsMessageText);
         // Return the fab back to visible.
         getActivity().findViewById(R.id.games_fab).setVisibility(View.VISIBLE);
-        return layout;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -1,14 +1,11 @@
 package com.pajato.android.gamechat.game;
 
-import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -27,17 +24,15 @@ public class LocalTTTFragment extends BaseFragment {
     private String mSpace;
 
     // Board management objects
-    private View mBoard;
     private int turnCount;
 
-    public LocalTTTFragment() {
+    public LocalTTTFragment() {}
 
-    }
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_ttt;}
 
-    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                                       final Bundle savedInstanceState) {
+    @Override public void onInitialize() {
         // Initialize Member Variables
-        mBoard = inflater.inflate(R.layout.fragment_ttt, container, false);
         mTurn = true;
         mXValue = getString(R.string.xValue);
         mOValue = getString(R.string.oValue);
@@ -46,8 +41,6 @@ public class LocalTTTFragment extends BaseFragment {
 
         getActivity().findViewById(R.id.games_fab).setVisibility(View.VISIBLE);
         setHasOptionsMenu(true);
-
-        return mBoard;
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -121,18 +114,18 @@ public class LocalTTTFragment extends BaseFragment {
             if(xWins) {
                 Winner.setText(R.string.winner_x);
                 handlePlayerIcons(true);
-                GameManager.instance.generateSnackbar(mBoard, "Player 1 (" + mXValue + ") Wins!",
+                GameManager.instance.generateSnackbar(mLayout, "Player 1 (" + mXValue + ") Wins!",
                         ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
             } else if (oWins) {
                 Winner.setText(R.string.winner_o);
                 handlePlayerIcons(false);
-                GameManager.instance.generateSnackbar(mBoard, "Player 2 (" + mOValue + ") Wins!",
+                GameManager.instance.generateSnackbar(mLayout, "Player 2 (" + mOValue + ") Wins!",
                         ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
                 // If no one has won, the turn timer has run out. End the game.
                 } else {
                 // Reveal Tie Messages
                 Winner.setText(R.string.winner_tie);
-                GameManager.instance.generateSnackbar(mBoard, "It's a Tie!", -1, true);
+                GameManager.instance.generateSnackbar(mLayout, "It's a Tie!", -1, true);
             }
             return false;
         }
@@ -149,7 +142,7 @@ public class LocalTTTFragment extends BaseFragment {
         // Go through all the buttons.
         for(int i = 0; i < 3; i++) {
             for(int j = 0; j < 3; j++) {
-                Button currTile = (Button) mBoard.findViewWithTag("button" + Integer.toString(i) + Integer.toString(j));
+                Button currTile = (Button) mLayout.findViewWithTag("button" + Integer.toString(i) + Integer.toString(j));
                 String tileValue = currTile.getText().toString();
 
                 // Assign each possible state for each tile as a value. The only possible values
@@ -243,21 +236,21 @@ public class LocalTTTFragment extends BaseFragment {
         handlePlayerIcons(mTurn);
 
         // Set values for each tile to empty.
-        ((Button) mBoard.findViewWithTag("button00")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button01")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button02")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button10")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button11")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button12")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button20")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button21")).setText(mSpace);
-        ((Button) mBoard.findViewWithTag("button22")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button00")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button01")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button02")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button10")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button11")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button12")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button20")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button21")).setText(mSpace);
+        ((Button) mLayout.findViewWithTag("button22")).setText(mSpace);
         // Output New Game Messages
 
         String newTurn = "New Game! Player " + (mTurn
                 ? "1 ( " + mXValue + ")"
                 : "2 (" + mOValue + ")") + "'s Turn";
-        GameManager.instance.generateSnackbar(mBoard, newTurn, ContextCompat.getColor(getActivity(),
+        GameManager.instance.generateSnackbar(mLayout, newTurn, ContextCompat.getColor(getActivity(),
                 R.color.colorPrimaryDark), false);
         checkNotFinished();
     }
@@ -270,7 +263,7 @@ public class LocalTTTFragment extends BaseFragment {
      * @param buttonTag the tag of the button clicked.
      */
     private void handleTileClick(final String player, final String buttonTag) {
-        Button b = (Button) mBoard.findViewWithTag(buttonTag);
+        Button b = (Button) mLayout.findViewWithTag(buttonTag);
         // Only updates the tile if the current value is empty and the game has not finished yet.
         if (b.getText().toString().equals(getString(R.string.spaceValue)) && checkNotFinished()) {
             b.setText(getTurn(mTurn));

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -2,9 +2,7 @@ package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
 import android.view.KeyEvent;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ImageButton;
@@ -34,18 +32,19 @@ public class SettingsFragment extends BaseFragment {
         super.setArguments(args);
     }
 
-    @Override public View onCreateView(final LayoutInflater layoutInflater,
-                                       final ViewGroup container, final Bundle savedInstanceState) {
-        View main = layoutInflater.inflate(R.layout.fragment_settings, container, false);
-        TextView title = (TextView) main.findViewById(R.id.settings_title);
+    /** Set the layout file. */
+    @Override public int getLayout() {return R.layout.fragment_settings;}
+
+    @Override public void onInitialize() {
+        TextView title = (TextView) mLayout.findViewById(R.id.settings_title);
 
         // Setup the group choice spinner and adapter.
-        Spinner groupChoices = (Spinner) main.findViewById(R.id.settings_group_spinner);
+        Spinner groupChoices = (Spinner) mLayout.findViewById(R.id.settings_group_spinner);
         ArrayAdapter<CharSequence> groupAdapter = ArrayAdapter.createFromResource(getActivity(),
                 R.array.groups, android.R.layout.simple_spinner_item);
         groupAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         groupChoices.setAdapter(groupAdapter);
-        Spinner userChoices = (Spinner) main.findViewById(R.id.settings_user_spinner);
+        Spinner userChoices = (Spinner) mLayout.findViewById(R.id.settings_user_spinner);
 
         getActivity().findViewById(R.id.games_fab).setVisibility(View.GONE);
 
@@ -53,9 +52,9 @@ public class SettingsFragment extends BaseFragment {
         groupChoices.setOnItemSelectedListener(new UserSelector(userChoices));
 
         // Setup the references to the game option buttons.
-        mLocal = (ImageButton) main.findViewById(R.id.settings_local_button);
-        mOnline = (ImageButton) main.findViewById(R.id.settings_online_button);
-        mComputer = (ImageButton) main.findViewById(R.id.settings_computer_button);
+        mLocal = (ImageButton) mLayout.findViewById(R.id.settings_local_button);
+        mOnline = (ImageButton) mLayout.findViewById(R.id.settings_online_button);
+        mComputer = (ImageButton) mLayout.findViewById(R.id.settings_computer_button);
 
         // Handle the game-specific portions of the layout.
         if(game.equals(getString(R.string.new_game_ttt))) {
@@ -68,7 +67,6 @@ public class SettingsFragment extends BaseFragment {
             title.setText(R.string.playing_chess);
             setupChess();
         }
-        return main;
     }
 
     /** Handle the back button after the view has been created. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
@@ -35,52 +35,81 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     // Private class constants.
 
+    /** The lifecycle event format with no bundle. */
+    private static final String FORMAT_NO_BUNDLE = "Activity: %s; Lifecycle event: %s.";
+
+    /** The lifecycle event format with a bundle provided. */
+    private static final String FORMAT_WITH_BUNDLE =
+            "Activity: %s; Lifecycle event: %s; Bundle: %s.";
+
     /** The logcat tag constant. */
     private static final String TAG = BaseActivity.class.getSimpleName();
 
-    // Public instance methods
+    // Protected instance methods.
+
+    /** Log a lifecycle event that has no bundle. */
+    protected void logEvent(final String event) {
+        Log.v(TAG, String.format(Locale.US, FORMAT_NO_BUNDLE, this, event));
+    }
+
+    /** Log a lifecycle event that has a bundle. */
+    protected void logEvent(final String event, final Bundle bundle) {
+        Log.v(TAG, String.format(Locale.US, FORMAT_WITH_BUNDLE, this, event, bundle));
+    }
 
     /** Log the onCreate() state. */
     @Override protected void onCreate(Bundle bundle) {
         super.onCreate(bundle);
-        String format = "Main activity {%s} created with %sempty saved initialization state.";
-        Log.d(TAG, String.format(Locale.US, format, this, bundle == null ? "" : "non-"));
+        logEvent("onCreate", bundle);
     }
 
     /** Log the onDestroy() state. */
     @Override protected void onDestroy() {
         super.onDestroy();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is dying.", this));
+        logEvent("onDestroy");
     }
 
     /** Log the onPause() state. */
     @Override protected void onPause() {
         super.onPause();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is pausing.", this));
+        logEvent("onPause");
     }
 
     /** Log the onRestart() state. */
     @Override protected void onRestart() {
         super.onRestart();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is restarting.", this));
+        logEvent("onRestart");
     }
 
     /** Log the onResume() state. */
     @Override protected void onResume() {
         super.onResume();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is resuming.", this));
+        logEvent("onResume");
+    }
+
+    /** Log the lifecycle event. */
+    @Override protected void onSaveInstanceState(final Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        bundle.putBoolean("savingData", true);
+        logEvent("onSaveInstanceState", bundle);
+    }
+
+    /** Log the lifecycle event. */
+    @Override protected void onRestoreInstanceState(final Bundle bundle) {
+        super.onRestoreInstanceState(bundle);
+        logEvent("onRestoreInstanceState", bundle);
     }
 
     /** Log the onStart() state. */
     @Override protected void onStart() {
         super.onStart();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is starting.", this));
+        logEvent("onStart");
     }
 
     /** Log the onStop() state. */
     @Override protected void onStop() {
         super.onStop();
-        Log.d(TAG, String.format(Locale.US, "Main activity {%s} is stopping.", this));
+        logEvent("onStop");
     }
 
 }


### PR DESCRIPTION
<h1>Rationale:</h1>

When viewing messages in a chat room, backgrounding the app and then bringing the app back to the foreground results in the chat pane showing the groups view.  It turned out that driving the chat pane display based on events was interfering with the fragment manager and causing fits to be had.  This commit changes that approach and leaves well enough alone when it is detected that a resume was taking place.  Similarly, this commit ensures that the app event bus is correctly managed through fragment lifecycle events.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseFragment.java

- BaseFragment: Made abstract ... just because.
- Overhaul the way events get logged to be more efficient and clear.
- FORMAT_NO_BUNDLE, FORMAT_WITH_BUNDLE: New constants to control the logging output.
- mLastChatListTypeShown: New variable revealing the fact that a destroy lifecycle event did not destroy the class.
- mLayout: New convenience variable used by subclasses.
- getLayout(), onInitialize(): New abstract methods.
- onActivityCreated(): A missed lifecycle event that would be logged.
- onCreateView(): Handle this in the base class.
- onPause(): Turn off the app event bus for this fragment.
- initAdView(), logEvent(), setOptionsMenu(), showFutureFeatureMessage(): New methods.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- getLayout(): New method to provide the layout id to the base class.
- onAccountStateChange(): Log the event; detect when to spawn a new groups fragment, otherwise leave well enough alone.
- onInitialize(): New callback (from the base class) to handle initialization for onCreateView() (which is now done in the base class); use the new FAB init method signature;

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- lastTypeShown: New public variable saving the type of the last chat list viewed.
- chainFragment(): Save the type in lastTypeShown.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java

- mFab: Remove per AS advice on leaking by saving a view in an essentially static field.
- mFabId, mFabMenuId: Make private, which they should have been all along.
- mTag: Save the tag associated with the enveloping chat fragment.
- init(): Provide the chat fragment tag to save; build and use the fab on and from the stack frame; use the new dismissMenu() signature.
- dismissMenu(): Provide two variants, one taking a layout view and the other taking a fragment.  The latter gets the layout from the fragment's tag via the main chat fragment.
- setState(): Pass in the fragment to obtain the layout view.
- toggle(): Use a local fab obtained via the newly passed in fragment argument, which is also used to get the view.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/InitialFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- buttonClickHandler(), onResume(): Use the new FabManager interfaces.
- getLayout(): New method to provide the layout it to the base class.
- onInitialize(): New method to handle the fragment initialization.

modified:   app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java

- Summary: enhance and improve the lifecycle event logging.
- FORMAT_NO_BUNDLE, FORMAT_WITH_BUNDLE: New constants controlling the logging formats.
- logEvent(): New methods to handle logging in a canonical fashion.
- onSaveInstanceState(), onRestoreInstanceState: New methods (missed them before).