### PR TITLE
Fix a bug where the FAB menu is not shown.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -76,11 +76,11 @@ public abstract class BaseChatFragment extends Fragment {
 
     /** The lifecycle event format string with no bundle. */
     private static final String FORMAT_NO_BUNDLE =
-        "Event: %s; Fragment: %s; Fragment Manager: %s; Fragment Type: %s.";
+        "Event: %s; Fragment: %s; Fragment Manager: %s; Fragment List Type: %s.";
 
     /** The lifecycle event format string with a bundle provided. */
     private static final String FORMAT_WITH_BUNDLE =
-        "Event: %s; Fragment: %s; Fragment Manager: %s; Fragment Type: %s; Bundle: %s.";
+        "Event: %s; Fragment: %s; Fragment Manager: %s; Fragment List Type: %s; Bundle: %s.";
 
     // Protected instance variables.
 
@@ -158,7 +158,8 @@ public abstract class BaseChatFragment extends Fragment {
 
     /** Initialize the fragment. */
     public void onInitialize() {
-        // All chat and game fragments will use the options menu.
+        // All chat and game fragments will use the options menu and start with the FAB in the
+        // closed state.
         setHasOptionsMenu(true);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java
@@ -507,12 +507,10 @@ public enum ChatListManager {
             if (!snapshot.exists()) return;
 
             // Build the message and process the filter flag by checking for a duplicated message.
-            // This code is suspect in origin and likely not needed, hence the logging.
+            // Duplicate messages have been detected by GameChat and is mentioned on StackOverflow:
+            // http://stackoverflow.com/questions/38206413/firebase-childeventlistener-onchildadded-adding-duplicate-objects
             Message message = snapshot.getValue(Message.class);
-            if (filter && isDupe(message)) {
-                Log.e(TAG, "Encountered a duplicated message!", new Throwable());
-                return;
-            }
+            if (filter && isDupe(message)) return;
 
             // The event should be propagated to the app.
             AppEventManager.instance.post(new MessageChangeEvent(mGroupKey, mRoomKey, message, type));

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -136,7 +136,7 @@ enum ChatManager {
         return null;
     }
 
-    /** Set the item to be relevant for a list of rooms. */
+    /** Set the item to be relevant for a list of groups, rooms or messages. */
     private void setItem(Fragment fragment, ChatListItem item) {
         if (fragment instanceof BaseChatFragment) {
             ((BaseChatFragment) fragment).setItem(item);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java
@@ -75,6 +75,15 @@ public enum FabManager {
         // correct initial state.
         mTag = fragmentTag;
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+    }
+
+    /** Initialize the fab state. */
+    public void init(final Fragment fragment) {
+        View layout = getView(fragment);
+        if (layout == null) return;
+
+        // Set the fab state to closed.
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
         dismissMenu(layout);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -17,29 +17,17 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.content.Intent;
-import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.account.Account;
-import com.pajato.android.gamechat.account.AccountManager;
-import com.pajato.android.gamechat.account.AccountStateChangeEvent;
-import com.pajato.android.gamechat.chat.model.Group;
-import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
 import com.pajato.android.gamechat.event.MessageListChangeEvent;
-import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
-
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showNoAccount;
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showNoJoinedRooms;
 
 /**
  * Provide a fragment to handle the display of the groups available to the current user.  This is
@@ -54,37 +42,10 @@ public class ShowGroupListFragment extends BaseChatFragment {
 
     /** Process a given button click event looking for one on the chat fab button. */
     @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        // Determine if this event is for the chat fab button.
-        View view = event.view;
-        logEvent(String.format("onClick: with event {%s};", view));
-        switch (view.getId()) {
-            case R.id.chatFab:
-                // It is a chat fab button.  Toggle the state.
-                FabManager.chat.toggle(this);
-                break;
-            case R.id.addGroupButton:
-            case R.id.addGroupMenuItem:
-                // Dismiss the FAB menu, and start up the add group activity.
-                FabManager.chat.dismissMenu(this);
-                Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
-                startActivity(intent);
-                break;
-
-        default:
-            // Process the event payload, if any.
-            processPayload(view);
-            break;
-        }
-    }
-
-    /** Handle an account state change event by showing the no account fragment if necessary. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
-        // Determine if this represents a no account situation due to a sign out event.
-        logEvent("onAccountStateChange:");
-        if (event.account == null) {
-            // There is no account.  Switch to the no account fragment.
-            ChatManager.instance.replaceFragment(showNoAccount, this.getActivity());
-        }
+        // Assume that the button click is from a group view list item and give the base class a
+        // chance to verify or refute the assumption.  If verified, the group view will drill into
+        // the room view.
+        processPayload(event.view);
     }
 
     /** Set the layout file. */
@@ -96,20 +57,6 @@ public class ShowGroupListFragment extends BaseChatFragment {
         setOptionsMenu(menu, inflater, new int[] {R.id.search}, new int[] {R.id.back});
     }
 
-    /** A new group loaded event has been detected.  Join it if not already joined. */
-    @Subscribe public void onGroupProfileChange(final ProfileGroupChangeEvent event) {
-        // Ensure that the User is logged in (a prompting will be generated if not.)
-        Account account = AccountManager.instance.getCurrentAccount(getContext());
-        if (account == null) return;
-
-        // Ensure that a group key and group are packaged in the event.
-        String groupKey = event.key;
-        Group group = event.group;
-        if (groupKey != null && group != null)
-            // The group and key are available.  Accept any open invitations.
-            DatabaseManager.instance.acceptGroupInvite(account, group, groupKey);
-    }
-
     /** Handle the setup for the groups panel. */
     @Override public void onInitialize() {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
@@ -119,26 +66,7 @@ public class ShowGroupListFragment extends BaseChatFragment {
         mItemListType = ChatListManager.ChatListType.group;
         initAdView(mLayout);
         initList(mLayout, ChatListManager.instance.getList(mItemListType, mItem), false);
-    }
-
-    /** Deal with a change in the joined rooms state. */
-    @Subscribe public void onJoinedRoomListChange(@NonNull final JoinedRoomListChangeEvent event) {
-        // Turn off the loading progress dialog and handle a signed in account with some joined
-        // rooms by rendering the list.
-        if (event.joinedRoomList.size() == 0) {
-            // Handle the case where there are no joined rooms by enabling the no rooms message.
-            ChatManager.instance.replaceFragment(showNoJoinedRooms, this.getActivity());
-        } else {
-            // Handle a joined rooms change by setting up database watchers on the messages in each
-            // room.
-            for (String joinedRoom : event.joinedRoomList) {
-                // Set up the database watcher on this list.
-                String[] split = joinedRoom.split(" ");
-                String groupKey = split[0];
-                String roomKey = split[1];
-                ChatListManager.instance.setMessageWatcher(groupKey, roomKey);
-            }
-        }
+        FabManager.chat.init(this);
     }
 
     /** Manage the list UI every time a message change occurs. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
@@ -33,7 +33,6 @@ import android.widget.EditText;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.account.AccountManager;
-import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -43,7 +42,6 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showNoAccount;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 
 /**
@@ -84,15 +82,6 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_messages;}
 
-    /** Handle an account state change event by showing the no sign in message. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
-        // Determine if this represents a no account situation due to a sign out event.
-        if (event.account == null) {
-            // There is no account.  Switch to the no account fragment.
-            ChatManager.instance.replaceFragment(showNoAccount, this.getActivity());
-        }
-    }
-
     /** Handle a button click on the FAB button by posting a new message. */
     @Override public void onClick(final View view) {
         // Ensure that the click occurred on the send message button.
@@ -127,6 +116,7 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         switch(item.getItemId()) {
             case R.id.back:
                 // Pop the fragment back stack to return to the rooms view.
+                logEvent("onOptionsItemSelected (showMessageList, back)");
                 ChatManager.instance.popBackStack(getActivity());
                 break;
             default:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
@@ -17,26 +17,21 @@
 
 package com.pajato.android.gamechat.chat;
 
-import android.content.Intent;
-import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.account.AccountStateChangeEvent;
-import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.AppEventManager;
-import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
+import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MessageListChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showNoAccount;
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showNoJoinedRooms;
+import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showGroupList;
 
 /**
  * Provide a fragment to handle the display of the groups available to the current user.  This is
@@ -51,38 +46,14 @@ public class ShowRoomListFragment extends BaseChatFragment {
 
     /** Process a given button click event from the FAB, it's menu or a recycler list row. */
     @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        // Determine if this event is for the chat fab button.
-        View view = event.view;
-        switch (view.getId()) {
-            case R.id.chatFab:
-                // It is a chat fab button.  Toggle the state.
-                FabManager.chat.toggle(this);
-                break;
-            case R.id.addGroupButton:
-            case R.id.addGroupMenuItem:
-                // Dismiss the FAB menu, and start up the add group activity.
-                FabManager.chat.dismissMenu(this);
-                Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
-                startActivity(intent);
-                break;
-            default:
-                // Process the event payload, if any.
-                processPayload(view);
-                break;
-        }
+        // Assume that the button click is from a group view list item and give the base class a
+        // chance to verify or refute the assumption.  If verified, the group view will drill into
+        // the room view.
+        processPayload(event.view);
     }
 
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_rooms;}
-
-    /** Handle an account state change event by showing the no sign in message. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
-        // Determine if this represents a no account situation due to a sign out event.
-        if (event.account == null) {
-            // There is no account.  Switch to the no account fragment.
-            ChatManager.instance.replaceFragment(showNoAccount, this.getActivity());
-        }
-    }
 
     /** Provide a general button click handler to post the click for general consumption. */
     public void onClick(final View view) {
@@ -104,31 +75,14 @@ public class ShowRoomListFragment extends BaseChatFragment {
         mItemListType = ChatListManager.ChatListType.room;
         initAdView(mLayout);
         initList(mLayout, ChatListManager.instance.getList(mItemListType, mItem), false);
-    }
-
-    /** Deal with a change in the joined rooms state. */
-    @Subscribe public void onJoinedRoomListChange(@NonNull final JoinedRoomListChangeEvent event) {
-        // Determine if there are no joined rooms.
-        if (event.joinedRoomList.size() == 0) {
-            // Handle the case where there are no joined rooms by enabling the no rooms message.
-            ChatManager.instance.replaceFragment(showNoJoinedRooms, this.getActivity());
-        } else {
-            // Handle a joined rooms change by setting up database watchers on the messages in each
-            // room.
-            for (String joinedRoom : event.joinedRoomList) {
-                // Set up the database watcher on this list.
-                String[] split = joinedRoom.split(" ");
-                String groupKey = split[0];
-                String roomKey = split[1];
-                ChatListManager.instance.setMessageWatcher(groupKey, roomKey);
-            }
-        }
+        FabManager.chat.init(this);
     }
 
     /** Manage the list UI every time a message change occurs. */
     @Subscribe public void onMessageListChange(final MessageListChangeEvent event) {
         // Log the event and update the list saving the result for a retry later.
-        logEvent(String.format(Locale.US, "onMessageListChange with event {%s}", event));
+        String format = "onMessageListChange (showRoomList) with event {%s}";
+        logEvent(String.format(Locale.US, format, event));
         mUpdateOnResume = !updateAdapterList();
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -36,7 +36,6 @@ import com.pajato.android.gamechat.chat.ChatListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.MessageListChangeEvent;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -199,12 +198,6 @@ public class MainActivity extends BaseActivity
         // manager misses an authentication event then the app will not behave as intended.
         setContentView(R.layout.activity_main);
         init();
-    }
-
-    /** Manage the list UI every time a message change occurs. */
-    @Subscribe public void onMessageListChange(final MessageListChangeEvent event) {
-        // Log the event and update the list saving the result for a retry later.
-        Log.d(TAG, "MainActivity checking in; I got the message!");
     }
 
     /** Respect the lifecycle and ensure that the event bus shuts down. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
@@ -36,6 +36,9 @@ public enum ProgressManager {
     /** The view pager adapter used to manage paging on a smartphone layout. */
     private ProgressDialog mProgressDialog;
 
+    /** Indicates if the dialog is showing. */
+    private boolean mIsShowing;
+
     // Public instance methods
 
     /** Show the initial loading dialog. */
@@ -52,14 +55,16 @@ public enum ProgressManager {
         mProgressDialog.setTitle("Starting...");
         mProgressDialog.setMessage("Please wait while the app starts up...");
         mProgressDialog.show();
+        mIsShowing = true;
     }
 
     /** Dismiss the initial loading dialog if one is showing. */
     public void hide() {
         Log.d(TAG, "Attempting to hide the progress dialog.");
-        if (mProgressDialog != null) {
+        if (mIsShowing && mProgressDialog != null) {
             mProgressDialog.dismiss();
             mProgressDialog = null;
+            mIsShowing = false;
         }
     }
 }


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a problem where the FAB menu was not being shown after drilling into the rooms in a group.  It turns out the the FAB was actually being handled ... but twice!  This gave the impression that the FAB was not being shown where it was being shown and then un-shown so fast that the end result was the only visible impression.  The fix was to move the FAB handling to the envelope chat fragment.  In so doing there was only one place where the FAB handling was being done.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- FORMAT_NO_BUNDLE, FORMAT_WITH_BUNDLE: enhance the logging ouput.
- onInitialize(): enhance documentation (minor).

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- buttonClickHandler(): new method to provide one-stop handling for the FAB and the add group trigger.
- onGroupProfileChange(): new method to handle group profile changes that could be generated by an invite.
- onJoinedRoomListChange(): new method to handle changes to the Users' joined rooms status.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatListManager.java

- MessageChangeHandler#process(): Document the StackOverflow snippet on dupes in Firebase and lose the log entry about dupes.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- setItem(): Minor documentation enhancement.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/FabManager.java

- init(): Add an overloaded method to initialize for a list fragment (group and room).

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java

- buttonClickHandler(): Simplify by moving the FAB and group add handling to ChatFragment.
- onAccountStateChange(), onGroupProfileChange(), onJoinedRoomListChange(): Move to ChatFragment for single sourcing.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java

- onAccountStateChange(): move to ChatFragment for single sourceing.
- onClick(): log the back button actions.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java

- buttonClickHandler(): Simplify by moving the FAB and group add handling to ChatFragment.
- onAccountStateChange(), onJoinedRoomListChange(): Move to ChatFragment for single sourcing.
- onMessageListChange(): enhance logging.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onMessageListChange(): Remove.

modified:   app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java

- mIsShowning: new instance variable to track the state.
- show(), hide(): use the mIsShowing flag to protect from side effects.