### PR TITLE
Fix the Game menu title clicking.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
@@ -83,7 +83,7 @@ public class MenuAdapter extends RecyclerView.Adapter<ViewHolder> implements Vie
     }
 
     /** Post any item clicks to the app. */
-    public void onClick(final View view) {
+    @Override public void onClick(final View view) {
         view.setId((Integer) view.getTag());
         AppEventManager.instance.post(new ClickEvent(view));
     }
@@ -119,8 +119,12 @@ public class MenuAdapter extends RecyclerView.Adapter<ViewHolder> implements Vie
 
     /** Obtain a view by inflating the given resource id. */
     private View getView(final ViewGroup parent, final int resourceId) {
+        // Inflate the entry view and set the click handlers for the fields.
         View result = LayoutInflater.from(parent.getContext()).inflate(resourceId, parent, false);
-        result.setOnClickListener(this);
+        View view = result.findViewById(R.id.menuItemTitle);
+        if (view != null) view.setOnClickListener(this);
+        view = result.findViewById(R.id.menuItemIcon);
+        if (view != null) view.setOnClickListener(this);
 
         return result;
     }
@@ -144,11 +148,14 @@ public class MenuAdapter extends RecyclerView.Adapter<ViewHolder> implements Vie
 
     /** Update the given view holder using the data from the given entry. */
     private void updateMenuItemHolder(final MenuItemViewHolder holder, final MenuEntry entry) {
-        // Set the text on the holder and put the entry on the item view tag..
+        // Set the text on the holder and put the entry on the item layout, title and icon view
+        // tags.
         Context context = holder.title.getContext();
         String text = context.getString(entry.titleResId);
         holder.title.setText(Html.fromHtml(text));
         holder.itemView.setTag(entry.iconResId);
+        holder.title.setTag(entry.iconResId);
+        holder.icon.setTag(entry.iconResId);
 
         // Set the icon on the holder.
         if (loadUrl(holder, entry)) return;

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -151,15 +151,18 @@ public class GameFragment extends BaseGameFragment {
 
     // Private instance methods.
 
+    /** Return a menu entry for with given title and icon resource items. */
+    private MenuEntry getEntry(final int titleId, final int iconId) {
+        return new MenuEntry(new MenuItemEntry(titleId, iconId));
+    }
+
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getHomeMenu() {
         List<MenuEntry> menu = new ArrayList<>();
-        final int tttIconResId = R.mipmap.ic_tictactoe_red;
-        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayTicTacToe, tttIconResId)));
-        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayCheckers, R.mipmap.ic_checkers)));
-        menu.add(new MenuEntry(new MenuItemEntry(R.string.PlayChess, R.mipmap.ic_chess)));
-        final int gotoRoomsIconResId = R.drawable.ic_casino_black_24dp;
-        menu.add(new MenuEntry(new MenuItemEntry(R.string.GoToRooms, gotoRoomsIconResId)));
+        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red));
+        menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers));
+        menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess));
+        menu.add(getEntry(R.string.Home, R.drawable.ic_casino_black_24dp));
         return menu;
     }
 }

--- a/app/src/main/res/menu/game_menu.xml
+++ b/app/src/main/res/menu/game_menu.xml
@@ -9,7 +9,7 @@
         android:orderInCategory="0"/>
     <item
         android:id="@+id/options_menu_new_game"
-        android:title="@string/GoToRooms"
+        android:title="@string/Home"
         app:showAsAction="never"
         android:orderInCategory="10" />
 </menu>

--- a/app/src/main/res/values/strings_game.xml
+++ b/app/src/main/res/values/strings_game.xml
@@ -5,7 +5,7 @@
     <string name="FutureChess">Chess online and against the computer </string>
     <string name="FutureSelectRooms">Select rooms</string>
     <string name="FutureTTT">TicTacToe vs the computer </string>
-    <string name="GoToRooms">Go to My Games</string>
+    <string name="Home">Go to My Games</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="NewGame">New Game</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -67,10 +67,9 @@ http://www.gnu.org/licenses
     <style name="FabMenuButton">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:onClick">onClick</item>
     </style>
 
     <style name="FabMenuIcon">


### PR DESCRIPTION
<h1>Rationale:</h1>

When clicking on the menu title button, the item does not trigger.  I am not sure why, but I am sure that putting an onclick handler on both the icon and the button does work so this commit provides that fix.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java

- onClick(): add an override, just to be on the safe side.
- getView(): put onclick listeners on the title button and on the icon.
- updateMenuItemHolder(): update the tag values on the title button and icon as well as the layout view.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- getEntry(), getHomeMenu(): simplify and get ready to apply the FAM implementation to chat.

modified:   app/src/main/res/menu/game_menu.xml
modified:   app/src/main/res/values/strings_game.xml

- GoToRooms: change the key to Home.

modified:   app/src/main/res/values/styles.xml

- FabMenuButton: decrease the space between the button and the icon a bit.