### PR TITLE
Remove tile click delegation.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/event/TileClickEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/TileClickEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+import android.view.View;
+
+/**
+ * Provides a button click data model class for the tic-tac-toe game..
+ *
+ * @author Paul Michael Reilly
+ */
+public class TileClickEvent {
+
+    // Private instance variables.
+
+    /** The view associated with the click event, if any. */
+    public View view;
+
+    // Public constructors.
+
+    /** Build the event with the given view. */
+    public TileClickEvent(final View view) {
+        this.view = view;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -26,6 +26,7 @@ import android.view.View;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.TileClickEvent;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -91,6 +92,15 @@ public class GameFragment extends BaseGameFragment {
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_game;}
 
+    /** Handle a tile click event by sending a message to the current tic-tac-toe fragment. */
+    @Subscribe public void onClick(final TileClickEvent event) {
+        int index = GameManager.instance.getCurrent();
+        if (index == GameManager.TTT_LOCAL_INDEX || index == GameManager.TTT_ONLINE_INDEX) {
+            String msg = GameManager.instance.getTurn() + "\n" + event.view.getTag().toString();
+            GameManager.instance.sendMessage(msg, index);
+        }
+    }
+
     /** Handle the options menu by inflating it. */
     @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater menuInflater) {
         // Inflate the menu; this adds items to the action bar if it is present.
@@ -128,16 +138,5 @@ public class GameFragment extends BaseGameFragment {
 
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
-
-    /**
-     * Sends a message alerting the event handling system that there was a tile clicked, and
-     * swaps the mTurn to the opposite player.
-     *
-     * @param view the tile clicked
-     */
-    public void tileOnClick(final View view) {
-        String msg = GameManager.instance.getTurn() + "\n" + view.getTag().toString();
-        GameManager.instance.sendMessage(msg, GameManager.instance.getCurrent());
-    }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -63,11 +63,6 @@ public class LocalTTTFragment extends BaseGameFragment {
         GameManager.instance.sendNewGame(GameManager.NO_GAMES_INDEX, getActivity());
     }
 
-    /** Placeholder for button click handling. */
-    @Subscribe public void onClick(final ClickEvent event) {
-        // TODO: flesh this out.
-    }
-
     @Override public void onInitialize() {
         // Initialize Member Variables
         super.onInitialize();

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -38,6 +38,7 @@ import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
+import com.pajato.android.gamechat.event.TileClickEvent;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -147,14 +148,13 @@ public class MainActivity extends BaseActivity
     }
 
     /**
-     * TODO: Remove this method and use the event bus to propagate all button clicks.
      * An OnClick Listener for the tic-tac-toe tiles.
      *
      * @param view the tile clicked
      */
-    public void tileOnClick(final View view) {
-        // Pass responsibility for this onClick listener onto GameFragment
-        PaneManager.instance.tileOnClick(view);
+    public void onTileClick(final View view) {
+        // Post this event to the game fragment via the app event manager.
+        AppEventManager.instance.post(new TileClickEvent(view));
     }
 
     // Protected instance methods

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -87,12 +87,6 @@ public enum PaneManager {
         }
     }
 
-    /** Handle the delegated tile click by delegating it to the game fragment. */
-    public void tileOnClick(final View view) {
-        // Delegate this to the game fragment.
-        ((GameFragment) fragmentList.get(GAME_INDEX)).tileOnClick(view);
-    }
-
     // Nested classes
 
     /** Provide a class to handle the view pager setup. */

--- a/app/src/main/res/layout/fragment_ttt.xml
+++ b/app/src/main/res/layout/fragment_ttt.xml
@@ -134,57 +134,57 @@ http://www.gnu.org/licenses
 
         <Button
             android:tag="button00"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button01"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button02"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
 
         <Button
             android:tag="button10"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button11"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button12"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
 
         <Button
             android:tag="button20"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button21"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>
         <Button
             android:tag="button22"
-            android:onClick="tileOnClick"
+            android:onClick="onTileClick"
             android:layout_gravity="top|start"
             android:text="@string/spaceValue"
             android:textAppearance="@style/TextAppearance.AppCompat.Display3"/>


### PR DESCRIPTION
<h1>Rationale:</h1>

From the start of Bryan's work on TTT, we used delegation of click events.  Over time we have moved click event handling to the auspices of the app event manager.  With this commit the remaining technical debt associated with delegated click handling has been paid down.

<h1>File changes:</h1>

new file:   app/src/main/java/com/pajato/android/gamechat/event/TileClickEvent.java

- Add a special event class for the tile clicks.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- onClick(): add a handler for the tile click event.
- tileOnClick(): remove the delegation model.

modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java

- onClick(): Remove the placelholder.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- tileOnClick(): rename to onTileClick() and implement by posting a tile click event.

modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- tileOnClick(): remove the delegation model detritus.

modified:   app/src/main/res/layout/fragment_ttt.xml

- Rename tileOnClick to onTileClick.