### PR TITLE
Activate game icons.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -48,6 +48,7 @@ public class GameFragment extends BaseGameFragment {
         // Grab the View ID and the floating action button and dimmer views.
         View view = event.view;
         switch (view.getId()) {
+            case R.id.IconTicTacToe:
             case R.id.init_ttt:
             case R.id.init_ttt_button:
                 // When a button is clicked, send a new game and reset the fab menu and background
@@ -56,6 +57,7 @@ public class GameFragment extends BaseGameFragment {
                 GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, ttt);
                 FabManager.game.dismissMenu(this);
                 break;
+            case R.id.IconCheckers:
             case R.id.init_checkers:
             case R.id.init_checkers_button:
                 // Do it for checkers.
@@ -63,6 +65,7 @@ public class GameFragment extends BaseGameFragment {
                 GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, checkers);
                 FabManager.game.dismissMenu(this);
                 break;
+            case R.id.IconChess:
             case R.id.init_chess:
             case R.id.init_chess_button:
                 // Do it for chess.

--- a/app/src/main/res/layout/fragment_game_no_games.xml
+++ b/app/src/main/res/layout/fragment_game_no_games.xml
@@ -16,18 +16,24 @@
             android:layout_width="96dp"
             android:layout_height="96dp"
             android:background="@color/colorLightPurple"
+            android:id="@+id/IconTicTacToe"
+            android:onClick="onClick"
             android:contentDescription="@string/TicTacToeImageDesc"
             android:src="@mipmap/ic_tictactoe_red"/>
         <ImageView
             android:layout_width="96dp"
             android:layout_height="96dp"
             android:background="@color/colorLightPurple"
+            android:id="@+id/IconCheckers"
+            android:onClick="onClick"
             android:contentDescription="@string/CheckersImageDesc"
             android:src="@mipmap/ic_checkers"/>
         <ImageView
             android:layout_width="96dp"
             android:layout_height="96dp"
             android:background="@color/colorLightPurple"
+            android:id="@+id/IconChess"
+            android:onClick="onClick"
             android:contentDescription="@string/ChessImageDesc"
             android:src="@mipmap/ic_chess"/>
     </LinearLayout>


### PR DESCRIPTION
<h1>Rationale:</h1>

During a recent demo I was asked why the game icons were not "live" (on the show no games screen).  No reasonable answer was forthcoming.  This commit makes the icons active.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- onClick(): add the icon resource ids to the existing launch targets.

modified:   app/src/main/res/layout/fragment_game_no_games.xml

- Add icon resource ids and onclick handlers.