### PR TITLE
Apply RNF to the NavigationManager class.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     // Android
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha7'
 
     // Google
     compile "com.google.android.gms:play-services-ads:$rootProject.ext.gmsVersion"

--- a/app/src/main/java/com/pajato/android/gamechat/event/NavDrawerOpenEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/NavDrawerOpenEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+import android.app.Activity;
+
+/**
+ * Provides a nav drawer open event class. This informs the nav drawer manager so that the drawer
+ * can be closed.
+ *
+ * @author Paul Michael Reilly
+ */
+public class NavDrawerOpenEvent {
+
+    // Public instance variables.
+
+    /** The activity detecting the event. */
+    public Activity activity;
+
+    // Public constructors.
+
+    /** Build the instance with a given activity. */
+    public NavDrawerOpenEvent(final Activity activity) {
+        this.activity = activity;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -37,7 +37,6 @@ public class CheckersFragment extends BaseGameFragment {
     private SparseIntArray mBoardMap;
     private ImageButton mHighlightedTile;
     private boolean mIsHighlighted = false;
-    private View mLayout;
     private ArrayList<Integer> mPossibleMoves;
 
     /** Set the layout file. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -37,6 +37,7 @@ import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -93,26 +94,7 @@ public class MainActivity extends BaseActivity
         }
     }
 
-    /** Process a given button click event by logging it. */
-    @Subscribe public void buttonClickHandler(final ClickEvent event) {
-        View view = event.view;
-        String format = "Button click event on view: {%s}.";
-        Log.v(TAG, String.format(Locale.US, format, view.getClass().getSimpleName()));
-
-        // Process the sign in and sign out button clicks.
-        switch (view.getId()) {
-            case R.id.currentProfile:
-            case R.id.signIn:
-            case R.id.signOut:
-                // On a sign in or sign out event, make sure the navigation drawer gets closed.
-                NavigationManager.instance.closeDrawerIfOpen(this);
-                break;
-            default:
-                // Ignore everything else.
-                break;
-        }    }
-
-    /** Handle a back button press event posted by the event manager. */
+    /** Handle a back button press event posted by the app event manager. */
     @Subscribe public void onBackPressed(final BackPressEvent event) {
         // No other subscriber has handled the back press.  Let the system deal with it.
         super.onBackPressed();
@@ -122,6 +104,25 @@ public class MainActivity extends BaseActivity
     @Override public void onBackPressed() {
         // If the navigation drawer is open, close it, otherwise let the system deal with it.
         AppEventManager.instance.post(new BackPressEvent(this));
+    }
+
+    /** Process a given button click event handling the nav drawer closing. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        // Log all button clicks and rocess the sign in and sign out button clicks.
+        View view = event.view;
+        String format = "Button click event on view: {%s}.";
+        Log.v(TAG, String.format(Locale.US, format, view.getClass().getSimpleName()));
+        switch (view.getId()) {
+            case R.id.currentProfile:
+            case R.id.signIn:
+            case R.id.signOut:
+                // On a sign in or sign out event, make sure the navigation drawer gets closed.
+                AppEventManager.instance.post(new NavDrawerOpenEvent(this));
+                break;
+            default:
+                // Ignore everything else.
+                break;
+        }
     }
 
     /** Process a click on a given view by posting a button click event. */
@@ -140,9 +141,8 @@ public class MainActivity extends BaseActivity
             case R.id.nav_learn:
                 // Todo: add menu button handling as a future feature.
                 break;
-
         }
-        NavigationManager.instance.closeDrawerIfOpen(this);
+        AppEventManager.instance.post(new NavDrawerOpenEvent(this));
         return true;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -40,6 +40,7 @@ import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
+import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -81,6 +82,12 @@ public enum NavigationManager {
         if (closeDrawerIfOpen(event.activity)) AppEventManager.instance.cancel(event);
     }
 
+    /** Process a given button click event handling the nav drawer closing. */
+    @Subscribe public void onClick(final NavDrawerOpenEvent event) {
+        // The nav drawer is probably open so close it.
+        closeDrawerIfOpen(event.activity);
+    }
+
     /** Set up the navigation header to show an account. */
     public void setAccount(final Account account, final View header) {
         // Hide the sign in text and show the current profile and the sign
@@ -111,8 +118,10 @@ public enum NavigationManager {
         view.setVisibility(View.GONE);
     }
 
+    // Private instance methods.
+
     /** Check for an open navigation drawer and close it if one is found. */
-    public boolean closeDrawerIfOpen(final Activity activity) {
+    private boolean closeDrawerIfOpen(final Activity activity) {
         DrawerLayout drawer = (DrawerLayout) activity.findViewById(R.id.drawer_layout);
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
@@ -121,6 +130,45 @@ public enum NavigationManager {
 
         return false;
     }
+
+    /** Load the account icon, if available, using a placeholder otherwise. */
+    private void loadAccountIcon(final Account account, final View header) {
+        // Determine if there is an image to be loaded.
+        ImageView icon = (ImageView) header.findViewById(R.id.currentAccountIcon);
+        Uri imageUri = Uri.parse(account.url);
+        if (imageUri != null) {
+            // There is an image to load.  Use Glide to do the heavy lifting.
+            icon.setImageURI(imageUri);
+            Glide.with(header.getContext())
+                .load(account.url)
+                .transform(new CircleTransform(header.getContext()))
+                .into(icon);
+        } else {
+            // There is no image.  Use an anonymous image.
+            icon.setImageResource(R.drawable.ic_account_circle_black_24dp);
+        }
+        icon.setVisibility(View.VISIBLE);
+    }
+
+
+    /** Load the display name, if available, using a placeholder otherwise. */
+    private void setDisplayName(final Account account, final View header) {
+        // Determine if there is a display name to use.
+        String name = account.displayName;
+        if (name == null) {
+            // There is no display name, use a conjured name based on the email address, i.e. the
+            // username part of the email address with an initial cap.
+            name = account.email;
+            int index = name.indexOf('@');
+            name = name.substring(0, index);
+            name = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        }
+        TextView view = (TextView) header.findViewById(R.id.currentAccountDisplayName);
+        view.setText(name);
+        view.setVisibility(View.VISIBLE);
+    }
+
+    // Inner classes.
 
     /**
      * Provide a Glide transform that allows for circular image containers.  Provided by Harsha
@@ -163,45 +211,6 @@ public enum NavigationManager {
         public String getId() {
             return getClass().getName();
         }
-    }
-
-    // Private instance methods.
-
-    /** Load the account icon, if available, using a placeholder otherwise. */
-    private void loadAccountIcon(final Account account, final View header) {
-        // Determine if there is an image to be loaded.
-        ImageView icon = (ImageView) header.findViewById(R.id.currentAccountIcon);
-        Uri imageUri = Uri.parse(account.url);
-        if (imageUri != null) {
-            // There is an image to load.  Use Glide to do the heavy lifting.
-            icon.setImageURI(imageUri);
-            Glide.with(header.getContext())
-                .load(account.url)
-                .transform(new CircleTransform(header.getContext()))
-                .into(icon);
-        } else {
-            // There is no image.  Use an anonymous image.
-            icon.setImageResource(R.drawable.ic_account_circle_black_24dp);
-        }
-        icon.setVisibility(View.VISIBLE);
-    }
-
-
-    /** Load the display name, if available, using a placeholder otherwise. */
-    private void setDisplayName(final Account account, final View header) {
-        // Determine if there is a display name to use.
-        String name = account.displayName;
-        if (name == null) {
-            // There is no display name, use a conjured name based on the email address, i.e. the
-            // username part of the email address with an initial cap.
-            name = account.email;
-            int index = name.indexOf('@');
-            name = name.substring(0, index);
-            name = Character.toUpperCase(name.charAt(0)) + name.substring(1);
-        }
-        TextView view = (TextView) header.findViewById(R.id.currentAccountDisplayName);
-        view.setText(name);
-        view.setVisibility(View.VISIBLE);
     }
 
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"


### PR DESCRIPTION
<h1>Rationale:</h1>

During normal development a few days ago, I noticed that the navigation manager class was in need of some TLC.  This commit provides that TLC as well as some AS updates.

<h1>File changes:</h1>

modified:   app/build.gradle

- Update per AS warnings to use the released constraint layout class by REMOVING the previously required dependency.  Bizarre.

modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java

- mLayout: remove since the base class variable takes precedence.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- buttonClickHandler(): renamed to onClick(); post the NavDrawerOpenEvent rather than invoking the action method directly to make it more abstract.
- onNavigationItemSelectedListener(): also post the NavDrawerOpenEvent.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- onClick(): new app event handler to deal with closing the nav drawer.
- closeDrawerIfOpen(): make private.
- loadAccountIcon(), setDisplayName(): mover per RNF.

modified:   app/src/main/res/layout/fragment_settings.xml

- Remove an unused namespace declaration.

new file:   app/src/main/java/com/pajato/android/gamechat/event/NavDrawerOpenEvent.java

- Provided a marker event class for dealing with an open nav drawer.