### PR TITLE
Fix the messages view double back press bug.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -30,7 +30,6 @@ import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -158,8 +157,7 @@ public abstract class BaseChatFragment extends Fragment {
 
     /** Initialize the fragment. */
     public void onInitialize() {
-        // All chat and game fragments will use the options menu and start with the FAB in the
-        // closed state.
+        // All chat and game fragments will use the options menu.
         setHasOptionsMenu(true);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
@@ -68,6 +67,9 @@ public class ChatFragment extends BaseChatFragment {
                 startActivity(intent);
                 break;
             default:
+                // Determine if the button click was generaged by a group view or room view drill
+                // down.  Handle it by adding the next fragment to the back stack.
+                processPayload(event.view);
                 break;
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.chat;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -84,16 +85,12 @@ enum ChatManager {
         // activity, adding a backstack.
         lastTypeShown = type;
         setItem(fragment, item);
-        context.getSupportFragmentManager().enableDebugLogging(true);
-        context.getSupportFragmentManager().beginTransaction()
+        FragmentManager manager = context.getSupportFragmentManager();
+        FragmentManager.enableDebugLogging(true);
+        manager.beginTransaction()
             .replace(R.id.chatFragmentContainer, fragment)
-            .addToBackStack(null)
+            .addToBackStack(type.toString())
             .commit();
-    }
-
-    /** Return to the previous fragment added to the back stack. */
-    public void popBackStack(final FragmentActivity context) {
-        context.getSupportFragmentManager().popBackStack();
     }
 
     /** Attach a fragment identified by a type, creating that fragment as necessary. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -22,7 +22,6 @@ import android.view.MenuInflater;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MessageListChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -39,14 +38,6 @@ import java.util.Locale;
 public class ShowGroupListFragment extends BaseChatFragment {
 
     // Public instance methods.
-
-    /** Process a given button click event looking for one on the chat fab button. */
-    @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        // Assume that the button click is from a group view list item and give the base class a
-        // chance to verify or refute the assumption.  If verified, the group view will drill into
-        // the room view.
-        processPayload(event.view);
-    }
 
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_groups;}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat;
 
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
@@ -31,8 +30,6 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.showGroupList;
-
 /**
  * Provide a fragment to handle the display of the groups available to the current user.  This is
  * the top level view in the chat hierarchy.  It shows all the joined groups and allows for drilling
@@ -43,14 +40,6 @@ import static com.pajato.android.gamechat.chat.ChatManager.ChatFragmentType.show
 public class ShowRoomListFragment extends BaseChatFragment {
 
     // Public instance methods.
-
-    /** Process a given button click event from the FAB, it's menu or a recycler list row. */
-    @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        // Assume that the button click is from a group view list item and give the base class a
-        // chance to verify or refute the assumption.  If verified, the group view will drill into
-        // the room view.
-        processPayload(event.view);
-    }
 
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_rooms;}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
@@ -17,6 +17,10 @@
 
 package com.pajato.android.gamechat.chat.adapter;
 
+import java.util.Locale;
+
+import static android.R.attr.key;
+
 /**
  * Provide a POJO to encapsulate a recycler view list item: either a date label view or a room list
  * view showing the rooms in a group with messages characterized by a preceding date label view.
@@ -39,6 +43,9 @@ public class ChatListItem {
 
     /** The chat list item count of new messages in a group or a room. */
     int count;
+
+    /** A description of the item. */
+    public String desc;
 
     /** The item email address, possibly null, used for contact items. */
     public String email;
@@ -73,6 +80,7 @@ public class ChatListItem {
     public ChatListItem(final ContactHeaderItem item) {
         type = CONTACT_HEADER_ITEM_TYPE;
         nameResourceId = item.getNameResourceId();
+        desc = String.format(Locale.US, "Contact header with id: {%d}.", nameResourceId);
     }
 
     /** Build an instance for a given contact list item. */
@@ -82,6 +90,8 @@ public class ChatListItem {
         email = item.email;
         phone = item.phone;
         url = item.url;
+        String format = "Contact item with name {%s}, email: {%s}, phone: {%s} and url {%s}.";
+        desc = String.format(Locale.US, format, name, email, phone, url);
     }
 
     /** Build an instance for a given group list item. */
@@ -91,12 +101,15 @@ public class ChatListItem {
         name = item.name;
         count = item.count;
         text = item.text;
+        String format = "Group item with name {%s}, key: {%s}, count: {%s} and text {%s}.";
+        desc = String.format(Locale.US, format, name, key, count, text);
     }
 
     /** Build an instance for a given date header item. */
     public ChatListItem(final DateHeaderItem item) {
         type = DATE_ITEM_TYPE;
         nameResourceId = item.getNameResourceId();
+        desc = String.format(Locale.US, "Contact header with id: {%d}.", nameResourceId);
     }
 
     /** Build an instance for a given room list item. */
@@ -108,6 +121,8 @@ public class ChatListItem {
         count = 0;
         text = item.text;
         url = item.url;
+        String format = "Message item with name {%s}, key: {%s}, count: {%s} and text {%s}.";
+        desc = String.format(Locale.US, format, name, key, count, text);
     }
 
     /** Build an instance for a given room list item. */
@@ -118,6 +133,8 @@ public class ChatListItem {
         name = item.name;
         count = item.count;
         text = item.text;
+        String format = "Room item with name {%s}, key: {%s}, count: {%s} and text {%s}.";
+        desc = String.format(Locale.US, format, name, key, count, text);
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'
 


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug where the messages view was entered onto the fragment manager's back stack twice requiring two back pressed to move up the stack.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onInitialize(): update doc comment.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- buttonClickHandler(): process group and room view button clicks as the default case.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- chainFragment(): fix an AS warning to make the enable debugging call be static; add a string to identify the fragment for the back stack.
- popBackStack(): remove as it has been made obsolete by removing the toolbar back button.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java

- buttonClickHandler(): remove as it is now covered by the envelope chat fragment.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java

- desc: new variable to provide an item description (added to each constructor).

modified:   build.gradle

- Upgrade to the AS 2.2 release.