### PR TITLE
Consolidate database operations.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/Account.java
@@ -32,38 +32,54 @@ import java.util.Map;
  */
 @IgnoreExtraProperties public class Account {
 
+    // Public constants
+
+    /** The account types. */
+    public final static int STANDARD = 1;
+    public final static int PROTECTED = 2;
+
     // Public instance variables
 
-    /** The account id, the backend push key. */
-    public String accountId;
-
-    /** The account email. */
-    public String accountEmail;
-
-    /** The account icon, a URL. */
-    public String accountUrl;
+    /** The account creation timestamp. */
+    public long createTime;
 
     /** The account display name, usually something like "Fred C. Jones". */
     public String displayName;
 
-    /** The account token, an access key supplied by the provider. */
-    public String token;
-
-    /** The account provider id, a string like "google.com". */
-    String providerId;
+    /** The account email. */
+    public String email;
 
     /** A list of group ids the account can access. */
     public List<String> groupIdList = new ArrayList<>();
 
+    /** The account id, the backend push key. */
+    public String id;
+
     /** The list of joined rooms providing the group and room push keys. */
     public List<String> joinedRoomList = new ArrayList<>();
+
+    /** The modification timestamp. */
+    public long modTime;
+
+    /** The account provider id, a string like "google.com". */
+    public String providerId;
+
+    /** The account token, an access key supplied by the provider. */
+    public String token;
+
+    /** The account type. */
+    public int type;
+
+    /** The account icon, a URL. */
+    public String url;
 
     // Public instance methods.
 
     /** Get a non-null display name using "Anonymous" if need be. */
     public String getDisplayName(final Account current, final String me, final String anonymous) {
-        // Determine if the given account is this account and return the me value if it has been provided.
-        if (current != null && current.accountId.equals(accountId) && me != null) return me;
+        // Determine if the given account is this account and return the me value if it has been
+        // provided.
+        if (current != null && current.id.equals(id) && me != null) return me;
 
         // Determine if this account has a display name or should use the given default.
         if (displayName == null && anonymous != null) return anonymous;
@@ -75,14 +91,17 @@ import java.util.Map;
     /** Generate the map of data to persist into Firebase. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
-        result.put("accountId", accountId);
-        result.put("accountEmail", accountEmail);
-        result.put("accountUrl", accountUrl);
+        result.put("createTime", createTime);
         result.put("displayName", displayName);
-        result.put("token", token);
-        result.put("providerId", providerId);
+        result.put("email", email);
         result.put("groupIdList", groupIdList);
+        result.put("id", id);
         result.put("joinedRoomList", joinedRoomList);
+        result.put("modTime", modTime);
+        result.put("providerId", providerId);
+        result.put("token", token);
+        result.put("type", type);
+        result.put("url", url);
 
         return result;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
@@ -74,24 +74,6 @@ public enum ChatListManager {
 
     // Public class constants.
 
-    /** The format used to generate the database path for the message list. */
-    public static final String MESSAGES_FORMAT = "/groups/%s/rooms/%s/messages/";
-
-    /** The format used to generate the database path for a particular message. */
-    public static final String UNREAD_LIST_FORMAT = MESSAGES_FORMAT + "%s/unreadList";
-
-    // Message type constants.
-    public static final int STANDARD = 0;
-    public static final int SYSTEM = 1;
-
-    // Private class constants.
-
-    /** The format specifying the path to the rooms profile on Firebase. */
-    private static final String GROUP_PROFILE_PATH = "/groups/%s/profile/";
-
-    /** The format specifying the path to the rooms profile on Firebase. */
-    private static final String ROOMS_PROFILE_PATH = "/groups/%s/rooms/%s/profile/";
-
     // Private instance variables.
 
     /** A map associating date header type values with lists of group push keys. */
@@ -204,8 +186,8 @@ public enum ChatListManager {
         // Register an active rooms change handler on the account, if there is an account,
         // preferring a cached handler, if one is available.
         if (event.account != null) {
-            // There is an active account.  Register it.
-            String path = String.format("/accounts/%s/joinedRoomList", event.account.accountId);
+            // There is an active account.  Register a joined room list change handler.
+            String path = DatabaseManager.instance.getJoinedRoomListPath(event.account);
             String name = "joinedRoomListChangeHandler";
             DatabaseEventHandler handler = DatabaseManager.instance.getHandler(name);
             if (handler == null) handler = new JoinedRoomListChangeHandler(name, path);
@@ -234,7 +216,7 @@ public enum ChatListManager {
             String[] split = entry.split(" ");
             String groupKey = split[0];
             String roomKey = split[1];
-            String path = String.format(Locale.US, GROUP_PROFILE_PATH, groupKey);
+            String path = DatabaseManager.instance.getGroupProfilePath(groupKey);
             String name = "profileChangeHandler" + groupKey;
             DatabaseEventHandler handler = DatabaseManager.instance.getHandler(name);
             if (handler == null) handler = new ProfileGroupChangeHandler(name, path, groupKey);
@@ -242,7 +224,7 @@ public enum ChatListManager {
 
             // Kick off a value event listener for the room profile.  Tag each listener with the
             // room key to ensure only one listener per room is ever active at any one time.
-            path = String.format(Locale.US, ROOMS_PROFILE_PATH, groupKey, roomKey);
+            path = DatabaseManager.instance.getRoomProfilePath(groupKey, roomKey);
             name = "profileChangeHandler" + roomKey;
             handler = new ProfileRoomChangeHandler(name, path, roomKey);
             DatabaseManager.instance.registerHandler(handler);
@@ -458,8 +440,7 @@ public enum ChatListManager {
 
         /** Build a handler with the given name and path. */
         MessagesChangeHandler(final String name, final String groupKey, final String roomKey) {
-            super(name, String.format(Locale.US, MESSSAGES_FORMAT, groupKey,
-                    roomKey));
+            super(name, String.format(Locale.US, MESSSAGES_FORMAT, groupKey, roomKey));
             mGroupKey = groupKey;
             mRoomKey = roomKey;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.chat.adapter;
 
-import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.database.DatabaseManager;
@@ -26,12 +24,8 @@ import com.pajato.android.gamechat.database.DatabaseManager;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-
-import static com.pajato.android.gamechat.chat.ChatListManager.UNREAD_LIST_FORMAT;
 
 /**
  * Provide a POJO to encapsulate a message item to be added to a recycler view.
@@ -79,15 +73,10 @@ public class MessageItem {
         String accountId = AccountManager.instance.getCurrentAccountId();
         List<String> unreadList = message.unreadList;
         if (unreadList != null && unreadList.contains(accountId)) {
-            // The message is still marked new.  Change it to "seen" by removing the key and
-            // persisting the message.
+            // The message is still marked new.  Change it to "seen" by removing this User from the
+            // list of Users who have not yet read the message and persist it.
             unreadList.remove(accountId);
-            DatabaseReference database = FirebaseDatabase.getInstance().getReference();
-            String key = message.messageKey;
-            String path = String.format(Locale.US, UNREAD_LIST_FORMAT, groupKey, roomKey, key);
-            Map<String, Object> unreadMap = new HashMap<>();
-            unreadMap.put("unreadList", unreadList);
-            DatabaseManager.instance.updateChildren(database, path, unreadMap);
+            DatabaseManager.instance.updateUnreadList(groupKey, roomKey, message);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -27,6 +27,13 @@ import java.util.Map;
 /** Provide a Firebase model class repesenting a chat message, an icon, a name and text. */
 @IgnoreExtraProperties public class Message {
 
+    // Public class constants.
+
+    /** The message types. */
+    public final static int SYSTEM = 0;
+    public final static int STANDARD = 1;
+    public final static int PROTECTED = 2;
+
     /** The member account identifer who posted the message. */
     public String owner;
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
@@ -17,16 +17,30 @@
 
 package com.pajato.android.gamechat.database;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ValueEventListener;
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.account.Account;
+import com.pajato.android.gamechat.account.AccountManager;
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.chat.model.Room;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
 
 /**
  * Provide a fragment to handle the display of the rooms available to the current user.
@@ -38,19 +52,171 @@ public enum DatabaseManager {
 
     // Private class constants.
 
+    /** The path to the account node on the database. */
+    private static final String ACCOUNT_FORMAT = "/accounts/%s/";
+
+    /** The lookup key for the localized "anonymous" name. */
+    private static final String ANONYMOUS_NAME_KEY = "anonymousNameKey";
+
+    /** The path to the groups node on the database. */
+    private static final String GROUPS_PATH = "/groups/";
+
+    /** The path format for a group profile. */
+    private static final String GROUP_PROFILE_FORMAT = GROUPS_PATH + "%s/profile/";
+
+    /** The path format for detecting changes to the joined room list. */
+    private static final String JOINED_ROOM_LIST_FORMAT = ACCOUNT_FORMAT + "joinedRoomList";
+
+    /** The path format for the rooms node within a group. */
+    private static final String ROOMS_FORMAT = GROUPS_PATH + "%s/rooms/";
+
+    /** The path format for the profile node within a room. */
+    private static final String ROOM_PROFILE_FORMAT = ROOMS_FORMAT + "%s/profile/";
+
+    /** The path format for a message. */
+    private static final String MESSAGES_FORMAT = ROOMS_FORMAT + "%s/messages/";
+
+    /** The path format for a message. */
+    private static final String MESSAGE_FORMAT = MESSAGES_FORMAT + "%s/";
+
+    /** The default group name (the "me" group) key. */
+    private static final String ME_GROUP_KEY = "meGroupKey";
+
+    /** The lookup key for the localized "me" name. */
+    private static final String ME_NAME_KEY = "meNameKey";
+
+    /** The default room name (the "me" room) key. */
+    private static final String ME_ROOM_KEY = "meRoomKey";
+
+    /** The format used to generate the database path for a particular message. */
+    private static final String UNREAD_LIST_FORMAT = MESSAGES_FORMAT + "%s/unreadList";
+
+    /** The default system name (GameChat) key. */
+    private static final String SYSTEM_NAME_KEY = "systemNameKey";
+
     /** The logcat tag. */
     private static final String TAG = DatabaseManager.class.getSimpleName();
 
     // Public instance variables.
+
+    /** The database reference object. */
+    private DatabaseReference mDatabase = FirebaseDatabase.getInstance().getReference();
+
+    /** The map providing localized resources. */
+    private Map<String, String> mResourceMap = new HashMap<>();
 
     /** The Firebase value event listener map. */
     private Map<String, DatabaseEventHandler> mHandlerMap = new HashMap<>();
 
     // Public instance methods.
 
+    /** Create and persist an account to the database. */
+    public void createAccount(@NonNull FirebaseUser user, final int accountType) {
+        // Set up the push keys for the account, default "me" group and room.
+        String groupKey = mDatabase.child(GROUPS_PATH).push().getKey();
+        String path = String.format(Locale.US, ROOMS_FORMAT, groupKey);
+        String roomKey = mDatabase.child(path).push().getKey();
+
+        // Set up and persist the account for the given user.
+        long tstamp = new Date().getTime();
+        Account account = new Account();
+        account.id = user.getUid();
+        account.email = user.getEmail();
+        account.displayName = user.getDisplayName();
+        account.url = AccountManager.instance.getPhotoUrl(user);
+        account.providerId = user.getProviderId();
+        account.type = accountType;
+        account.createTime = tstamp;
+        account.groupIdList.add(groupKey);
+        account.joinedRoomList.add(groupKey + " " + roomKey);
+        updateChildren(String.format(Locale.US, ACCOUNT_FORMAT, account.id), account.toMap());
+
+        // Update the group profile on the database.
+        List<String> memberList = new ArrayList<>();
+        memberList.add(account.id);
+        String name = mResourceMap.get(ME_GROUP_KEY);
+        Group group = new Group(account.id, name, tstamp, 0, memberList);
+        updateChildren(String.format(Locale.US, GROUP_PROFILE_FORMAT, groupKey), group.toMap());
+
+        // Update the "me" room profile on the database.
+        name = mResourceMap.get(ME_ROOM_KEY);
+        Room room = new Room(account.id, name, groupKey, tstamp, 0, "me", memberList);
+        String roomProfilePath = String.format(Locale.US, ROOM_PROFILE_FORMAT, groupKey, roomKey);
+        updateChildren(roomProfilePath, room.toMap());
+
+        // Update the "me" room default message on the database.
+        String text = "Welcome to your own private group and room.  Enjoy!";
+        createMessage(text, SYSTEM, account, groupKey, roomKey, room);
+    }
+
+    /** Return a group push key resulting from persisting the given group on the database. */
+    public String createGroupProfile(final Group group) {
+        DatabaseReference database = FirebaseDatabase.getInstance().getReference();
+        String groupKey = database.child(GROUPS_PATH).push().getKey();
+        String profilePath = String.format(Locale.US, GROUP_PROFILE_FORMAT, groupKey);
+        updateChildren(profilePath, group.toMap());
+
+        return groupKey;
+    }
+
+    /** Persist a standard message (one sent from a standard user) to the database. */
+    public void createMessage(final String text, final int type, @NonNull final Account account,
+                              final String groupKey, final String roomKey, final Room room) {
+        String path = String.format(Locale.US, MESSAGES_FORMAT, groupKey, roomKey);
+        String key = mDatabase.child(path).push().getKey();
+        String id = account.id;
+        String name = getName(type, account);
+        String url = getPhotoUrl(type, account);
+        long tstamp = new Date().getTime();
+        List<String> members = room.memberIdList;
+        Message message = new Message(id, name, url, key, tstamp, 0, text, type, members);
+        path = String.format(Locale.US, MESSAGE_FORMAT, groupKey, roomKey, key);
+        updateChildren(path, message.toMap());
+    }
+
+    /** Return a room push key resulting from persisting the given room on the database. */
+    public String createRoomProfile(final String groupKey, final Room room) {
+        String roomsPath = String.format(Locale.US, ROOMS_FORMAT, groupKey);
+        String roomKey = mDatabase.child(roomsPath).push().getKey();
+        String profilePath = String.format(Locale.US, ROOM_PROFILE_FORMAT, groupKey, roomKey);
+        updateChildren(profilePath, room.toMap());
+
+        return roomKey;
+    }
+
+    /** Return the database path to the given group's profile. */
+    public String getGroupProfilePath(final String groupKey) {
+        return String.format(Locale.US, GROUP_PROFILE_FORMAT, groupKey);
+    }
+
+    /** Return the database path to the joined list in a given account. */
+    public String getJoinedRoomListPath(final Account account) {
+        return String.format(Locale.US, JOINED_ROOM_LIST_FORMAT, account.id);
+    }
+
+    /** Return the database path to the given group's profile. */
+    public String getRoomProfilePath(final String groupKey, final String roomKey) {
+        return String.format(Locale.US, ROOM_PROFILE_FORMAT, groupKey, roomKey);
+    }
+
     /** Return a handler registered with the given name, null if one is not found. */
     public DatabaseEventHandler getHandler(final String name) {
         return mHandlerMap.get(name);
+    }
+
+    /** Intialize the database manager by setting up localized resources. */
+    public void init(final Context context) {
+        mResourceMap.clear();
+        mResourceMap.put(ME_GROUP_KEY, context.getString(R.string.DefaultPrivateGroupName));
+        mResourceMap.put(ME_ROOM_KEY, context.getString(R.string.DefaultPrivateRoomName));
+        mResourceMap.put(SYSTEM_NAME_KEY, context.getString(R.string.app_name));
+        mResourceMap.put(ANONYMOUS_NAME_KEY, context.getString(R.string.anonymous));
+        mResourceMap.put(ME_NAME_KEY, context.getString(R.string.me));
+    }
+
+    /** Return TRUE iff the a handler with the given name is registered. */
+    public boolean isRegistered(String name) {
+        return mHandlerMap.containsKey(name);
     }
 
     /** Register a given value event listener. */
@@ -99,23 +265,49 @@ public enum DatabaseManager {
         }
     }
 
-    /** Store an object on the database using a given path, pushKey, and properties. */
-    public void updateChildren(final DatabaseReference database, final String path,
-                               final String pushKey, final Map<String, Object> properties) {
-        Map<String, Object> childUpdates = new HashMap<>();
-        childUpdates.put(path + pushKey, properties);
-        database.updateChildren(childUpdates);
+    /** Update the given account on the database. */
+    public void updateAccount(final Account account) {
+        String path = String.format(Locale.US, ACCOUNT_FORMAT, account.id);
+        account.modTime = new Date().getTime();
+        updateChildren(path, account.toMap());
     }
 
     /** Store an object on the database using a given path, pushKey, and properties. */
-    public void updateChildren(final DatabaseReference database, final String path,
-                               final Map<String, Object> properties) {
+    public void updateChildren(final String path, final Map<String, Object> properties) {
         Map<String, Object> childUpdates = new HashMap<>();
         childUpdates.put(path, properties);
-        database.updateChildren(childUpdates);
+        mDatabase.updateChildren(childUpdates);
+    }
+
+    /** Persist the given message to reflect a change to the unread list. */
+    public void updateUnreadList(final String groupKey, final String roomKey,
+                                 final Message message) {
+        String key = message.messageKey;
+        String path = String.format(Locale.US, UNREAD_LIST_FORMAT, groupKey, roomKey, key);
+        Map<String, Object> unreadMap = new HashMap<>();
+        unreadMap.put("unreadList", message.unreadList);
+        DatabaseManager.instance.updateChildren(path, unreadMap);
     }
 
     // Private instance methods.
+
+    /** Return the message display name for a given type and account. */
+    private String getName(final int type, final Account account) {
+        // If the type is system, return the localized system name.
+        if (type == SYSTEM) return mResourceMap.get(SYSTEM_NAME_KEY);
+
+        // Return the localized dislay name.
+        String me = mResourceMap.get(ME_NAME_KEY);
+        String anonymous = mResourceMap.get(ANONYMOUS_NAME_KEY);
+        return account.getDisplayName(account, me, anonymous);
+    }
+
+    /** Return the message photo url (possibly null) for a given type and account. */
+    private String getPhotoUrl(final int type, final Account account) {
+        String systemUrl = "android.resource://com.pajato.android.gamechat/drawable/ic_launcher";
+        if (type == SYSTEM) return systemUrl;
+        return account.url;
+    }
 
     /** Remove the database event listener, if any is found associated with the given handler. */
     private void removeEventListener(final DatabaseReference database,
@@ -140,7 +332,4 @@ public enum DatabaseManager {
         }
     }
 
-    public boolean isRegistered(String name) {
-        return mHandlerMap.containsKey(name);
-    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -232,6 +232,7 @@ public class MainActivity extends BaseActivity
         ProgressManager.instance.show(this);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        DatabaseManager.instance.init(this);
         NavigationManager.instance.init(this, toolbar);
         PaneManager.instance.init(this);
         AccountManager.instance.init();

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -81,7 +81,7 @@ public enum NavigationManager {
         loadAccountIcon(account, header);
         setDisplayName(account, header);
         TextView email = (TextView) header.findViewById(R.id.currentAccountEmail);
-        email.setText(account.accountEmail);
+        email.setText(account.email);
     }
 
     /** Set up the navigation header to show the sign in button. */
@@ -156,12 +156,12 @@ public enum NavigationManager {
     private void loadAccountIcon(final Account account, final View header) {
         // Determine if there is an image to be loaded.
         ImageView icon = (ImageView) header.findViewById(R.id.currentAccountIcon);
-        Uri imageUri = Uri.parse(account.accountUrl);
+        Uri imageUri = Uri.parse(account.url);
         if (imageUri != null) {
             // There is an image to load.  Use Glide to do the heavy lifting.
             icon.setImageURI(imageUri);
             Glide.with(header.getContext())
-                .load(account.accountUrl)
+                .load(account.url)
                 .transform(new CircleTransform(header.getContext()))
                 .into(icon);
         } else {
@@ -179,7 +179,7 @@ public enum NavigationManager {
         if (name == null) {
             // There is no display name, use a conjured name based on the email address, i.e. the
             // username part of the email address with an initial cap.
-            name = account.accountEmail;
+            name = account.email;
             int index = name.indexOf('@');
             name = name.substring(0, index);
             name = Character.toUpperCase(name.charAt(0)) + name.substring(1);

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -6,6 +6,9 @@
     <string name="AddRoom">Add Room</string>
     <string name="AddRoomDesc">Add Room menu button</string>
     <string name="ChatTitle">Chat</string>
+    <string name="DefaultRoomName">Common</string>
+    <string name="DefaultPrivateGroupName">Me Group</string>
+    <string name="DefaultPrivateRoomName">Me Room</string>
     <string name="FutureFeature">is a future feature.  Volunteer by sending feedback using the overflow menu.</string>
     <string name="Group">Group</string>
     <string name="GroupListIcon">The group icon.</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit centralizes the database operations into the database manager thus avoiding the risk of making a change in one class but missing it in another, something increasingly likely now that the database is achieving substance.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/Account.java

- Summary: add fields, rename fields, doc changes and apply RNF.
- STANDARD, PROTECTED: New public class constants defining the possible account types.
- accountId, accountEmail, accountUrl: Renamed to id, email, url respectively.
- type, createTime, modTime: New fields.
- getDisplayNmae(): Enhance the documentation.

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- Summary: apply RNF, consolidate database operations, use shortened account field names.
- AccountChangeHandler#onDataChange(): Use the database manager to create an account.
- createAccount(): Moved to the database manager.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- Summary: apply RNF, remove group invite hack, handle message creation in the database manager, use shortened account field names, greatly simplify processGroup().
- MESSAGES_FORMAT: Removed (now obtained from the database manager).
- onOptionsItemSelected(), addGroupInstallUsers(): Remove install users hack.
- onCreate(): Move the group initialization to init().
- createMessage(): Move to database manager.
- init(): Initialize the group with a creation timestamp; handle the edit text default name setting in initToolbar();
- initToolbar(): Set the default group name.
- processGroup(): Simplify significantly by moving code to the database manager.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java

- MESSAGES_FORMAT, UNREAD_LIST_FORMAT, GROUP_PROFILE_PATH, ROOMS_PROFIlE_PATH: Move these to the database manager.
- STANDARD, SYSTEM: Move these to the Message model class.
- onAccountStateChange(), onJoinedRoomsChange(): Use the database manager to get paths.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java

- Summary: apply RNF, remove stale code,
- getFragmentLayout(): Removed since it is no longer used.
- postMessage(): Obtain the paths from the database manager, provide a snackbar on a software failure, use the database manager to create and persist the message, provide a message sent affirmation snackbar.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java

- MessageItem(): Use the database manager to deal with the clearing of the "unseen" flag.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java

- SYSTEM, STANDARD, PROTECTED: Declare message type constants.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- Summary: extensive changes to consolidate database operations, a complete overhaul for all intents and purposes.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- init(): Initialize the database manager.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- Summary: use shortened account field names.

modified:   app/src/main/res/values/strings_chat.xml

- DefaultRoomName, DefaultPrivateGroupName, DefaultPrivateRoomName: New localizable strings.