### PR TITLE
Show icons in the settings view.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -58,7 +58,7 @@ public abstract class BaseGameFragment extends BaseFragment {
     /**
      * The game type (enum), set at fragment view creation time.
      */
-    GameManager.Game mGame;
+    Game mGame;
 
     /**
      * The current turn indicator: True = Player 1, False = Player 2.

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Scanner;
 
+import static com.pajato.android.gamechat.game.Game.checkers;
 import static com.pajato.android.gamechat.game.GameManager.CHECKERS_INDEX;
-import static com.pajato.android.gamechat.game.GameManager.Game.checkers;
 
 /**
  * A simple Checkers game for use in GameChat.

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -19,7 +19,7 @@ import com.pajato.android.gamechat.R;
 import java.util.ArrayList;
 import java.util.Scanner;
 
-import static com.pajato.android.gamechat.game.GameManager.Game.chess;
+import static com.pajato.android.gamechat.game.Game.chess;
 
 /**
  * A simple Chess game for use in GameChat.

--- a/app/src/main/java/com/pajato/android/gamechat/game/Game.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Game.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.game;
+
+import com.pajato.android.gamechat.R;
+
+import static com.pajato.android.gamechat.game.GameManager.CHECKERS_INDEX;
+import static com.pajato.android.gamechat.game.GameManager.CHESS_INDEX;
+import static com.pajato.android.gamechat.game.GameManager.TTT_LOCAL_INDEX;
+import static com.pajato.android.gamechat.game.GameManager.TTT_ONLINE_INDEX;
+
+/**
+ * The games enum values associate games, modes, fragments and resources in a very flexible, concise
+ * fashion.
+ *
+ * @author Paul Michael Reilly
+ */
+enum Game {
+    checkers (-1, CHECKERS_INDEX, -1, R.mipmap.ic_checkers, R.string.PlayCheckers,
+              R.string.player_primary, R.string.player_secondary, R.string.FutureCheckers),
+    chess (-1, CHESS_INDEX, -1, R.mipmap.ic_chess, R.string.PlayChess, R.string.player_primary,
+           R.string.player_secondary, R.string.FutureChess),
+    ttt (TTT_ONLINE_INDEX, TTT_LOCAL_INDEX, -1, R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe,
+         R.string.xValue, R.string.oValue, R.string.FutureTTT);
+
+    // Instance variables.
+
+    /** The online fragment index. */
+    int onlineFragmentIndex;
+
+    /** The local fragment index. */
+    int localFragmentIndex;
+
+    /** The computer fragment index. */
+    int computerFragmentIndex;
+
+    /** The primary player index. */
+    int primaryIndex;
+
+    /** The secondary player index. */
+    int secondaryIndex;
+
+    /** The game icon resource id. */
+    int iconResId;
+
+    /** The game title resource id. */
+    int titleResId;
+
+    /** The game future feature prefix resource id. */
+    int futureResId;
+
+    // Constructor.
+
+    /** Build an instance given the online, local and computer opponent fragment indexes. */
+    Game(final int online, final int local, final int computer, final int iconId, final int titleId,
+         final int primary, final int secondary, final int futureId) {
+        onlineFragmentIndex = online;
+        localFragmentIndex = local;
+        computerFragmentIndex = computer;
+        iconResId = iconId;
+        titleResId = titleId;
+        primaryIndex = primary;
+        secondaryIndex = secondary;
+        futureResId = futureId;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -31,9 +31,9 @@ import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.game.GameManager.Game.checkers;
-import static com.pajato.android.gamechat.game.GameManager.Game.chess;
-import static com.pajato.android.gamechat.game.GameManager.Game.ttt;
+import static com.pajato.android.gamechat.game.Game.checkers;
+import static com.pajato.android.gamechat.game.Game.chess;
+import static com.pajato.android.gamechat.game.Game.ttt;
 import static com.pajato.android.gamechat.game.GameManager.NO_GAMES_INDEX;
 import static com.pajato.android.gamechat.game.GameManager.SETTINGS_INDEX;
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -36,55 +36,6 @@ import java.util.ArrayList;
 enum GameManager {
     instance;
 
-    // Public enums
-
-    /** The games enum values associate games, modes, and fragments in a very flexible fashion. */
-    public enum Game {
-        checkers (-1, CHECKERS_INDEX, -1, R.string.PlayCheckers, R.string.player_primary,
-                  R.string.player_secondary, R.string.FutureCheckers),
-        chess (-1, CHESS_INDEX, -1, R.string.PlayChess, R.string.player_primary,
-               R.string.player_secondary, R.string.FutureChess),
-        ttt (TTT_ONLINE_INDEX, TTT_LOCAL_INDEX, -1, R.string.PlayTicTacToe, R.string.xValue,
-             R.string.oValue, R.string.FutureTTT);
-
-        // Instance variables.
-
-        /** The online fragment index. */
-        int onlineFragmentIndex;
-
-        /** The local fragment index. */
-        int localFragmentIndex;
-
-        /** The computer fragment index. */
-        int computerFragmentIndex;
-
-        /** The primary player index. */
-        int primaryIndex;
-
-        /** The secondary player index. */
-        int secondaryIndex;
-
-        /** The game title resource id. */
-        int titleResId;
-
-        /** The game future feature prefix resource id. */
-        int futureResId;
-
-        // Constructor.
-
-        /** Build an instance given the online, local and computer opponent fragment indexes. */
-        Game(final int online, final int local, final int computer, final int titleId,
-             final int primary, final int secondary, final int futureId) {
-            onlineFragmentIndex = online;
-            localFragmentIndex = local;
-            computerFragmentIndex = computer;
-            titleResId = titleId;
-            primaryIndex = primary;
-            secondaryIndex = secondary;
-            futureResId = futureId;
-        }
-    }
-
     // Public class constants.
 
     // Fragment array index constants.
@@ -129,25 +80,6 @@ enum GameManager {
         sendNewGame(NO_GAMES_INDEX, context);
     }
 
-    /** Create and show a Snackbar notification based on the given parameters. */
-    public void notify(final View view, final String output, final int color, final boolean done) {
-        Snackbar notification;
-        if (done) {
-            // The game is ended so generate a notification that could start a new game.
-            notification = Snackbar.make(view, output, Snackbar.LENGTH_INDEFINITE);
-            final String playAgain = getFragment(getCurrent()).getString(R.string.PlayAgain);
-            notification.setAction(playAgain, new NotificationActionHandler());
-        } else {
-            // The game hasn't ended so generate a notification without an action.
-            notification = Snackbar.make(view, output, Snackbar.LENGTH_SHORT);
-        }
-
-        // Determine if a color has been specified. If so, set it, otherwise display the
-        // notification to the User.
-        if (color != -1) notification.getView().setBackgroundColor(color);
-        notification.show();
-    }
-
     /** Return the current fragment's index value. */
     public int getCurrent() {
         return mCurrentFragment;
@@ -177,6 +109,25 @@ enum GameManager {
                 // For chess and checkers, we need either primary or secondary player strings.
                 return getTurn(index, context, R.string.player_primary, R.string.player_secondary);
         }
+    }
+
+    /** Create and show a Snackbar notification based on the given parameters. */
+    public void notify(final View view, final String output, final int color, final boolean done) {
+        Snackbar notification;
+        if (done) {
+            // The game is ended so generate a notification that could start a new game.
+            notification = Snackbar.make(view, output, Snackbar.LENGTH_INDEFINITE);
+            final String playAgain = getFragment(getCurrent()).getString(R.string.PlayAgain);
+            notification.setAction(playAgain, new NotificationActionHandler());
+        } else {
+            // The game hasn't ended so generate a notification without an action.
+            notification = Snackbar.make(view, output, Snackbar.LENGTH_SHORT);
+        }
+
+        // Determine if a color has been specified. If so, set it, otherwise display the
+        // notification to the User.
+        if (color != -1) notification.getView().setBackgroundColor(color);
+        notification.show();
     }
 
     /**

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -30,13 +30,12 @@ import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
-import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Scanner;
 
-import static com.pajato.android.gamechat.game.GameManager.Game.ttt;
+import static com.pajato.android.gamechat.game.Game.ttt;
 
 public class LocalTTTFragment extends BaseGameFragment {
 
@@ -89,24 +88,19 @@ public class LocalTTTFragment extends BaseGameFragment {
         return super.onOptionsItemSelected(item);
     }
 
-    /**
-     * Translates the messages sent by the event system and handles the individual clicks
-     * based on messages sent.
-     *
-     * @param msg the message to be handled.
-     */
+    /** Handle the given message by either starting a new game or dealing with a tile click. */
     @Override public void messageHandler(final String msg) {
-        //TODO: Modify this when an implemented event handling system is implemented.
+        // Parse the message to obtain the button tag, skipping over the player indicator.
         Scanner input = new Scanner(msg);
-        String player = input.nextLine();
+        input.nextLine();
         String buttonTag = input.nextLine();
         input.close();
 
         // Call appropriate methods for each button.
-        if(buttonTag.equals(getString(R.string.NewGame))) {
+        if (buttonTag.equals(getString(R.string.NewGame))) {
             handleNewGame();
         } else {
-            handleTileClick(player, buttonTag);
+            handleTileClick(buttonTag);
         }
     }
 
@@ -288,17 +282,12 @@ public class LocalTTTFragment extends BaseGameFragment {
         checkNotFinished();
     }
 
-    /**
-     * Assigns a value to a button without text, either X or O, depending on the player whose
-     * turn it is.
-     *
-     * @param player the player who initiated the click.
-     * @param buttonTag the tag of the button clicked.
-     */
-    private void handleTileClick(final String player, final String buttonTag) {
-        Button b = (Button) mLayout.findViewWithTag(buttonTag);
+    /** Handle a click on a tile by setting the turn indicator, count and completion. */
+    private void handleTileClick(final String buttonTag) {
         // Only updates the tile if the current value is empty and the game has not finished yet.
+        Button b = (Button) mLayout.findViewWithTag(buttonTag);
         if (b.getText().toString().equals(getString(R.string.spaceValue)) && checkNotFinished()) {
+            // Update the state of the board base on the current turn.
             b.setText(getTurn(mTurn));
             mTurn = !mTurn;
             turnCount++;

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -1,7 +1,25 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
 package com.pajato.android.gamechat.game;
 
 import android.os.Bundle;
 import android.view.View;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
@@ -15,8 +33,6 @@ import org.greenrobot.eventbus.Subscribe;
 import static com.pajato.android.gamechat.game.GameManager.ORDINAL_KEY;
 
 public class SettingsFragment extends BaseGameFragment {
-
-    // Private instance variables.
 
     // Public instance methods.
 
@@ -53,7 +69,7 @@ public class SettingsFragment extends BaseGameFragment {
         if (args != null && args.containsKey(ORDINAL_KEY)) {
             // Get the game emum value.
             int ordinal = args.getInt(ORDINAL_KEY, -1);
-            mGame = ordinal != -1 ? GameManager.Game.values()[ordinal] : null;
+            mGame = ordinal != -1 ? Game.values()[ordinal] : null;
         }
         super.setArguments(args);
     }
@@ -62,11 +78,14 @@ public class SettingsFragment extends BaseGameFragment {
     @Override public int getLayout() {return R.layout.fragment_settings;}
 
     @Override public void onResume() {
-        // Hide the FAB and set the title string.
+        // Hide the FAB and set the title string and the icon source.
         super.onResume();
         getActivity().findViewById(R.id.games_fab).setVisibility(View.GONE);
         TextView title = (TextView) mLayout.findViewById(R.id.settings_title);
         title.setText(mGame != null ? mGame.titleResId : R.string.GameError);
+        ImageButton icon = (ImageButton) mLayout.findViewById(R.id.settings_icon);
+        int imageResId = mGame != null ? mGame.iconResId : R.drawable.ic_launcher;
+        icon.setImageResource(imageResId);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -40,7 +40,7 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.HashMap;
 import java.util.Scanner;
 
-import static com.pajato.android.gamechat.game.GameManager.Game.ttt;
+import static com.pajato.android.gamechat.game.Game.ttt;
 import static com.pajato.android.gamechat.game.GameManager.TTT_LOCAL_INDEX;
 import static com.pajato.android.gamechat.game.GameManager.TTT_ONLINE_INDEX;
 

--- a/app/src/main/res/layout/fragment_game_no_games.xml
+++ b/app/src/main/res/layout/fragment_game_no_games.xml
@@ -15,7 +15,6 @@
         <ImageView
             android:layout_width="96dp"
             android:layout_height="96dp"
-            android:background="@color/colorLightPurple"
             android:id="@+id/IconTicTacToe"
             android:onClick="onClick"
             android:contentDescription="@string/TicTacToeImageDesc"
@@ -23,7 +22,6 @@
         <ImageView
             android:layout_width="96dp"
             android:layout_height="96dp"
-            android:background="@color/colorLightPurple"
             android:id="@+id/IconCheckers"
             android:onClick="onClick"
             android:contentDescription="@string/CheckersImageDesc"
@@ -31,7 +29,6 @@
         <ImageView
             android:layout_width="96dp"
             android:layout_height="96dp"
-            android:background="@color/colorLightPurple"
             android:id="@+id/IconChess"
             android:onClick="onClick"
             android:contentDescription="@string/ChessImageDesc"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -14,6 +14,7 @@
         android:layout_gravity="center"
         android:layout_marginTop="48dp"
         android:layout_marginBottom="24dp"
+        android:id="@+id/settings_icon"
         android:background="@color/white"
         android:contentDescription="@string/play_another_user_desc"
         android:src="@mipmap/ic_tictactoe_red"


### PR DESCRIPTION
<h1>Rationale:</h1>

When transitioning from the home (list of games or no games) view to a game mode selection, the icon was not being carried along to match the FAB choice, or to match the icon click.   This commit fixes that problem.  It also provides a few more source code changes to make the code more concise and consistent with other code (RNF).

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
new file:   app/src/main/java/com/pajato/android/gamechat/game/Game.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- checkers, chess, ttt: detach from GameManager.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameManager.java

- Game: move to it's own file.
- notify(): move to it's correct position (RNF).

modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java

- ttt: detach from GameManager.
- messageHandler(), handleTileClick(); clean up a few AS warnings (player not used); comply with AOSP coding conventions.

modified:   app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java

- Add copyright.
- onBackPressed(): detach Game from GameManager.
- onResume(): update the game icon as well as the game title.

modified:   app/src/main/res/layout/fragment_game_no_games.xml

- Remove the background from the icon image view elements.

modified:   app/src/main/res/layout/fragment_settings.xml

- Provide an id for the image button element so that it can be set programmatically.