### PR TITLE
Fix missing FAB issue with game settings fragment.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * Provide a fragment to handle the display of the rooms available to the current user.
+ * Provide a thin veneer over the GreenRobot EventBus facility.
  *
  * @author Paul Michael Reilly
  */
@@ -44,6 +44,12 @@ public enum AppEventManager {
     private Map<String, Object> mHandlerMap = new HashMap<>();
 
     // Public instance methods.
+
+    /** Cancel further processing on a given event. */
+    public void cancel(final Object event) {
+        // All subsequent subscribers will not see the given event.
+        EventBus.getDefault().cancelEventDelivery(event);
+    }
 
     /** Post an event using the GreenRobot library. */
     public void post(final Object event) {
@@ -74,6 +80,15 @@ public enum AppEventManager {
             mHandlerMap.remove(name);
             Log.d(TAG, String.format(Locale.US, "Unregistered app event listener {%s}.", name));
         }
+    }
+    /** Unregister all named listeners. */
+    public void unregisterAll() {
+        // Remove all registered listeners and clear the map.
+        for (Object handler : mHandlerMap.values()) {
+            EventBus.getDefault().unregister(handler);
+        }
+        mHandlerMap.clear();
+        Log.d(TAG, "Unregistered all app event listeners.");
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/BackPressEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/BackPressEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+import android.app.Activity;
+
+/**
+ * Provides a back button event class. One of these is posted on a back press event.
+ *
+ * @author Paul Michael Reilly
+ */
+public class BackPressEvent {
+
+    // Public instance variables.
+
+    /** The activity detecting the event. */
+    public Activity activity;
+
+    // Public constructors.
+
+    /** Build the instance with a given activity. */
+    public BackPressEvent(final Activity activity) {
+        this.activity = activity;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -85,7 +85,6 @@ public abstract class BaseGameFragment extends Fragment {
     @Override public void onAttach(Context context) {
         super.onAttach(context);
         logEvent("onAttach");
-        AppEventManager.instance.register(this);
     }
 
     @Override public void onCreate(Bundle bundle) {
@@ -120,7 +119,6 @@ public abstract class BaseGameFragment extends Fragment {
     @Override public void onDetach() {
         super.onDetach();
         logEvent("onDetach");
-        AppEventManager.instance.unregister(this);
     }
 
     /** Initialize the fragment. */
@@ -151,14 +149,18 @@ public abstract class BaseGameFragment extends Fragment {
 
     /** Log the lifecycle event, stop showing ads and turn off the app event bus. */
     @Override public void onPause() {
+        // Log the event and stop listening for app events.
         super.onPause();
         logEvent("onPause");
+        AppEventManager.instance.unregister(this);
     }
 
     /** Log the lifecycle event and resume showing ads. */
     @Override public void onResume() {
+        // Log the event and start listening for app events.
         super.onResume();
         logEvent("onResume");
+        AppEventManager.instance.register(this);
     }
 
     /** Log the lifecycle event. */

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
-import android.view.KeyEvent;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -10,7 +9,9 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.chat.FabManager;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.BackPressEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -26,8 +27,14 @@ public class SettingsFragment extends BaseGameFragment {
 
     }
 
-    @Subscribe public void onClick(final ClickEvent event) {
-
+    /** Handle a back press event by canceling out of the settings fragment. */
+    @Subscribe(priority=1)
+    public void onBackPressed(final BackPressEvent event) {
+        // Re-enable the FAB and return to the start fragment after disabling further event
+        // subscribers.
+        AppEventManager.instance.cancel(event);
+        FabManager.game.setState(this, View.VISIBLE);
+        GameManager.instance.sendNewGame(GameManager.NO_GAMES_INDEX, getActivity());
     }
 
     @Override public void setArguments(final Bundle args) {
@@ -72,25 +79,6 @@ public class SettingsFragment extends BaseGameFragment {
         } else if(game.equals(getString(R.string.new_game_chess))) {
             title.setText(R.string.playing_chess);
             setupChess();
-        }
-    }
-
-    /** Handle the back button after the view has been created. */
-    @Override public void onViewCreated(final View view, final Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-
-        if(this.getView() != null) {
-            this.getView().setFocusableInTouchMode(true);
-            this.getView().requestFocus();
-            this.getView().setOnKeyListener(new View.OnKeyListener() {
-                @Override public boolean onKey(View v, int keyCode, KeyEvent event) {
-                    if (keyCode == KeyEvent.KEYCODE_BACK) {
-                        GameManager.instance.sendNewGame(GameManager.NO_GAMES_INDEX, getActivity());
-                        return true;
-                    }
-                    return false;
-                }
-            });
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -35,6 +35,7 @@ import com.pajato.android.gamechat.account.AccountStateChangeEvent;
 import com.pajato.android.gamechat.chat.ChatListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.BackPressEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
@@ -111,10 +112,16 @@ public class MainActivity extends BaseActivity
                 break;
         }    }
 
-    /** Handle a back button press. */
+    /** Handle a back button press event posted by the event manager. */
+    @Subscribe public void onBackPressed(final BackPressEvent event) {
+        // No other subscriber has handled the back press.  Let the system deal with it.
+        super.onBackPressed();
+    }
+
+    /** Handle a back button press event delivered by the system. */
     @Override public void onBackPressed() {
         // If the navigation drawer is open, close it, otherwise let the system deal with it.
-        if (!NavigationManager.instance.closeDrawerIfOpen(this)) super.onBackPressed();
+        AppEventManager.instance.post(new BackPressEvent(this));
     }
 
     /** Process a click on a given view by posting a button click event. */
@@ -198,6 +205,12 @@ public class MainActivity extends BaseActivity
         // manager misses an authentication event then the app will not behave as intended.
         setContentView(R.layout.activity_main);
         init();
+    }
+
+    /** Handle the imminent destruction of the app by shutting down the app event manager. */
+    @Override protected void onDestroy() {
+        super.onDestroy();
+        AppEventManager.instance.unregisterAll();
     }
 
     /** Respect the lifecycle and ensure that the event bus shuts down. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -38,6 +38,12 @@ import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.Account;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.BackPressEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import static android.graphics.Shader.TileMode.CLAMP;
 
 
 /** Provide a singleton to manage the app navigation provided by the navigation drawer. */
@@ -61,9 +67,18 @@ public enum NavigationManager {
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-        // Set up the handle navigation menu item clicks.
+        // Set up the handle navigation menu item clicks and register this manager with the app
+        // event manager.
         NavigationView navigationView = (NavigationView) activity.findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(activity);
+        AppEventManager.instance.register(this);
+    }
+
+    /** Handle a back press event. */
+    @Subscribe(priority = 1)
+    public void onBackPressed(final BackPressEvent event) {
+        // Detect and close an open nav drawer.  Cancel propagation if the drawer is open.
+        if (closeDrawerIfOpen(event.activity)) AppEventManager.instance.cancel(event);
     }
 
     /** Set up the navigation header to show an account. */
@@ -137,7 +152,7 @@ public enum NavigationManager {
 
             Canvas canvas = new Canvas(result);
             Paint paint = new Paint();
-            paint.setShader(new BitmapShader(squared, BitmapShader.TileMode.CLAMP, BitmapShader.TileMode.CLAMP));
+            paint.setShader(new BitmapShader(squared, CLAMP, CLAMP));
             paint.setAntiAlias(true);
             float r = size / 2f;
             canvas.drawCircle(r, r, r, paint);


### PR DESCRIPTION
<h1>Rationale:</h1>

The game settings fragment would return to the no games fragment correctly on a back press but the FAB was not being shown.  Debugging revealed that the issue was that the FAB visibility was turned off when starting the settings fragment but was not turned back on when leaving the settings fragment.  Digging deeper, the mechanism used to handle the back press is probably overkill.  The recommended approach is to have the activity capture and handle the back press.  The preferred solution for GameChat is to let the main activity capture the back press and propagate it to other modules via the app event bus. The first module dealing with the back press turns off subsequent event propagation (unless that might not be the right thing to do at the moment).  This commit adopts the more app-centric approach reather than a per-module approach.

This issue also drove home the notion that registering the app event bus during resume and unregistering it during pause is a very good convention because that is when the fragment or activity is running in the foreground, exactly when events should be processed.  Events needing to be processed when the activity or fragment is not running in the foreground should be handled as part of a "service".  This revelation means the Chat world event model needs to be revisited yet again.

And one last observation.  In the game panel, the default "home" base is either the no games fragment or the with games fragment.  This is a bug waiting to land.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java

- cancel(), unregisterAll(): new methods providing a richer event bus mechanism.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- Summary: make the app event bus follow the recommended conventions for games.
- onAttach(): remove the app event bus registration.
- onDetach(): remove the app event bus de-registration.
- onResume(): add the app event bus registration.
- onPause(): add the app event bus de-registration.

modified:   app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java

- onBackPressed(): new method implementing the preferred approach and making the FAB visible.
- onViewCreated(): remove the stale approach to handling the back button.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onBackPressed(): overload to handle the app event post by invoking the system action; handle the system callback by posting and app event.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- onBackPressed(): deal with the app event to detect and close an open nav drawer.

new file:   app/src/main/java/com/pajato/android/gamechat/event/BackPressEvent.java

- Add a simple pojo to define a back press handler.