### PR TITLE
Enhance add groups...

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@ http://www.gnu.org/licenses
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
         <activity
             android:name=".chat.AddGroupActivity"
-            android:label="@string/GroupAddTitle"
+            android:label="@string/AddGroupTitle"
             android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
         <service

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
@@ -27,6 +27,7 @@ import com.google.firebase.database.GenericTypeIndicator;
 import com.google.firebase.database.ValueEventListener;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
+import com.pajato.android.gamechat.chat.adapter.ContactHeaderItem;
 import com.pajato.android.gamechat.chat.adapter.DateHeaderItem;
 import com.pajato.android.gamechat.chat.adapter.DateHeaderItem.DateHeaderType;
 import com.pajato.android.gamechat.chat.adapter.GroupItem;
@@ -53,6 +54,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.pajato.android.gamechat.chat.adapter.ContactHeaderItem.ContactHeaderType.contacts;
+import static com.pajato.android.gamechat.chat.adapter.ContactHeaderItem.ContactHeaderType.frequent;
 import static com.pajato.android.gamechat.chat.adapter.DateHeaderItem.DateHeaderType.old;
 
 /**
@@ -66,7 +69,7 @@ public enum ChatListManager {
 
     /** The chat list type. */
     public enum ChatListType {
-        group, message, room
+        group, message, room, member
     }
 
     // Public class constants.
@@ -117,6 +120,8 @@ public enum ChatListManager {
                 return getMessageListData(item);
             case room:
                 return getRoomListData(item.groupKey);
+            case member:
+                return getMemberListData(item);
             default:
                 // TODO: log a message here.
                 break;
@@ -157,9 +162,25 @@ public enum ChatListManager {
     }
 
     /** Return a list of the members of a given room. */
-    public List<String> getMembers(final String roomKey) {
+    public List<String> getRoomMembers(final String roomKey) {
         Room room = getRoomProfile(roomKey);
         return room.memberIdList;
+    }
+
+    /** Return a set of potential group members. */
+    private List<ChatListItem> getMemberListData(final ChatListItem item) {
+        // Determine if there are any frequent members to add.  If so, add them and then add the
+        // members from the User's device contacts.
+        List<ChatListItem> result = new ArrayList<>();
+        if (item != null) {
+            // TODO: extract the list of frequent members from the item, somehow and add it to the
+            // result.
+            result.add(new ChatListItem(new ContactHeaderItem(frequent)));
+        }
+        result.add(new ChatListItem(new ContactHeaderItem(contacts)));
+        result.addAll(ContactManager.instance.getDeviceContactList());
+
+        return result;
     }
 
     /** Get a map of messages by room in a given group. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ContactManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ContactManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.chat;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.ContactsContract;
+import android.provider.ContactsContract.CommonDataKinds.Email;
+import android.provider.ContactsContract.CommonDataKinds.Phone;
+import android.provider.ContactsContract.CommonDataKinds.Photo;
+import android.provider.ContactsContract.Data;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.pajato.android.gamechat.chat.adapter.ChatListItem;
+import com.pajato.android.gamechat.chat.adapter.ContactItem;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static android.provider.ContactsContract.Contacts.CONTENT_URI;
+import static android.provider.ContactsContract.Contacts.HAS_PHONE_NUMBER;
+import static android.provider.ContactsContract.Contacts.Photo.CONTENT_DIRECTORY;
+
+/**
+ * Provides the interface to the device contact list.
+ *
+ * @author Paul Michael Reilly
+ */
+enum ContactManager {
+    instance;
+
+    // Public enums.
+
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = ContactManager.class.getSimpleName();
+
+    // Private instance variables.
+
+    /** The contact cache, a map associating a name and a chat list item. */
+    private Map<String, ChatListItem> mContactMap = new HashMap<>();
+
+    // Public instance methods.
+
+    /** Return a list of device contacts formatted as chat list items. */
+    public List<ChatListItem> getDeviceContactList() {
+        // Convert each contact to a chat list item.
+        List<ChatListItem> result = new ArrayList<>();
+        for (String name : mContactMap.keySet()) {
+            result.add(mContactMap.get(name));
+        }
+
+        return result;
+    }
+
+    /** Initialize the contacts cache. */
+    public void init(@NonNull final Context context) {
+        // If the cache has data, use it.
+        if (mContactMap.size() > 0) return;
+
+        // Populate the cache.
+        Log.d(TAG, "Starting to populate the contacts cache.");
+        fetch(context);
+        Log.d(TAG, "Finished populating the contacts cache.");
+    }
+
+    // Private instance methods.
+
+    /** ... */
+    public void fetch(Context context) {
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(CONTENT_URI, null, null, null, null);
+        if (cursor == null) return;
+
+        // ...
+        while (cursor.moveToNext()) {
+            // Determine if this row is for a contact not seen yet.
+            String name = cursor.getString(cursor.getColumnIndex(Phone.DISPLAY_NAME));
+            if (!mContactMap.containsKey(name)) {
+                // The contact has not yet been see.  Cache it now, using the first email and/or
+                // phone number encountered.
+                String id = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts._ID));
+                String email = getEmail(resolver, id);
+                String value = cursor.getString(cursor.getColumnIndex(HAS_PHONE_NUMBER));
+                String phone = Integer.parseInt(value) > 0 ? getPhone(resolver, id) : null;
+                String url = getPhotoUrl(resolver, id);
+                if ((email != null && email.length() > 0) || phone != null && phone.length() > 0) {
+                    ChatListItem item = new ChatListItem(new ContactItem(name, email, phone, url));
+                    mContactMap.put(name, item);
+                }
+            }
+        }
+        cursor.close();
+    }
+
+    /** Return the first email from a contact, null if there is no email entries. */
+    private String getEmail(@NonNull final ContentResolver resolver, @NonNull final String id) {
+        // Query the email entries in the contact with the given id.
+        String result = null;
+        String queryText = Email.CONTACT_ID + " = " + id;
+        Cursor emails = resolver.query(Email.CONTENT_URI, null, queryText, null, null);
+        if (emails == null) return null;
+
+        // ...
+        if (emails.moveToNext()) result = emails.getString(emails.getColumnIndex(Email.DATA));
+        emails.close();
+
+        return result;
+    }
+
+    /** Return the first phone number from a contact, null if there are no phone numbers. */
+    private String getPhone(@NonNull final ContentResolver resolver, @NonNull final String id) {
+        // Query the phone entries in the contact with the given id.
+        String result = null;
+        String queryText = Phone.CONTACT_ID + " = ?";
+        String[] queryData = new String[] {id};
+        Cursor cursor = resolver.query(Phone.CONTENT_URI, null, queryText, queryData, null);
+        if (cursor == null) return null;
+
+        // ...
+        if (cursor.moveToNext()) result = cursor.getString(cursor.getColumnIndex(Phone.NUMBER));
+        cursor.close();
+
+        return result;
+    }
+
+    /** Return the contact photo URL, null if no photo URL is available. */
+    private String getPhotoUrl(@NonNull final ContentResolver resolver, @NonNull final String id) {
+        // Query the phone entries in the contact with the given id.
+        String result = null;
+        String queryText = Data.CONTACT_ID + " = " + id + " AND " + Data.MIMETYPE + "='"
+            + Photo.CONTENT_ITEM_TYPE + "'";
+        Cursor cursor = resolver.query(Data.CONTENT_URI, null, queryText, null, null);
+        if (cursor == null) return null;
+
+        // ...
+        if (cursor.moveToNext()) {
+            Uri person = ContentUris.withAppendedId(CONTENT_URI, Long.parseLong(id));
+            result = Uri.withAppendedPath(person, CONTENT_DIRECTORY).toString();
+        }
+        cursor.close();
+
+        return result;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
@@ -205,7 +205,7 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
             String url = account.accountUrl != null ? account.accountUrl : null;
             long tstamp = new Date().getTime();
             String text = editText.getText().toString();
-            List<String> members = ChatListManager.instance.getMembers(mItem.roomKey);
+            List<String> members = ChatListManager.instance.getRoomMembers(mItem.roomKey);
             members.remove(uid);
             int type = STANDARD;
             Message message = new Message(uid, name, url, key, tstamp, tstamp, text, type, members);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
@@ -39,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static com.pajato.android.gamechat.chat.adapter.ChatListItem.CONTACT_HEADER_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.ChatListItem.CONTACT_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.DATE_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.GROUP_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.MESSAGE_ITEM_TYPE;
@@ -72,8 +74,12 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
     /** Manage the recycler view holder thingy. */
     @Override public ViewHolder onCreateViewHolder(final ViewGroup parent, final int entryType) {
         switch (entryType) {
+            case CONTACT_HEADER_ITEM_TYPE:
+                return new HeaderViewHolder(getView(parent, R.layout.item_header));
+            case CONTACT_ITEM_TYPE:
+                return new ContactViewHolder(getView(parent, R.layout.item_contact));
             case DATE_ITEM_TYPE:
-                return new DateHeaderViewHolder(getView(parent, R.layout.item_date_header));
+                return new HeaderViewHolder(getView(parent, R.layout.item_header));
             case GROUP_ITEM_TYPE:
                 return new ChatListViewHolder(getView(parent, R.layout.item_group));
             case ROOM_ITEM_TYPE:
@@ -96,7 +102,7 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
                     // The date header simply updates the section title.
                     int id = item.nameResourceId;
                     String name = holder.itemView.getContext().getResources().getString(id);
-                    ((DateHeaderViewHolder) holder).mTitle.setText(name);
+                    ((HeaderViewHolder) holder).title.setText(name);
                     break;
                 case GROUP_ITEM_TYPE:
                 case MESSAGE_ITEM_TYPE:
@@ -186,16 +192,7 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         }
     }
 
-    // Nested classes.
-
-    /** ... */
-    private class DateHeaderViewHolder extends RecyclerView.ViewHolder {
-        TextView mTitle;
-        DateHeaderViewHolder(View itemView) {
-            super(itemView);
-            mTitle = (TextView) itemView.findViewById(R.id.chatName);
-        }
-    }
+    // Inner classes.
 
     /** ... */
     private class ChatListViewHolder extends RecyclerView.ViewHolder {
@@ -204,12 +201,46 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         TextView text;
         ImageView icon;
 
+        /** ... */
         ChatListViewHolder(View itemView) {
             super(itemView);
             name = (TextView) itemView.findViewById(R.id.chatName);
             count = (TextView) itemView.findViewById(R.id.newCount);
             text = (TextView) itemView.findViewById(R.id.chatText);
             icon = (ImageView) itemView.findViewById(R.id.chatIcon);
+        }
+    }
+
+    /** Provide a class to include a contact header in the list. */
+    private class HeaderViewHolder extends RecyclerView.ViewHolder {
+
+        // Private instance variables.
+
+        /** The text view showing the date or contact header. */
+        TextView title;
+
+        /** ... */
+        HeaderViewHolder(View itemView) {
+            super(itemView);
+            title = (TextView) itemView.findViewById(R.id.header);
+        }
+    }
+
+    /** Provide a class to include a contact header in the list. */
+    private class ContactViewHolder extends RecyclerView.ViewHolder {
+
+        // Private instance variables.
+
+        TextView name;
+        TextView email;
+        ImageView icon;
+
+        /** ... */
+        ContactViewHolder(View itemView) {
+            super(itemView);
+            name = (TextView) itemView.findViewById(R.id.contactName);
+            email = (TextView) itemView.findViewById(R.id.contactEmail);
+            icon = (ImageView) itemView.findViewById(R.id.contactIcon);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
@@ -27,40 +27,63 @@ public class ChatListItem {
 
     // Public constants.
 
-    static final int DATE_ITEM_TYPE = 0;
-    static final int GROUP_ITEM_TYPE= 1;
-    static final int MESSAGE_ITEM_TYPE = 2;
-    static final int ROOM_ITEM_TYPE = 3;
+    static final int CONTACT_HEADER_ITEM_TYPE = 0;
+    static final int CONTACT_ITEM_TYPE = 1;
+    static final int DATE_ITEM_TYPE = 2;
+    static final int GROUP_ITEM_TYPE= 3;
+    static final int MESSAGE_ITEM_TYPE = 4;
+    static final int ROOM_ITEM_TYPE = 5;
 
     // Public enums
 
     // Public instance variables.
 
-    /** The group (push) key. */
+    /** The chat list item count of new messages in a group or a room. */
+    int count;
+
+    /** The item email address, possibly null, used for contact items. */
+    public String email;
+
+    /** The group (push) key, possibly null, used for chat list items (groups, rooms, messages) */
     public String groupKey;
 
-    /** The room (push) key, possibly null. */
-    public String roomKey;
-
-    /** The item type. */
-    public int type;
-
-    /** The URL for the item. */
-    public String url;
-
-    /** The item name, possibly null. */
+    /** The item name, possibly null, used for all items. */
     public String name;
 
     /** The item name resource identifier. */
     int nameResourceId;
 
-    /** The chat list item count of new messages in a group or a room. */
-    int count;
+    /** The item phone number, possibly null, used for contact items. */
+    public String phone;
+
+    /** The room (push) key, possibly null, used for chat list items. */
+    public String roomKey;
+
+    /** The item type, always non-null. */
+    public int type;
+
+    /** The URL for the item, possibly null, used for icons with contacts and chat list items. */
+    public String url;
 
     /** The list of rooms or groups with messages to show, or the text of a message. */
     public String text;
 
     // Public constructors.
+
+    /** Build an instance for a given contact header item. */
+    public ChatListItem(final ContactHeaderItem item) {
+        type = CONTACT_HEADER_ITEM_TYPE;
+        nameResourceId = item.getNameResourceId();
+    }
+
+    /** Build an instance for a given contact list item. */
+    public ChatListItem(final ContactItem item) {
+        type = CONTACT_ITEM_TYPE;
+        name = item.name;
+        email = item.email;
+        phone = item.phone;
+        url = item.url;
+    }
 
     /** Build an instance for a given group list item. */
     public ChatListItem(final GroupItem item) {
@@ -97,7 +120,5 @@ public class ChatListItem {
         count = item.count;
         text = item.text;
     }
-
-    // Public instance methods.
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactHeaderItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactHeaderItem.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.chat.adapter;
+
+import com.pajato.android.gamechat.R;
+
+/**
+ * Provide a POJO to encapsulate a recycler view list item: either a date label view or a room list
+ * view showing the rooms in a group with messages characterized by a preceding date label view.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ContactHeaderItem {
+
+    // Public enums
+
+    /** Provide an enumeration of the types of views presented in a rooms list. */
+    public enum ContactHeaderType {
+        frequent (R.string.frequent),
+        contacts (R.string.contacts);
+
+        private int mResourceId;
+
+        ContactHeaderType(final int id) {
+            mResourceId = id;
+        }
+
+        public int getNameResourceId() {return mResourceId;}
+    }
+
+    // Private instance variables.
+
+    /** The item type. */
+    private ContactHeaderType mType;
+
+    // Public constructors.
+
+    /** Build an instance for a given date entry. */
+    public ContactHeaderItem(final ContactHeaderType type) {
+        mType = type;
+    }
+
+    // Public instance methods.
+
+    int getNameResourceId() {return mType.getNameResourceId();}
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactItem.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.chat.adapter;
+
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.pajato.android.gamechat.account.AccountManager;
+import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.database.DatabaseManager;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Provide a POJO to encapsulate a contact item to be added to a recycler view.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ContactItem {
+
+    // Private class constants.
+
+    // Public instance variables.
+
+    /** The email address, possibly null. */
+    public String email;
+
+    /** The phone number, possibly null. */
+    public String phone;
+
+    /** The contact's icon URL, possibly null. */
+    String url;
+
+    /** The contact's display name. */
+    public String name;
+
+    // Public constructors.
+
+    /** Build an instance for the given group. */
+    public ContactItem(final String name, final String email, final String phone, final String url) {
+        // Update the group and room keys, the message text and url fields, and set the count to 0
+        // to flag that it is not relevant for a message item.  Set the name field to the poster's
+        // display name concatenated with the creation date.
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.url = url;
+    }
+
+}

--- a/app/src/main/res/layout/activity_group_add.xml
+++ b/app/src/main/res/layout/activity_group_add.xml
@@ -43,22 +43,49 @@ http://www.gnu.org/licenses
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="bottom"
-        android:layout_marginStart="16dp">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:labelFor="@+id/groupNameText"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:text="@string/GroupAddLabelText"/>
+        android:orientation="horizontal"
+        android:background="@color/colorPrimaryDark">
+        <ImageButton
+            android:id="@+id/setGroupIcon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="16dp"
+            android:onClick="onClick"
+            android:background="@color/colorLightGray"
+            android:contentDescription="@string/SetGroupIconDesc"
+            android:src="@drawable/ic_group_black_24dp" />
         <EditText
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
+            android:layout_weight="1.0"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:background="@android:color/transparent"
             android:id="@+id/groupNameText"
+            android:textColor="@color/white"
             android:textSize="18sp"
             android:textStyle="normal"
-            android:hint="@string/GroupAddHintText"/>
+            android:textColorHint="@color/white"
+            android:hint="@string/AddGroupNameHint"
+            tools:text="Paul Michael Reilly Group"/>
+        <ImageButton
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:id="@+id/clearGroupName"
+            android:onClick="onClick"
+            android:background="@color/colorLightGray"
+            android:contentDescription="@string/AddGroupDesc"
+            android:src="@drawable/ic_clear_black_24dp"/>
     </LinearLayout>
+    <TextView
+        android:id="@+id/addGroupMembers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="36dp"
+        android:layout_gravity="center"
+        android:onClick="onClick"
+        android:textColor="@color/colorBlue"
+        android:textSize="16sp"
+        android:textStyle="normal"
+        android:text="@string/AddGroupMembers"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -48,7 +48,7 @@ http://www.gnu.org/licenses
                 android:text="@string/JoinRoom" />
             <ImageView
                 style="@style/FabMenuIcon"
-                android:contentDescription="@string/JoinRoomDescription"
+                android:contentDescription="@string/JoinRoomDesc"
                 android:src="@drawable/ic_casino_black_24dp" />
         </LinearLayout>
         <LinearLayout
@@ -60,7 +60,7 @@ http://www.gnu.org/licenses
                 android:text="@string/AddRoom" />
             <ImageView
                 style="@style/FabMenuIcon"
-                android:contentDescription="@string/AddRoomDescription"
+                android:contentDescription="@string/AddRoomDesc"
                 android:src="@drawable/ic_casino_black_24dp" />
         </LinearLayout>
         <LinearLayout
@@ -69,10 +69,10 @@ http://www.gnu.org/licenses
             <Button
                 style="@style/FabMenuButton"
                 android:id="@+id/addGroupButton"
-                android:text="@string/AddGroup" />
+                android:text="@string/AddGroupTitle" />
             <ImageView
                 style="@style/FabMenuIcon"
-                android:contentDescription="@string/AddGroupDescription"
+                android:contentDescription="@string/AddGroupDesc"
                 android:src="@drawable/ic_group_add_black_24dp" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_contact.xml
+++ b/app/src/main/res/layout/item_contact.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/ChatMessageTheme"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="1dp"
+    android:layout_marginBottom="1dp"
+    android:orientation="horizontal">
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/contactIcon"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="4dp"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_account_circle_black_36dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:gravity="center_vertical"
+        android:orientation="vertical">
+        <TextView
+            android:id="@+id/contactName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            tools:text="A simple sample message that extends over two lines..."/>
+        <TextView
+            android:id="@+id/contactEmail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -17,12 +17,11 @@ http://www.gnu.org/licenses
 
 Sign in icon (Login Rounded Right) courtesy of: https://icons8.com
 -->
-<LinearLayout
+<LinearLayout style="@style/DateHeaderTheme"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    style="@style/DateHeaderTheme">
+    xmlns:tools="http://schemas.android.com/tools">
     <TextView
-        android:id="@+id/chatName"
+        android:id="@+id/header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"
@@ -31,5 +30,5 @@ Sign in icon (Login Rounded Right) courtesy of: https://icons8.com
         android:textAlignment="center"
         android:textSize="20sp"
         android:textStyle="bold"
-        tools:text="Now"/>
- </LinearLayout>
+        tools:text="Header Title"/>
+</LinearLayout>

--- a/app/src/main/res/menu/add_group_menu.xml
+++ b/app/src/main/res/menu/add_group_menu.xml
@@ -1,13 +1,18 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/add_group_learn_more"
+        android:id="@+id/addGroupLearnMore"
         android:title="@string/menuItemTitleLearnMore"
         app:showAsAction="never"
         android:orderInCategory="0"/>
     <item
-        android:id="@+id/add_group_feedback"
+        android:id="@+id/addGroupFeedback"
         android:title="@string/menuItemTitleFeedback"
         app:showAsAction="never"
-        android:orderInCategory="97" />
+        android:orderInCategory="55" />
+    <item
+        android:id="@+id/addGroupInstallUsers"
+        android:title="@string/InstallDebugUsers"
+        app:showAsAction="never"
+        android:orderInCategory="100" />
 </menu>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -1,13 +1,13 @@
 <resources>
-    <string name="AddGroup">Add Group</string>
-    <string name="AddGroupDescription">Add Group menu button</string>
+    <string name="AddGroupTitle">Add Group</string>
+    <string name="AddGroupDesc">Add Group menu button</string>
+    <string name="AddGroupMembers">Invite group members</string>
+    <string name="AddGroupNameHint">Type group name</string>Title">
     <string name="AddRoom">Add Room</string>
-    <string name="AddRoomDescription">Add Room menu button</string>
+    <string name="AddRoomDesc">Add Room menu button</string>
     <string name="ChatTitle">Chat</string>
     <string name="FutureFeature">is a future feature.  Volunteer by sending feedback using the overflow menu.</string>
-    <string name="GroupAddHintText">Enter group name</string>
-    <string name="GroupAddLabelText">Name:</string>
-    <string name="GroupAddTitle">Add Group</string>
+    <string name="Group">Group</string>
     <string name="GroupListIcon">The group icon.</string>
     <string name="InsertEmoticon">Inserting an emoticon</string>
     <string name="InsertEmoticonDesc">Insert emoticon image button.</string>
@@ -15,17 +15,22 @@
     <string name="InsertMapDesc">Inser map image button.</string>
     <string name="InsertPhoto">Inserting a photo from your device</string>
     <string name="InsertPhotoDesc">Insert photo from file image button.</string>
+    <string name="InstallDebugUsers">Install developer users</string>
+    <string name="InviteGroupMembersFeature">Inviting group members</string>
     <string name="JoinRoom">Join Room</string>
-    <string name="JoinRoomDescription">Join Room menu button</string>
-    <string name="NoAccountMessageText">
-You are signed out.  GameChat is much more fun when you can interact with your family and friends.  Meanwhile play games by your self to enjoy your alone time.
-    </string>
+    <string name="JoinRoomDesc">Join Room menu button</string>
+    <string name="LearnMoreFeature">Providing context help</string>
+    <string name="NoAccountMessageText">You are signed out.  GameChat is much more fun when you can interact with your family and friends.  Meanwhile play games by your self to enjoy your alone time.</string>
     <string name="NoRoomsMessageText">You must join a room to see messages.</string>
     <string name="RoomListIcon">The room list icon.</string>
+    <string name="SetAddGroupIconFeature">Setting the add group icon</string>
+    <string name="SetGroupIconDesc">Set the group icon</string>
     <string name="TakePicture">Inserting a picture using your camera</string>
     <string name="TakePictureDesc">Take a camera picture image button.</string>
     <string name="TakeVideo">Inserting a video from your camera</string>
     <string name="TakeVideoDesc">Take a video image button.</string>
     <string name="backItemTitleText">Back</string>
+    <string name="contacts">Contacts</string>
     <string name="editMessageHint">Type a message</string>
+    <string name="frequent">Frequent</string>
 </resources>


### PR DESCRIPTION
<h1>Rationale:</h1>

While working on getting live, multi-player games working with Firebase it was painfully obvious that real groups needed to exist with mulitple members having access to these groups.  That meant enhancing the add group activity to allow multiple Users to be set up easily via a temporary hack.  The real code will be part of inviting Users to a group, a feature in progress.

<h1>File changes:</h1>

modified:   app/src/main/AndroidManifest.xml

- Use the RNF naming conventions (for consistency, so code is easier to grok and maintain) in accessing localized strings.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- buttonClickHandler(): Add support for clearing the forming group name, inviting group members and changing the group icon.
- onOptionsItemSelected(): Add support for "Learn More", "Send Feedback" and installing developers (a temporary hack to facilitate getting to alpha).
- addGroupInstallUsers(): Temporary hack to facilitate inviting developers to the group.
- clearGroupName(): Reset the forming group name to the empty string.
- createMessage(), getName(): Move per RNF.
- getDefaltAccountName(), getEmailName(): New methods supporting a default group name.
- init(): Rewrite.
- processGroup(): Ensure that the owner account id is included in the group member id list.
- sendFeedbackEmail(): Implement proving feedback for the add group activity.
- showFutureFeatureMessage(): New method to solicit help.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java

- ChatListType: Add new value, member, to support contact list items.
- getList(): Add support for contact list items.
- getMemberListData(): New method supporting contact list items.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java

- postMessage(): Use the renamed getRoomMembers() method.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

- onCreateViewHolder(): Use the new HeaderViewHolder class for both date and contact headers.
- DateHeaderViewHolder: Rename to HeaderViewHolder.
- ContactViewHolder: Provide support for listing contacts.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java

- CONTACT_ITEM_TYPE, CONTACT_HEADER_ITEM_TYPE: New constants support contact list items.
- Apply RNF, moving methods, constants and variables as necessary; also enhance comments.
- ChatListItem(): New constructors to support contact list items.

modified:   app/src/main/res/layout/activity_group_add.xml

- Overhaul the layout to be more "Hangout" like.

modified:   app/src/main/res/layout/fragment_chat.xml
modified:   app/src/main/res/values/strings_chat.xml

- Summary: Apply RNF and add a few items.

modified:   app/src/main/res/menu/add_group_menu.xml

- Add support installing developers into a group.

renamed:    app/src/main/res/layout/item_date_header.xml -> app/src/main/res/layout/item_header.xml

- Use a single header to cover both dates and contacts.

new file:   app/src/main/java/com/pajato/android/gamechat/chat/ContactManager.java
new file:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactHeaderItem.java
new file:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ContactItem.java
new file:   app/src/main/res/layout/item_contact.xml

- New files supporting the potential use of contact based lists.