### PR TITLE
Start losing the settings fragment.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -14,6 +14,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -40,8 +43,13 @@ public class CheckersFragment extends BaseGameFragment {
     private boolean mIsHighlighted = false;
     private ArrayList<Integer> mPossibleMoves;
 
+    // Public instance methods.
+
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_checkers;}
+
+    /** Handle button clicks ... placeholder. */
+    @Subscribe public void onClick(final ClickEvent event) {}
 
     @Override public void onInitialize() {
         super.onInitialize();

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -15,6 +15,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.Scanner;
@@ -43,8 +46,13 @@ public class ChessFragment extends BaseGameFragment {
     private boolean mSecondaryKingSideRookHasMoved;
     private boolean mSecondaryKingHasMoved;
 
+    // Public instance methods.
+
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_checkers;}
+
+    /** Handle button clicks ... placeholder. */
+    @Subscribe public void onClick(final ClickEvent event) {}
 
     @Override public void onInitialize() {
         // Setup the board and start a new game to create the board.

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -94,7 +94,7 @@ public class GameFragment extends BaseGameFragment {
         }
 
         if (title != null && game != null) {
-            GameManager.instance.sendNewGame(SETTINGS_INDEX, getActivity(), title, game);
+            GameManager.instance.sendNewGame(game, getActivity(), title);
             FabManager.game.dismissMenu(this);
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -154,6 +154,12 @@ enum GameManager {
     }
 
     /** Return TRUE iff the given fragment is running in the experience panel. */
+    public boolean sendNewGame(final Game game, final FragmentActivity context, final String msg) {
+        int index = game.localFragmentIndex;
+        return sendNewGame(index, context, msg, game);
+    }
+
+    /** Return TRUE iff the given fragment is running in the experience panel. */
     public boolean sendNewGame(final int index, final FragmentActivity context, final String msg,
                                final Game game) {
         instructions.clear();
@@ -173,9 +179,6 @@ enum GameManager {
             // If our fragment doesn't exist yet, construct it.
             if (mFragmentList[index] == null) {
                 switch (index) {
-                    case SETTINGS_INDEX:
-                        mFragmentList[SETTINGS_INDEX] = new SettingsFragment();
-                        break;
                     case TTT_LOCAL_INDEX:
                         mFragmentList[TTT_LOCAL_INDEX] = new LocalTTTFragment();
                         break;

--- a/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java
@@ -71,8 +71,6 @@ public class LocalTTTFragment extends BaseGameFragment {
         mOValue = getString(R.string.oValue);
         mSpace = getString(R.string.spaceValue);
         turnCount = 0;
-
-        getActivity().findViewById(R.id.gameFab).setVisibility(View.GONE);
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {

--- a/app/src/main/res/layout/fragment_ttt.xml
+++ b/app/src/main/res/layout/fragment_ttt.xml
@@ -30,8 +30,8 @@ http://www.gnu.org/licenses
         android:id="@+id/winner"
         android:visibility="invisible"
 
-        app:layout_constraintTop_toBottomOf="@+id/board"
-        android:layout_marginTop="32dp"
+        app:layout_constraintBottom_toTopOf="@+id/board"
+        android:layout_marginBottom="48dp"
         app:layout_constraintRight_toLeftOf="@+id/ttt_panel"
         app:layout_constraintLeft_toRightOf="@+id/ttt_panel"/>
 


### PR DESCRIPTION
<h1>Rationale:</h1>

Going from the game home screen to a new online game is tedious. The User first selects a game, then selects a game mode, then configures the mode, then gets to see a game board and actually play.  Instead, GameChat is moving toward having the User select a game and immediately being presented with a board in local mode.  From this board the User can either change the mode using the FAM or via a long press on the text field showing "friend".   This commit begins the move to this model by starting to remove the settings fragment.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java

- onClick(): add a placeholder app event bus subscription to prevent an event bus crash.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- buttonClickHandler(): use a new, overloaded, sendNewGame() method to go directly to the game of choice.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameManager.java

- sendNewGame(): new (overloaded) method to move directly to a game and bypass the settings fragment.

modified:   app/src/main/java/com/pajato/android/gamechat/game/LocalTTTFragment.java

- onInitialize(): do not hide the FAB.

modified:   app/src/main/res/layout/fragment_ttt.xml

- Move the player status to the top so that the FAB is not interfering.