### PR TITLE
Add a game panel FAM.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/CheckersTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/CheckersTest.java
@@ -40,7 +40,7 @@ public class CheckersTest extends BaseTest {
                 .perform(click());
 
         // Begin the process of starting a local checkers game
-        onView(withId(R.id.games_fab))
+        onView(withId(R.id.gameFab))
                 .check(matches(isDisplayed()))
                 .perform(click());
 

--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/ChessTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/ChessTest.java
@@ -36,7 +36,7 @@ public class ChessTest extends BaseTest {
                 .perform(click());
 
         // Begin the process of starting a local checkers game
-        onView(withId(R.id.games_fab))
+        onView(withId(R.id.gameFab))
                 .check(matches(isDisplayed()))
                 .perform(click());
 

--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/GameTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/GameTest.java
@@ -31,7 +31,7 @@ public class GameTest extends BaseTest {
                 .check(matches(isDisplayed()));
         onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
-        onView(withId(R.id.games_fab))
+        onView(withId(R.id.gameFab))
                 .check(matches(isDisplayed()))
                 .perform(click());
     }
@@ -114,7 +114,7 @@ public class GameTest extends BaseTest {
         // Ensure the init panel is present and open the FAB
         onView(withId(R.id.init_panel))
                 .check(matches(isDisplayed()));
-        onView(withId(R.id.games_fab))
+        onView(withId(R.id.gameFab))
                 .check(matches(isDisplayed()))
                 .perform(click());
     }

--- a/app/src/androidTest/java/com/pajato/android/gamechat/game/TTTTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/game/TTTTest.java
@@ -411,7 +411,7 @@ public class TTTTest extends BaseTest {
     /** A helper method that creates a new game using the Floating Action Button */
     private void getNewGame(final boolean onStart) {
         // Open the options menu and initiate a new game.
-        onView(withId(R.id.games_fab))
+        onView(withId(R.id.gameFab))
                 .perform(click());
         onView(withId(R.id.init_ttt_button))
                 .perform(click());

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -117,7 +117,7 @@ public class ChatFragment extends BaseChatFragment {
     @Override public void onInitialize() {
         // Declare the use of the options menu and intialize the FAB and it's menu.
         super.onInitialize();
-        FabManager.chat.init(mLayout, this.getTag());
+        FabManager.chat.setTag(this.getTag());
     }
 
     /** Deal with a change in the joined rooms state. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.common.adapter;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.text.Html;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.pajato.android.gamechat.common.adapter.MenuEntry.MENU_HEADER_TYPE;
+import static com.pajato.android.gamechat.common.adapter.MenuEntry.MENU_ITEM_TYPE;
+
+/**
+ * Provide a recycler view adapter to show zero or more menu entries.  A menu entry is either a
+ * header (group label) or a title/icon pair, commonly known as a menu item.  To avoid confusion,
+ * documentation for this class attempts to always prefix "item" with either "adapter" or "menu" to
+ * make the context very clear and unambiguous.
+ *
+ * @author Paul Michael Reilly
+ */
+public class MenuAdapter extends RecyclerView.Adapter<ViewHolder> implements View.OnClickListener {
+
+    // Private instance variables.
+
+    /** A list of menu (group) headers or menu items. */
+    private List<MenuEntry> mList = new ArrayList<>();
+
+    // Public instance methods.
+
+    /** Add menu entries to the adapter's main list. */
+    public void addEntries(final List<MenuEntry> entries) {
+        // Add all the items after clearing the current ones.
+        mList.addAll(entries);
+        notifyDataSetChanged();
+    }
+
+    /** Clear all current menu entries. */
+    public void clearEntries() {
+        mList.clear();
+    }
+
+    /** Populate the widgets for the item at the given position. */
+    @Override public void onBindViewHolder(ViewHolder holder, int position) {
+        MenuEntry menuEntry = mList.get(position);
+        if (menuEntry != null) {
+            switch (menuEntry.type) {
+                case MENU_ITEM_TYPE:
+                    // Update the menu item holder by setting up the title and icon.
+                    updateMenuItemHolder((MenuItemViewHolder) holder, menuEntry);
+                    break;
+            }
+        }
+    }
+
+    /** Post any item clicks to the app. */
+    public void onClick(final View view) {
+        view.setId((Integer) view.getTag());
+        AppEventManager.instance.post(new ClickEvent(view));
+    }
+
+    /** Create the recycler view holder using the given adapter adapter item type. */
+    @Override public ViewHolder onCreateViewHolder(final ViewGroup parent, final int type) {
+        switch (type) {
+            case MENU_ITEM_TYPE:
+                // Normal case: deal with a standard menu item.
+                return new MenuItemViewHolder(getView(parent, R.layout.item_menu));
+            case MENU_HEADER_TYPE:
+                // Rare case: deal with menu header (group label).
+                return new MenuHeaderViewHolder(getView(parent, R.layout.item_header));
+            default:
+                break;
+        }
+
+        return null;
+    }
+
+    /** Obtain the number of entries in the item list. */
+    @Override public int getItemCount() {
+        return mList == null ? 0 : mList.size();
+    }
+
+    /** Obtain the type for the item at the given position. */
+    @Override public int getItemViewType(int position) {
+        // Return the type for the item at the given position, -1 if there is no such item.
+        return mList != null && mList.size() > position ? mList.get(position).type : -1;
+    }
+
+    // Private instance methods.
+
+    /** Obtain a view by inflating the given resource id. */
+    private View getView(final ViewGroup parent, final int resourceId) {
+        View result = LayoutInflater.from(parent.getContext()).inflate(resourceId, parent, false);
+        result.setOnClickListener(this);
+
+        return result;
+    }
+
+    /** Return true iff the given entry has a URL for the icon that the holder can load. */
+    private boolean loadUrl(final MenuItemViewHolder holder, final MenuEntry entry) {
+        if (entry.url == null) return false;
+
+        // There is a url to use.  Parse it to see if it is valid.  Abort if not valid.
+        Uri imageUri = Uri.parse(entry.url);
+        if (imageUri == null) return false;
+
+        // There is an valid image to load.  Use Glide to do the heavy lifting.
+        Context context = holder.icon.getContext();
+        holder.icon.setImageURI(imageUri);
+        Glide.with(context)
+            .load(entry.url)
+            .into(holder.icon);
+        return true;
+    }
+
+    /** Update the given view holder using the data from the given entry. */
+    private void updateMenuItemHolder(final MenuItemViewHolder holder, final MenuEntry entry) {
+        // Set the text on the holder and put the entry on the item view tag..
+        Context context = holder.title.getContext();
+        String text = context.getString(entry.titleResId);
+        holder.title.setText(Html.fromHtml(text));
+        holder.itemView.setTag(entry.iconResId);
+
+        // Set the icon on the holder.
+        if (loadUrl(holder, entry)) return;
+
+        // The url is not viable (reason is unclear).  Time to try the icon resource id.
+        if (entry.iconResId > 0) {
+            holder.icon.setImageResource(entry.iconResId);
+            return;
+        }
+
+        holder.icon.setImageResource(R.drawable.ic_account_circle_black_24dp);
+    }
+
+    // Inner classes.
+
+    /** Provide a class to include a menu item (title and icon) in the list. */
+    private class MenuItemViewHolder extends RecyclerView.ViewHolder {
+        Button title;
+        ImageView icon;
+
+        /** Build a menu item view holder from the given adapter item view. */
+        MenuItemViewHolder(final View adapterItemView) {
+            super(adapterItemView);
+            title = (Button) adapterItemView.findViewById(R.id.menuItemTitle);
+            icon = (ImageView) adapterItemView.findViewById(R.id.menuItemIcon);
+        }
+    }
+
+    /** Provide a class to include a menu (group) header in the list. */
+    private class MenuHeaderViewHolder extends RecyclerView.ViewHolder {
+
+        /** The text view showing the date or contact header. */
+        TextView title;
+
+        /** Build a menu header (group) view holder from the given adapter item view. */
+        MenuHeaderViewHolder(final View adapterItemView) {
+            super(adapterItemView);
+            title = (TextView) adapterItemView.findViewById(R.id.header);
+        }
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.common.adapter;
+
+import java.util.Locale;
+
+/**
+ * Provide a POJO to encapsulate a recycler view list item: a FAB menu item.
+ *
+ * @author Paul Michael Reilly
+ */
+public class MenuEntry {
+
+    // Type constants.
+    final static int MENU_ITEM_TYPE = 0;
+    final static int MENU_HEADER_TYPE = 1;
+
+    // Public instance variables.
+
+    /** A description of the item. */
+    public String desc;
+
+    /** The menu item icon resource id. */
+    int iconResId;
+
+    /** The list of rooms or groups with messages to show, or the text of a message. */
+    int titleResId;
+
+    /** The entry type, provided by the item. */
+    public int type;
+
+    /** The URL for the item, possibly null, used for icons with contacts and chat list items. */
+    public String url;
+
+    // Public constructors.
+
+    /** Build an instance for a given menu item. */
+    public MenuEntry(final MenuItemEntry entry) {
+        type = MENU_ITEM_TYPE;
+        iconResId = entry.iconResId;
+        titleResId = entry.titleResId;
+        url = entry.url;
+        String format = "Menu item with title resource id {%s} and url {%s}.";
+        desc = String.format(Locale.US, format, titleResId, url);
+    }
+
+    /** Build an instance for a given menu item. */
+    public MenuEntry(final MenuHeaderEntry entry) {
+        type = MENU_HEADER_TYPE;
+        titleResId = entry.titleResId;
+        String format = "Menu header with title resource id {%s}.";
+        desc = String.format(Locale.US, format, titleResId);
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuHeaderEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuHeaderEntry.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+
+package com.pajato.android.gamechat.common.adapter;
+
+/**
+ * Provide a POJO to encapsulate a menu header to be added to a recycler view.
+ *
+ * @author Paul Michael Reilly
+ */
+class MenuHeaderEntry {
+
+    // Public instance variables.
+
+    /** The menu header title resource id. */
+    int titleResId;
+
+    // Public constructors.
+
+    /** Build an instance for the given title and icon. */
+    public MenuHeaderEntry(final int titleResId) {
+        this.titleResId = titleResId;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.common.adapter;
+
+/**
+ * Provide a POJO to encapsulate a menu item to be added to a recycler view.
+ *
+ * @author Paul Michael Reilly
+ */
+public class MenuItemEntry {
+
+    // Public instance variables.
+
+    /** The menu item icon resource id. */
+    int iconResId;
+
+    /** The menu item title resource id. */
+    int titleResId;
+
+    /** The menu item icon url. */
+    String url;
+
+    // Public constructors.
+
+    /** Build an instance for the given title and icon. */
+    public MenuItemEntry(final int titleResId, final String url) {
+        this.titleResId = titleResId;
+        this.url = url;
+    }
+
+    /** Build an instance for the given title and icon resource id. */
+    public MenuItemEntry(final int titleResId, final int iconResId) {
+        this.titleResId = titleResId;
+        this.iconResId = iconResId;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/event/TagClickEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/TagClickEvent.java
@@ -20,11 +20,11 @@ package com.pajato.android.gamechat.event;
 import android.view.View;
 
 /**
- * Provides a button click data model class for the tic-tac-toe game..
+ * Provides a button click data model class where the payload is in the view tag field.
  *
  * @author Paul Michael Reilly
  */
-public class TileClickEvent {
+public class TagClickEvent {
 
     // Private instance variables.
 
@@ -34,7 +34,7 @@ public class TileClickEvent {
     // Public constructors.
 
     /** Build the event with the given view. */
-    public TileClickEvent(final View view) {
+    public TagClickEvent(final View view) {
         this.view = view;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -50,7 +50,7 @@ public class CheckersFragment extends BaseGameFragment {
         mTurn = true;
         onNewGame();
 
-        getActivity().findViewById(R.id.games_fab).setVisibility(View.VISIBLE);
+        getActivity().findViewById(R.id.gameFab).setVisibility(View.VISIBLE);
 
         // Color the turn tiles.
         ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player_1_icon);

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -55,7 +55,7 @@ public class ChessFragment extends BaseGameFragment {
         onNewGame();
 
         // Return the FAB to Visibility
-        getActivity().findViewById(R.id.games_fab).setVisibility(View.VISIBLE);
+        getActivity().findViewById(R.id.gameFab).setVisibility(View.VISIBLE);
 
         // Color the Player Icons.
         ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player_1_icon);

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -25,11 +25,16 @@ import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.adapter.MenuItemEntry;
+import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.TileClickEvent;
+import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.pajato.android.gamechat.game.Game.checkers;
 import static com.pajato.android.gamechat.game.Game.chess;
@@ -44,48 +49,53 @@ import static com.pajato.android.gamechat.game.GameManager.SETTINGS_INDEX;
  */
 public class GameFragment extends BaseGameFragment {
 
+    // Public constants.
+
+    /** The lookup key for the FAB game home memu. */
+    public static final String GAME_HOME_FAM_KEY = "gameHomeFamKey";
+
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void buttonClickHandler(final ClickEvent event) {
         // Grab the View ID and the floating action button and dimmer views.
         View view = event.view;
+        String title = null;
+        Game game = null;
         switch (view.getId()) {
             case R.id.IconTicTacToe:
-            case R.id.init_ttt:
-            case R.id.init_ttt_button:
+            case R.mipmap.ic_tictactoe_red:
                 // When a button is clicked, send a new game and reset the fab menu and background
                 // dimmer.
-                String title = getString(R.string.new_game_ttt);
-                GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, ttt);
-                FabManager.game.dismissMenu(this);
+                title = getString(R.string.new_game_ttt);
+                game = ttt;
                 break;
             case R.id.IconCheckers:
-            case R.id.init_checkers:
-            case R.id.init_checkers_button:
+            case R.mipmap.ic_checkers:
                 // Do it for checkers.
                 title = getString(R.string.new_game_checkers);
-                GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, checkers);
-                FabManager.game.dismissMenu(this);
+                game = checkers;
                 break;
             case R.id.IconChess:
-            case R.id.init_chess:
-            case R.id.init_chess_button:
+            case R.mipmap.ic_chess:
                 // Do it for chess.
                 title = getString(R.string.new_game_chess);
-                GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, chess);
-                FabManager.game.dismissMenu(this);
+                game = chess;
                 break;
-            case R.id.init_rooms:
-            case R.id.init_rooms_button:
+            case R.drawable.ic_casino_black_24dp:
                 // And do it for the rooms option buttons.
-                GameManager.instance.sendNewGame(NO_GAMES_INDEX, getActivity());
+                showFutureFeatureMessage(R.string.FutureSelectRooms);
                 FabManager.game.dismissMenu(this);
                 break;
-            case R.id.games_fab:
+            case R.id.gameFab:
                 // If the click is on the fab, we have to handle if it's open or closed.
                 FabManager.game.toggle(this);
                 break;
             default:
                 break;
+        }
+
+        if (title != null && game != null) {
+            GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, game);
+            FabManager.game.dismissMenu(this);
         }
     }
 
@@ -93,7 +103,7 @@ public class GameFragment extends BaseGameFragment {
     @Override public int getLayout() {return R.layout.fragment_game;}
 
     /** Handle a tile click event by sending a message to the current tic-tac-toe fragment. */
-    @Subscribe public void onClick(final TileClickEvent event) {
+    @Subscribe public void onClick(final TagClickEvent event) {
         int index = GameManager.instance.getCurrent();
         if (index == GameManager.TTT_LOCAL_INDEX || index == GameManager.TTT_ONLINE_INDEX) {
             String msg = GameManager.instance.getTurn() + "\n" + event.view.getTag().toString();
@@ -113,7 +123,8 @@ public class GameFragment extends BaseGameFragment {
         super.onInitialize();
         mGame = null;
         GameManager.instance.init(getActivity());
-        FabManager.game.init(mLayout, this.getTag());
+        FabManager.game.setTag(this.getTag());
+        FabManager.game.setMenu(GAME_HOME_FAM_KEY, getHomeMenu());
     }
 
     /** Handle a menu item selection. */
@@ -139,4 +150,17 @@ public class GameFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    // Private instance methods.
+
+    /** Return the home FAM used in the top level show games and show no games fragments. */
+    private List<MenuEntry> getHomeMenu() {
+        List<MenuEntry> menu = new ArrayList<>();
+        final int tttIconResId = R.mipmap.ic_tictactoe_red;
+        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayTicTacToe, tttIconResId)));
+        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayCheckers, R.mipmap.ic_checkers)));
+        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayChess, R.mipmap.ic_chess)));
+        final int gotoRoomsIconResId = R.drawable.ic_casino_black_24dp;
+        menu.add(new MenuEntry(new MenuItemEntry(R.string.GoToRooms, gotoRoomsIconResId)));
+        return menu;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -72,7 +72,7 @@ public class LocalTTTFragment extends BaseGameFragment {
         mSpace = getString(R.string.spaceValue);
         turnCount = 0;
 
-        getActivity().findViewById(R.id.games_fab).setVisibility(View.GONE);
+        getActivity().findViewById(R.id.gameFab).setVisibility(View.GONE);
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {

--- a/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
@@ -80,7 +80,7 @@ public class SettingsFragment extends BaseGameFragment {
     @Override public void onResume() {
         // Hide the FAB and set the title string and the icon source.
         super.onResume();
-        getActivity().findViewById(R.id.games_fab).setVisibility(View.GONE);
+        getActivity().findViewById(R.id.gameFab).setVisibility(View.GONE);
         TextView title = (TextView) mLayout.findViewById(R.id.settings_title);
         title.setText(mGame != null ? mGame.titleResId : R.string.GameError);
         ImageButton icon = (ImageButton) mLayout.findViewById(R.id.settings_icon);

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java
@@ -23,6 +23,8 @@ import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import static com.pajato.android.gamechat.game.GameFragment.GAME_HOME_FAM_KEY;
+
 public class ShowNoGamesFragment extends BaseGameFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
@@ -41,4 +43,9 @@ public class ShowNoGamesFragment extends BaseGameFragment {
         FabManager.game.init(this);
     }
 
+    /** Reset the FAM to use the game home menu. */
+    @Override public void onResume() {
+        super.onResume();
+        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -78,7 +78,7 @@ public class TTTFragment extends BaseGameFragment {
         mSpace = getString(R.string.spaceValue);
         mTurn = true;
 
-        getActivity().findViewById(R.id.games_fab).setVisibility(View.VISIBLE);
+        getActivity().findViewById(R.id.gameFab).setVisibility(View.VISIBLE);
 
         // Setup our Firebase database reference and a listener to keep track of the board.
         Firebase.setAndroidContext(getContext());

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -38,7 +38,7 @@ import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
-import com.pajato.android.gamechat.event.TileClickEvent;
+import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -154,7 +154,7 @@ public class MainActivity extends BaseActivity
      */
     public void onTileClick(final View view) {
         // Post this event to the game fragment via the app event manager.
-        AppEventManager.instance.post(new TileClickEvent(view));
+        AppEventManager.instance.post(new TagClickEvent(view));
     }
 
     // Protected instance methods

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -32,68 +32,16 @@ http://www.gnu.org/licenses
         android:id="@+id/gameDimmer"
         tools:visibility="visible"/>
 
-    <LinearLayout style="@style/FabMenu"
-        android:id="@+id/games_fab_menu"
+    <FrameLayout style="@style/FabMenu"
+        android:layout_marginBottom="8dp"
+        android:id="@+id/gameFabMenu"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/games_fab">
-
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/init_ttt"
-            android:gravity="end">
-
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/init_ttt_button"
-                android:text="@string/PlayTicTacToe"/>
-
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/PlayTicTacToe"
-                android:src="@drawable/ic_casino_black_24dp"/>
-
-        </LinearLayout>
-
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/init_checkers"
-            android:gravity="end">
-
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/init_checkers_button"
-                android:text="@string/PlayCheckers"/>
-
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/PlayCheckers"
-                android:src="@drawable/ic_casino_black_24dp"/>
-
-        </LinearLayout>
-
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/init_chess"
-            android:gravity="end">
-
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/init_chess_button"
-                android:text="@string/PlayChess"/>
-
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/PlayChess"
-                android:src="@drawable/ic_casino_black_24dp"/>
-
-        </LinearLayout>
-
-        <LinearLayout style="@style/FabMenuItem"
-            android:id="@+id/init_rooms"
-            android:gravity="end">
-
-            <Button style="@style/FabMenuButton"
-                android:id="@+id/init_rooms_button"
-                android:text="@string/go_to_rooms"/>
-
-            <ImageView style="@style/FabMenuIcon"
-                android:contentDescription="@string/PlayChess"
-                android:src="@drawable/ic_casino_black_24dp"/>
-
-        </LinearLayout>
-
-    </LinearLayout>
+        app:layout_constraintBottom_toTopOf="@+id/gameFab">
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/gameList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </FrameLayout>
 
     <android.support.design.widget.FloatingActionButton
         android:layout_width="wrap_content"
@@ -101,7 +49,7 @@ http://www.gnu.org/licenses
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
         android:gravity="bottom|start"
-        android:id="@+id/games_fab"
+        android:id="@+id/gameFab"
         android:src="@drawable/ic_add_white_24dp"
         android:onClick="onClick"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -14,21 +14,21 @@ Public License for more details.
 
 You should have received a copy of the GNU General Public License along with GameChat.  If not, see
 http://www.gnu.org/licenses
-
-Sign in icon (Login Rounded Right) courtesy of: https://icons8.com
 -->
-<LinearLayout style="@style/HeaderTheme"
+<LinearLayout style="@style/FabMenuItem"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-    <TextView
-        android:id="@+id/header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        android:textStyle="bold"
-        tools:text="Header Title"/>
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_gravity="end"
+    android:orientation="horizontal">
+    <View
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_weight="1.0" />
+    <Button style="@style/FabMenuButton"
+        android:id="@+id/menuItemTitle"
+        tools:text="Play Chess"/>
+    <ImageView style="@style/GameMenuIcon"
+        android:id="@+id/menuItemIcon"
+        android:contentDescription="@string/MenuIconDesc"
+        tools:src="@mipmap/ic_chess" />
 </LinearLayout>

--- a/app/src/main/res/menu/game_menu.xml
+++ b/app/src/main/res/menu/game_menu.xml
@@ -9,7 +9,7 @@
         android:orderInCategory="0"/>
     <item
         android:id="@+id/options_menu_new_game"
-        android:title="@string/go_to_rooms"
+        android:title="@string/GoToRooms"
         app:showAsAction="never"
         android:orderInCategory="10" />
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,5 +9,4 @@
     <color name="colorGray">#616161</color>
     <color name="colorLightGray">#cfd8dc</color>
     <color name="colorLightBlue">#e0f2f1</color>
-    <color name="colorLightPurple">#b388ff</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="arrow_left"><![CDATA[<]]></string>
     <string name="arrow_right"><![CDATA[>]]></string>
     <string name="banner_ad_unit_id" translatable="false">ca-app-pub-3940256099942544/6300978111</string>
-    <string name="go_to_rooms">Go to My Rooms</string>
     <string name="menuItemTitleLearnMore">Learn More</string>
     <string name="menuItemTitleFeedback">Feedback</string>
     <string name="manage_accounts">Manage Accounts</string>

--- a/app/src/main/res/values/strings_game.xml
+++ b/app/src/main/res/values/strings_game.xml
@@ -3,8 +3,11 @@
     <string name="ChessImageDesc">Chess image.</string>
     <string name="FutureCheckers">Checkers online and against the computer </string>
     <string name="FutureChess">Chess online and against the computer </string>
+    <string name="FutureSelectRooms">Select rooms</string>
     <string name="FutureTTT">TicTacToe vs the computer </string>
     <string name="GameError">Invalid Game</string>
+    <string name="GoToRooms">Go to My Games</string>
+    <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="NewGame">New Game</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="PlayAgain">Play Again!</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -42,7 +42,7 @@ http://www.gnu.org/licenses
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <style name="DateHeaderTheme">
+    <style name="HeaderTheme">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:background">@color/colorLightGray</item>
@@ -59,11 +59,9 @@ http://www.gnu.org/licenses
     </style>
 
     <style name="FabMenuItem">
-        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">48dp</item>
         <item name="android:layout_marginBottom">8dp</item>
-        <item name="android:orientation">horizontal</item>
-        <item name="android:onClick">onClick</item>
     </style>
 
     <style name="FabMenuButton">
@@ -80,6 +78,12 @@ http://www.gnu.org/licenses
         <item name="android:layout_height">48dp</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:tint">@color/colorPrimaryDark</item>
+    </style>
+
+    <style name="GameMenuIcon">
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:layout_gravity">center</item>
     </style>
 
     <style name="RoomsIcon">


### PR DESCRIPTION
<h1>Rationale:</h1>

Analysing the on-line game configuration, it is clear that a more powerful Floating Action Menu (FAM) capability is required. The ability to replace and restore an entire menu.  This commit provides such a feature by using a list (recycler) view to provide menu items rather than using a hard coded layout.  The fab manager caches these menus for easy replace and restore.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/game/CheckersTest.java
modified:   app/src/androidTest/java/com/pajato/android/gamechat/game/ChessTest.java
modified:   app/src/androidTest/java/com/pajato/android/gamechat/game/GameTest.java
modified:   app/src/androidTest/java/com/pajato/android/gamechat/game/TTTTest.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/SettingsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- Replace R.id.games_fab with R.id.gameFab.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- init(): Rename one of the overloaded init methods to setTag().

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- Summary: apply RNF to move a few methods around; canonicalize the naming to Chat style; provide FAM support.
- game: replace parameters with names using the Chat style.
- mMemuMap: provide a map to cache floating action menus.
- setMenu(): new overloaded methods to register and reset a FAM.
- getView(): rename to getGameFragmentLayout() for clarity; tighten up the code a bit by using an error log abstraction.
- init(): Rename one of the overloaded init methods to setTag().
- logError(): A new procedural abstraction to handle error logging.

new file:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
new file:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java
new file:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuHeaderEntry.java
new file:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java
new file:   app/src/main/res/layout/item_menu.xml

- New files supporting a FAM abstraction.

renamed:    app/src/main/java/com/pajato/android/gamechat/event/TileClickEvent.java -> app/src/main/java/com/pajato/android/gamechat/event/TagClickEvent.java

- Seemed like a good idea at the time.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- Summary: Overhaul for the new FAM abstraction.
- buttonClickHandler(): tighten up a bit and use a contrived id to switch on FAM entries.
- onInitialize(): use the new FabManager APIs to set the envelope fragment tag and the home FAB.
- getHomeMenu(): new method to provide the first general FAM.

modified:   app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java

- onResume(): new method to provide FAM initialization during fragment lifecycle events.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onTileClick(): use the renamed TagClickEvent() method.

modified:   app/src/main/res/layout/fragment_game.xml

- Switch to using a recycler list view to provide a FAM abstraction.

modified:   app/src/main/res/layout/item_header.xml

- Use the renamed HeaderTheme.

modified:   app/src/main/res/menu/game_menu.xml

- Use the renamed (but still poor) GoToRooms.

modified:   app/src/main/res/values/colors.xml

- Lose light purple as it is no longer used.

modified:   app/src/main/res/values/strings.xml

- Move the goto rooms string to strings_game.xml.

modified:   app/src/main/res/values/strings_game.xml

- FutureSelectRooms, GoToRooms, MenuIconDesc: new resources.

modified:   app/src/main/res/values/styles.xml

- DateHeaderTheme: renamed to HeaderTheme.
- FabMenuItem: adapt to the new FAM abstraction.
- GameMenuIcon: new style to deal with not using tint on mipmap resources.