### PR TITLE
Fix bug in displaying groups with a new message.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.util.SparseArray;
+import android.widget.Toast;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -40,6 +41,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.pajato.android.gamechat.account.Account.STANDARD;
@@ -82,9 +84,25 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         return mCurrentAccountKey == null ? null : mAccountMap.get(mCurrentAccountKey);
     }
 
+    /** Retrun the account for the current User, null if there is no signed in User. */
+    public Account getCurrentAccount(final Context context) {
+        // Determine if there is a logged in account.  If so, return it.
+        if (mCurrentAccountKey != null) return mAccountMap.get(mCurrentAccountKey);
+
+        // The User is not signed in.  Prompt them to do so now.
+        String text = "Not logged in!  Please sign in.";
+        Toast.makeText(context, text, Toast.LENGTH_SHORT).show();
+        return null;
+    }
+
     /** Return the current account id, null if there is no curent signed in User. */
     public String getCurrentAccountId() {
         return mCurrentAccountKey;
+    }
+
+    /** Return a joined room entry, well formed (space separated) group key and room key pair. */
+    public String getJoinedRoomEntry(final String groupKey, final String roomKey) {
+        return String.format(Locale.US, "%s %s", groupKey, roomKey);
     }
 
     /** Obtain a suitable Uri to use for the User's icon. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -17,14 +17,13 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.support.v4.view.ViewPager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountStateChangeEvent;
-import com.pajato.android.gamechat.main.PaneManager;
+import com.pajato.android.gamechat.event.EventBusManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -37,7 +36,7 @@ import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.show
  *
  * @author Paul Michael Reilly (based on GameFragment written by Bryan Scott)
  */
-public class ChatFragment extends BaseFragment {
+public class ChatFragment extends BaseChatFragment {
 
     // Public instance methods.
 
@@ -64,6 +63,7 @@ public class ChatFragment extends BaseFragment {
     @Override public void onInitialize() {
         // Declare the use of the options menu and intialize the FAB and it's menu.
         super.onInitialize();
+        EventBusManager.instance.register(this);
         FabManager.chat.init(mLayout, this.getTag());
     }
 
@@ -72,26 +72,6 @@ public class ChatFragment extends BaseFragment {
         menuInflater.inflate(R.menu.chat_menu_base, menu);
         MenuItem item = menu.findItem(R.id.back);
         if (item != null) item.setVisible(false);
-    }
-
-    /** Handle an options menu choice. */
-    @Override public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.toolbar_game_icon:
-                // Show the game panel.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if(viewPager != null) {
-                    viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                }
-                break;
-            case R.id.search:
-                // TODO: Handle a search in the groups panel by fast scrolling to chat.
-                break;
-            default:
-                break;
-
-        }
-        return super.onOptionsItemSelected(item);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -138,8 +138,8 @@ enum ChatManager {
 
     /** Set the item to be relevant for a list of rooms. */
     private void setItem(Fragment fragment, ChatListItem item) {
-        if (fragment instanceof BaseFragment) {
-            ((BaseFragment) fragment).setItem(item);
+        if (fragment instanceof BaseChatFragment) {
+            ((BaseChatFragment) fragment).setItem(item);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
-import android.support.v4.view.ViewPager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.Menu;
@@ -38,7 +37,7 @@ import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.main.PaneManager;
+import com.pajato.android.gamechat.event.EventBusManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -50,7 +49,7 @@ import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
  *
  * @author Paul Michael Reilly
  */
-public class ShowMessagesFragment extends BaseFragment implements View.OnClickListener {
+public class ShowMessagesFragment extends BaseChatFragment implements View.OnClickListener {
 
     // Public instance methods.
 
@@ -112,8 +111,7 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
     @Override public void onInitialize() {
         // Inflate the layout for this fragment and initialize by setting the titles, declaring the
         // use of the options menu, removing the FAB button, fetching any remote configurations,
-        // setting up the list of messages, setting up the edit text field and setting up the
-        // database analytics.
+        // setting up the list of messages, and by setting up the edit text field.
         super.onInitialize();
         setTitles(null, mItem.roomKey);
         mItemListType = ChatListManager.ChatListType.message;
@@ -122,22 +120,18 @@ public class ShowMessagesFragment extends BaseFragment implements View.OnClickLi
         initEditText(mLayout);
     }
 
+    /** Handle the back button here, all others in the base class. */
     @Override public boolean onOptionsItemSelected(final MenuItem item) {
         switch(item.getItemId()) {
-            case R.id.toolbar_game_icon:
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if(viewPager != null) {
-                    viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                }
-                break;
             case R.id.back:
-                // Return to the spawning room view.
+                // Pop the fragment back stack to return to the rooms view.
                 ChatManager.instance.popBackStack(getActivity());
                 break;
-            case R.id.search:
-                break;
+            default:
+                return super.onOptionsItemSelected(item);
         }
-        return super.onOptionsItemSelected(item);
+
+        return true;
     }
 
     /** Deal with the fragment's lifecycle by managing the FAB. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
@@ -17,14 +17,9 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.support.v4.view.ViewPager;
-import android.view.MenuItem;
-
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.EventBusManager;
-import com.pajato.android.gamechat.main.PaneManager;
 import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -36,7 +31,7 @@ import org.greenrobot.eventbus.Subscribe;
  *
  * @author Paul Michael Reilly
  */
-public class ShowNoAccountFragment extends BaseFragment {
+public class ShowNoAccountFragment extends BaseChatFragment {
 
     // Public instance methods.
 
@@ -55,11 +50,6 @@ public class ShowNoAccountFragment extends BaseFragment {
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_no_account;}
 
-    /** Handle an account state change event by showing the no sign in message. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
-        // TODO: handle an account becoming available by switching to the show group list fragment.
-    }
-
     /** Handle the setup for the groups panel. */
     @Override public void onInitialize() {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
@@ -67,26 +57,6 @@ public class ShowNoAccountFragment extends BaseFragment {
         //ProgressManager.instance.show(this.getContext());
         super.onInitialize();
         ProgressManager.instance.hide();
-    }
-
-    /** Handle an options menu choice. */
-    @Override public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.toolbar_game_icon:
-                // Show the game panel.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if(viewPager != null) {
-                    viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                }
-                break;
-            case R.id.search:
-                // TODO: Handle a search in the groups panel by fast scrolling to chat.
-                break;
-            default:
-                break;
-
-        }
-        return super.onOptionsItemSelected(item);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java
@@ -17,59 +17,18 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.support.v4.view.ViewPager;
-import android.view.MenuItem;
-
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.EventBusManager;
-import com.pajato.android.gamechat.main.PaneManager;
-
-import org.greenrobot.eventbus.Subscribe;
 
 /**
  * Provide a fragment to handle the case where there are no joined rooms.
  *
  * @author Paul Michael Reilly
  */
-public class ShowNoJoinedRoomsFragment extends BaseFragment {
+public class ShowNoJoinedRoomsFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Process a given button click event looking for one on the chat fab button. */
-    @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        // Determine if this event is for the chat fab button.
-        int value = event.getView() != null ? event.getView().getId() : 0;
-        switch (value) {
-            // TODO: Deal with a FAB join room choice.
-        default:
-            // Ignore everything else.
-            break;
-        }
-    }
-
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_no_joined_rooms;}
-
-    /** Handle an options menu choice. */
-    @Override public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.toolbar_game_icon:
-                // Show the game panel.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if(viewPager != null) {
-                    viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                }
-                break;
-            case R.id.search:
-                // TODO: Handle a search in the groups panel by fast scrolling to chat.
-                break;
-            default:
-                break;
-
-        }
-
-        return super.onOptionsItemSelected(item);
-    }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
@@ -27,42 +27,52 @@ import java.util.Map;
 /** Provide a Firebase model class repesenting a chat group, a collection of members and rooms. */
 @IgnoreExtraProperties public class Group  {
 
-    /** The group owner/creator. */
-    public String owner;
+    /** The creation timestamp. */
+    public long createTime;
+
+    /** The group push key value. */
+    public String key;
 
     /** The group name. */
     public String name;
 
-    /** The creation timestamp. */
-    public long createTime;
+    /** The group member account identifiers. */
+    public List<String> memberIdList;
 
     /** The last modification timestamp. */
     public long modTime;
 
-    /** The group member account identifiers. */
-    public List<String> memberIdList;
+    /** The group owner/creator. */
+    public String owner;
+
+    /** The map associating a room name with it's push key. */
+    public Map<String, String> roomMap;
 
     /** Build an empty args constructor for the database. */
     public Group() {}
 
     /** Build a default Group. */
-    public Group(final String owner, final String name, final long createTime, final long modTime,
-                 final List<String> members) {
-        this.name = name;
-        this.owner = owner;
+    public Group(final String key, final String owner, final String name, final long createTime,
+                 final long modTime, final List<String> members, final Map<String, String> map) {
         this.createTime = createTime;
+        this.key = key;
+        this.name = name;
         this.modTime = modTime;
+        this.owner = owner;
         memberIdList = members;
+        roomMap = map;
     }
 
     /** Provide a default map for a Firebase create/update. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
-        result.put("owner", owner);
-        result.put("name", name);
         result.put("createTime", createTime);
-        result.put("modTime", modTime);
+        result.put("key", key);
+        result.put("name", name);
         result.put("memberIdList", memberIdList);
+        result.put("modTime", modTime);
+        result.put("owner", owner);
+        result.put("roomMap", roomMap);
 
         return result;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -38,7 +38,7 @@ import java.util.Map;
     public String owner;
 
     /** The message push key. */
-    public String messageKey;
+    public String key;
 
     /** The poster's display name. */
     public String name;
@@ -67,31 +67,31 @@ import java.util.Map;
     public Message() {}
 
     /** Build a default Message using all the parameters. */
-    public Message(final String owner, final String name, final String url, final String messageKey,
+    public Message(final String key, final String owner, final String name, final String url,
                    final long createTime, final long modTime, final String text, final int type,
                    final List<String> unreadList) {
-        this.owner = owner;
-        this.name = name;
-        this.url = url;
-        this.messageKey = messageKey;
         this.createTime = createTime;
+        this.key = key;
         this.modTime = modTime;
+        this.name = name;
+        this.owner = owner;
         this.text = text;
         this.type = type;
+        this.url = url;
         this.unreadList = unreadList;
     }
 
     /** Provide a default map for a Firebase create/update. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
-        result.put("owner", owner);
-        result.put("name", name);
-        result.put("url", url);
-        result.put("messageKey", messageKey);
         result.put("createTime", createTime);
+        result.put("key", key);
         result.put("modTime", modTime);
+        result.put("name", name);
+        result.put("owner", owner);
         result.put("text", text);
         result.put("type", type);
+        result.put("url", url);
         result.put("unreadList", unreadList);
 
         return result;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -28,37 +28,48 @@ import java.util.Map;
 /** Provide a Firebase model class for representing a chat room. */
 @IgnoreExtraProperties public class Room {
 
-    /** The room owner/creator, an account identifier. */
-    public String owner;
-
-    /** The room name. */
-    public String name;
-
-    /** The parent group push key. */
-    public String groupKey;
+    /** The room types. */
+    public final static int ME = 0;
+    public final static int PRIVATE = 1;
+    public final static int PUBLIC = 2;
 
     /** The creation timestamp. */
     public long createTime;
 
-    /** The last modification timestamp. */
-    public long modTime;
+    /** The parent group push key. */
+    public String groupKey;
 
-    /** The room type, one of "public", "private" or "me". */
-    public String type;
+    /** The room push key. */
+    public String key;
 
     /** The room member account identifiers. These are the people currently in the room. */
     public List<String> memberIdList = new ArrayList<>();
+
+    /** The last modification timestamp. */
+    public long modTime;
+
+    /** The room name. */
+    public String name;
+
+    /** The room owner/creator, an account identifier. */
+    public String owner;
+
+    /** The room type, one of "public", "private" or "me". */
+    public int type;
 
     /** Build an empty args constructor for the database. */
     public Room() {}
 
     /** Build a default room. */
-    public Room(final String owner, final String name, final String groupkey, final long createTime,
-                final long modTime, final String type, final List<String> members) {
+    public Room(final String key, final String owner, final String name, final String groupkey,
+                final long createTime, final long modTime, final int type,
+                final List<String> members) {
+        this.createTime = createTime;
+        this.groupKey = groupKey;
+        this.key = key;
+        this.modTime = modTime;
         this.name = name;
         this.owner = owner;
-        this.createTime = createTime;
-        this.modTime = modTime;
         this.type = type;
         memberIdList = members;
     }
@@ -66,10 +77,11 @@ import java.util.Map;
     /** Provide a default map for a Firebase create/update. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
-        result.put("owner", owner);
-        result.put("name", name);
-        result.put("groupKey", groupKey);
         result.put("createTime", createTime);
+        result.put("groupKey", groupKey);
+        result.put("key", key);
+        result.put("name", name);
+        result.put("owner", owner);
         result.put("modTime", modTime);
         result.put("type", type);
         result.put("memberIdList", memberIdList);

--- a/app/src/main/java/com/pajato/android/gamechat/event/MessageChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/MessageChangeEvent.java
@@ -26,6 +26,12 @@ import com.pajato.android.gamechat.chat.model.Message;
  */
 public class MessageChangeEvent {
 
+    // Public type constants.
+    public static final int NEW = 0;
+    public static final int CHANGED = 1;
+    public static final int REMOVED = 2;
+    public static final int MOVED = 3;
+
     // Public instance variables.
 
     /** The push key for the group containing the message. */
@@ -37,11 +43,16 @@ public class MessageChangeEvent {
     /** The value associated with the click event, either a tag value of the reoource id. */
     public Message message;
 
+    /** The change type. */
+    public int type;
+
     /** Build the event with the given list. */
-    public MessageChangeEvent(final String groupKey, final String roomKey, final Message message) {
+    public MessageChangeEvent(final String groupKey, final String roomKey, final Message message,
+                              final int type) {
         this.groupKey = groupKey;
         this.roomKey =  roomKey;
         this.message = message;
+        this.type = type;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.game;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.view.ViewPager;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.main.PaneManager;
+
+import java.util.Locale;
+
+/**
+ * Provide a base class to support fragment lifecycle debugging.  All fragment lifecycle events are
+ * handled by providing logcat tracing information.
+ *
+ * @author Paul Michael Reilly
+ */
+public abstract class BaseGameFragment extends Fragment {
+
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = BaseGameFragment.class.getSimpleName();
+
+    /** The lifecycle event format string with no bundle. */
+    private static final String FORMAT_NO_BUNDLE =
+        "Fragment: %s; Fragment Manager: %s; Lifecycle event: %s.";
+
+    /** The lifecycle event format string with a bundle provided. */
+    private static final String FORMAT_WITH_BUNDLE =
+        "Fragment: %s; Fragment Manager: %s; Lifecycle event: %s; Bundle: %s.";
+
+    // Protected instance variables.
+
+    /** The persisted layout view for this fragment. */
+    protected View mLayout;
+
+    // Public constructors.
+
+    /** Provide a default, no args constructor. */
+    public BaseGameFragment() {}
+
+    // Public instance methods.
+
+    /** Obtain a layout file from the subclass. */
+    abstract public int getLayout();
+
+    @Override public void onActivityCreated(Bundle bundle) {
+        super.onActivityCreated(bundle);
+        logEvent("onActivityCreated", bundle);
+    }
+
+    @Override public void onAttach(Context context) {
+        super.onAttach(context);
+        logEvent("onAttach");
+    }
+
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        logEvent("onCreate", bundle);
+    }
+
+    /** Handle the onCreateView lifecycle event. */
+    @Override public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
+                                       final Bundle savedInstanceState) {
+        // Determine if the layout exists and reuse it if so.
+        logEvent("onCreateView", savedInstanceState);
+        if (mLayout != null) return mLayout;
+
+        // The layout does not exist.  Create and persist it, and initialize the fragment layout.
+        mLayout = inflater.inflate(getLayout(), container, false);
+        onInitialize();
+        return mLayout;
+    }
+
+    /** Log the lifecycle event and kill the ads. */
+    @Override public void onDestroy() {
+        logEvent("onDestroy");
+        super.onDestroy();
+    }
+
+    @Override public void onDestroyView() {
+        super.onDestroyView();
+        logEvent("onDestroyView");
+    }
+
+    @Override public void onDetach() {
+        super.onDetach();
+        logEvent("onDetach");
+    }
+
+    /** Initialize the fragment. */
+    public void onInitialize() {
+        // All chat and game fragments will use the options menu.
+        setHasOptionsMenu(true);
+    }
+
+    /** Handle an options menu choice. */
+    @Override public boolean onOptionsItemSelected(final MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.toolbar_game_icon:
+                // Show the game panel.
+                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+                if(viewPager != null) {
+                    viewPager.setCurrentItem(PaneManager.GAME_INDEX);
+                }
+                break;
+            case R.id.search:
+                // TODO: Handle a search in the groups panel by fast scrolling to chat.
+                break;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+
+        return true;
+    }
+
+    /** Log the lifecycle event, stop showing ads and turn off the app event bus. */
+    @Override public void onPause() {
+        super.onPause();
+        logEvent("onPause");
+    }
+
+    /** Log the lifecycle event and resume showing ads. */
+    @Override public void onResume() {
+        super.onResume();
+        logEvent("onResume");
+    }
+
+    /** Log the lifecycle event. */
+    @Override public void onStart() {
+        super.onStart();
+        logEvent("onStart");
+    }
+
+    /** Log the lifecycle event. */
+    @Override public void onStop() {
+        super.onStop();
+        logEvent("onStop");
+    }
+
+    /** Log the lifecycle event. */
+    @Override public void onViewStateRestored(Bundle bundle) {
+        super.onViewStateRestored(bundle);
+        logEvent("onViewStateRestored", bundle);
+    }
+
+    // Protected instance methods.
+
+    /** Log a lifecycle event that has no bundle. */
+    protected void logEvent(final String event) {
+        String manager = getFragmentManager().toString();
+        String format = FORMAT_NO_BUNDLE;
+        Log.v(TAG, String.format(Locale.US, format, this, manager, event));
+    }
+
+    /** Log a lifecycle event that has a bundle. */
+    protected void logEvent(final String event, final Bundle bundle) {
+        String manager = getFragmentManager().toString();
+        String format = FORMAT_WITH_BUNDLE;
+        Log.v(TAG, String.format(Locale.US, format, this, manager, event, bundle));
+    }
+
+    /** Provide a way to handle volunteer solicitations for unimplemented functions. */
+    protected void showFutureFeatureMessage(final int resourceId) {
+        // Post a toast message.
+        Context context = getContext();
+        String prefix = context.getString(resourceId);
+        String suffix = context.getString(R.string.FutureFeature);
+        CharSequence text = String.format(Locale.getDefault(), "%s %s", prefix, suffix);
+        Toast.makeText(context, text, Toast.LENGTH_LONG).show();
+    }
+
+    // Private instance methods.
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -14,7 +14,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
 
 import java.util.ArrayList;
 import java.util.Scanner;
@@ -24,7 +24,7 @@ import java.util.Scanner;
  *
  * @author Bryan Scott
  */
-public class CheckersFragment extends BaseFragment {
+public class CheckersFragment extends BaseGameFragment {
     private static final int PRIMARY_PIECE = 1;
     private static final int PRIMARY_KING = 2;
     private static final int SECONDARY_PIECE = 3;

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -15,7 +15,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
 
 import java.util.ArrayList;
 import java.util.Scanner;
@@ -25,7 +25,7 @@ import java.util.Scanner;
  *
  * @author Bryan Scott
  */
-public class ChessFragment extends BaseFragment {
+public class ChessFragment extends BaseGameFragment {
     public boolean mTurn;
 
     // Board Management Objects

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -24,7 +24,7 @@ import android.view.MenuItem;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.chat.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.main.PaneManager;
@@ -39,7 +39,7 @@ import static com.pajato.android.gamechat.game.GameManager.SETTINGS_INDEX;
  *
  * @author Bryan Scott
  */
-public class GameFragment extends BaseFragment {
+public class GameFragment extends BaseGameFragment {
 
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void buttonClickHandler(final ClickEvent event) {

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -10,11 +10,11 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
 
 import java.util.Scanner;
 
-public class LocalTTTFragment extends BaseFragment {
+public class LocalTTTFragment extends BaseGameFragment {
     // Keeps track of the Turn user. True = Player 1, False = Player 2.
     public boolean mTurn;
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -10,9 +10,9 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
 
-public class SettingsFragment extends BaseFragment {
+public class SettingsFragment extends BaseGameFragment {
     private String game;
     private boolean isValidUser = false;
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java
@@ -18,9 +18,8 @@
 package com.pajato.android.gamechat.game;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
 
-public class ShowNoGamesFragment extends BaseFragment {
+public class ShowNoGamesFragment extends BaseGameFragment {
 
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_game_no_games;}

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -16,7 +16,6 @@ import com.firebase.client.FirebaseError;
 import com.firebase.client.GenericTypeIndicator;
 import com.firebase.client.ValueEventListener;
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseFragment;
 
 import java.util.HashMap;
 import java.util.Scanner;
@@ -26,7 +25,7 @@ import java.util.Scanner;
  *
  * @author Bryan Scott
  */
-public class TTTFragment extends BaseFragment {
+public class TTTFragment extends BaseGameFragment {
 
     private static final String TAG = TTTFragment.class.getSimpleName();
     private static final String FIREBASE_URL = "https://gamechat-1271.firebaseio.com/boards/ticTacToe";

--- a/app/src/main/res/menu/chat_menu_base.xml
+++ b/app/src/main/res/menu/chat_menu_base.xml
@@ -54,4 +54,7 @@ more. -->
         android:tag="@integer/learnMore"
         android:icon="@drawable/ic_info_black"
         android:title="@string/navigation_drawer_label_problems_learn" />
+    <item
+        android:id="@+id/joinDeveloperGroups"
+        android:title="@string/joinDeveloperGroups" />
 </menu>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -36,4 +36,5 @@
     <string name="contacts">Contacts</string>
     <string name="editMessageHint">Type a message</string>
     <string name="frequent">Frequent</string>
+    <string name="joinDeveloperGroups">Join Developer Groups</string>
 </resources>


### PR DESCRIPTION
<h1>Rationale:</h1>

At some recent point a bug was introduced whereby the show groups view would not reflect "seen" messages, continuing to report these messages as unseen.  The problem was centered around not receing message change updates via the app event bus at a time when the show groups fragment could update the recycler adapter.  The fix was to introduce a flag to case updates to be applied during the next onResume lifecycle change.

While fixing this bug, the base fragment class was spit into two: one for chat, one for games.

Finally, some early work has been added to support group invites with a special hack for developers.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- getCurrentAccount(): Overload to prompt the user to signin by issuing a toast message.
- getJoinedRoomEntry(): New method to provide a single place to generate a well formed joined room list entry.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- Summary: add code to generate a room map in the group.  The room map facilitates accepting invitation to join a group and is preliminary to using dynamic links.
- init(): set up the target group as basically empty, including an empty member list and room map.
- processGroup: rewrite to use key generation as a direct database operation instead of as a side effect, for rooms and groups; set up the new room map on the group, rearrange teh persistence ordering, now doing them all at the end.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- Use the renamed BaseChatFragment class.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java

- Summary: get group profiles on demand; overhaul changed messages notificatons to the app.
- getGroupProfile(): when a group is not cached, queue up the database to retrieve it.
- getRoomMembers(): remove as it is not used any longer.
- MessagesChangeHandler: make static so that AS is happy with constants; provide logging for the supported on change methods; obtain the messages database path from the database manager.
- MessagesChangeHandler#onChild*(): flesh each out to log and potentially post an app event.
- MessagesChangeHandler#process(): new method to handle filtering dupes and notifying the app of relevnat changes.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- Deal with base class renaming.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java

- buttonClickHandler(): log calls.
- onGroupProfileChange(): new method to handle newly registered groups (part of group invites).
- onMessageListChange(): deal with all changes to events to fix the "unseen" bug.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowNoAccountFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowNoJoinedRoomsFragment.java

- onOptionItemsSelected(): use the base class for common items.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java

- onMessageListChange(): utilize the base class.
- onOptionItemsSelected(): use the base class for common items.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- Summary: use RNF throughout; provide a self reference field (key) and a type field; add the room map for Group.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- Summary: extensive overhaul to centralize the database operations; add (early) support for group invites; use new constructors for model classes; support resource based (localized) default string values.
- mResourceMap: new map to store default, localized resource strings, such as default room names, default group names, localized spellings for "me"  and "anonymous", etc;
- mGroupInviteMap: new map to store group invites (a wip).
- acceptGroupInvite(), extendGroupInvite(), hasGroupInvite(): new methods to support group invites (early wip).
- appendDefaultJoinedRoomEntry(): new method to setting up the joined room list on an account.
- createAccount: let the acount manager handle the joined room entry format; set up the room map in a group; set up the group and room using the modified constructors.
- createGroupProfile(), createRoomProfile(), createMessage(): set the creation timestamp.
- getGroupKey(), getRoomKey(): new methods to obtain push keys.
- getMessagesPath(): new method to centralize the database path to messages.
- init(): new method to set up default resources.

modified:   app/src/main/java/com/pajato/android/gamechat/event/MessageChangeEvent.java

- NEW, CHANGED, REMOVED, MOVED: new type constants.
- type: new field.
- MessageChangeEvent(): add the type.

modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- Use the new BaseGrameFragment class.

modified:   app/src/main/res/menu/chat_menu_base.xml
modified:   app/src/main/res/values/strings_chat.xml

- Add a temporary menu item for developers to join grous easily.

renamed:    app/src/main/java/com/pajato/android/gamechat/chat/BaseFragment.java -> app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
new file:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- Summary: split the base fragment into two files, one for chat and one for games.  The time was ripe.
- BaseChatFragment: reverse ordering of logging events and calls to the super() methods.
- BaseChatFragment#onAttach(): register app event handlers here.
- BaseChatFrgament#onDetach(): unregister app event handler here.