### PR TITLE
Introduce an experience profile watcher.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -29,7 +29,6 @@ import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.InvitationManager;
-import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.event.AccountStateChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
@@ -128,16 +127,6 @@ public class ChatFragment extends BaseChatFragment {
         if (event.joinedRoomList.size() == 0) {
             // Handle the case where there are no joined rooms by enabling the no rooms message.
             ChatManager.instance.replaceFragment(showNoJoinedRooms, this.getActivity());
-        } else {
-            // Handle a joined rooms change by setting up database watchers on the messages in each
-            // room.
-            for (String joinedRoom : event.joinedRoomList) {
-                // Set up the database watcher on this list.
-                String[] split = joinedRoom.split(" ");
-                String groupKey = split[0];
-                String roomKey = split[1];
-                DatabaseListManager.instance.setMessageWatcher(groupKey, roomKey);
-            }
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
@@ -57,7 +57,7 @@ public enum DatabaseManager {
     private static final String JOINED_ROOM_LIST_PATH = ACCOUNT_PATH + "joinedRoomList";
     private static final String ROOMS_PATH = GROUPS_PATH + "%s/rooms/";
     private static final String ROOM_PROFILE_PATH = ROOMS_PATH + "%s/profile/";
-    //private static final String EXPERIENCES_PATH = ROOMS_PATH + "%s/exps";
+    private static final String EXP_PROFILE_PATH = ROOMS_PATH + "/exp/profiles/";
     private static final String MESSAGES_PATH = ROOMS_PATH + "%s/messages/";
     private static final String MESSAGE_PATH = MESSAGES_PATH + "%s/";
     private static final String UNREAD_LIST_PATH = MESSAGES_PATH + "%s/unreadList";
@@ -152,6 +152,11 @@ public enum DatabaseManager {
         String profilePath = String.format(Locale.US, ROOM_PROFILE_PATH, groupKey, roomKey);
         room.createTime = new Date().getTime();
         updateChildren(profilePath, room.toMap());
+    }
+
+    /** Return the database path to a experience profile for a given room and profile key. */
+    public String getExpProfilePath(final String groupKey, final String roomKey) {
+        return String.format(Locale.US, EXP_PROFILE_PATH, groupKey, roomKey);
     }
 
     /** Return a room push key to use with a subsequent room object persistence. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileChangeHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.database.handler;
+
+import android.util.Log;
+
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.database.DatabaseListManager;
+import com.pajato.android.gamechat.database.DatabaseManager;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.game.event.ExpProfileChangeEvent;
+import com.pajato.android.gamechat.game.model.ExpProfile;
+
+import java.util.Locale;
+
+import static com.pajato.android.gamechat.database.DatabaseListManager.ChatListType.room;
+import static com.pajato.android.gamechat.event.MessageChangeEvent.CHANGED;
+import static com.pajato.android.gamechat.event.MessageChangeEvent.MOVED;
+import static com.pajato.android.gamechat.event.MessageChangeEvent.NEW;
+import static com.pajato.android.gamechat.event.MessageChangeEvent.REMOVED;
+
+/**
+ * Provide a class to handle new and changed experiences inside a group and room.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ExpProfileChangeHandler extends DatabaseEventHandler implements ChildEventListener {
+
+    /** The logcat format string. */
+    private static final String LOG_FORMAT = "%s: {%s, %s}.";
+
+    /** The logcat TAG. */
+    private static final String TAG = ExpProfileChangeHandler.class.getSimpleName();
+
+    // Public constructors.
+
+    /** Build a handler with the given name and path. */
+    public ExpProfileChangeHandler(final String name, final String groupKey, final String roomKey) {
+        super(name, DatabaseManager.instance.getExpProfilePath(groupKey, roomKey));
+    }
+
+    /** Deal with a new message. */
+    @Override public void onChildAdded(DataSnapshot dataSnapshot, String s) {
+        // Log the event and determine if the data snapshot exists, aborting if it does not.
+        Log.d(TAG, String.format(Locale.US, LOG_FORMAT, "onChildAdded", dataSnapshot, s));
+        process(dataSnapshot, NEW);
+    }
+
+    /** Deal with a change in an existing message. */
+    @Override public void onChildChanged(DataSnapshot dataSnapshot, String s) {
+        Log.d(TAG, String.format(Locale.US, LOG_FORMAT, "onChildChanged", dataSnapshot, s));
+        process(dataSnapshot, CHANGED);
+    }
+
+    @Override public void onChildRemoved(DataSnapshot dataSnapshot) {
+        Log.d(TAG, String.format(Locale.US, LOG_FORMAT, "onChildRemoved", dataSnapshot, null));
+        process(dataSnapshot, REMOVED);
+    }
+
+    @Override public void onChildMoved(DataSnapshot dataSnapshot, String s) {
+        Log.d(TAG, String.format(Locale.US, LOG_FORMAT, "onChildMoved", dataSnapshot, s));
+        if (!dataSnapshot.exists()) return;
+        process(dataSnapshot, MOVED);
+    }
+
+    /** ... */
+    @Override public void onCancelled(DatabaseError error) {
+        // Failed to read value
+        Log.w(TAG, "Failed to read value.", error.toException());
+    }
+
+    // Private instance methods.
+
+    /** Process the change by updating the database list and notifying the app. */
+    private void process(final DataSnapshot snapshot, final int type) {
+        // Abort if the data snapshot does not exist.
+        if (!snapshot.exists()) return;
+
+        // A snapshot exists.  Extract the experience profile from it and handle it based on the
+        // change type. Finally notify the app of the change.
+        ExpProfile expProfile = snapshot.getValue(ExpProfile.class);
+        switch (type) {
+            case NEW:
+            case CHANGED:
+                // Update the database list experience profile map by adding or replacing the entry.
+                DatabaseListManager.instance.expProfileMap.put(expProfile.key, expProfile);
+                break;
+            case REMOVED:
+                // Update the database list experience profile map by removing the entry (key).
+                DatabaseListManager.instance.expProfileMap.put(expProfile.key, expProfile);
+                break;
+            case MOVED:
+            default:
+                // Not sure what a moved change means or what to do about it, so do nothing.
+                break;
+        }
+        AppEventManager.instance.post(new ExpProfileChangeEvent(expProfile, type));
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/event/ExpProfileChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/event/ExpProfileChangeEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.game.event;
+
+import com.pajato.android.gamechat.game.model.ExpProfile;
+
+/**
+ * Provides a class to model an experience profile change.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ExpProfileChangeEvent {
+
+    // Public instance variables.
+
+    /** The experience profile changed. */
+    public ExpProfile expProfile;
+
+    /** The chagen type, one of new, changed, removed or moved. */
+    public int type;
+
+    // Public constructor.
+
+    /** Build an instance with a given room, experience profile and change type. */
+    public ExpProfileChangeEvent(final ExpProfile expProfile, final int type) {
+        this.expProfile = expProfile;
+        this.type = type;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.game.model;
+
+import com.google.firebase.database.Exclude;
+import com.google.firebase.database.IgnoreExtraProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provide a Firebase model class repesenting an experience profile: a key to the full experience, a
+ * display name for displaying to the User and an experience type, an integer denoting tictactoe,
+ * chess or checkers, for example.
+ *
+ * @author Paul Michael Reilly
+ */
+@IgnoreExtraProperties
+public class ExpProfile {
+
+    /** The experience key. */
+    public String key;
+
+    /** The experience's display name. */
+    public String name;
+
+    /** The experience type value. */
+    public int type;
+
+    // Public constructors.
+
+    /** Build an empty args constructor for the database. */
+    public ExpProfile() {}
+
+    /** Build a default TicTacToe using all the parameters. */
+    public ExpProfile(final String key, final String name, final int type) {
+        this.key = key;
+        this.name = name;
+        this.type = type;
+    }
+
+    /** Provide a default map for a Firebase create/update. */
+    @Exclude public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("key", key);
+        result.put("name", name);
+        result.put("type", type);
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit introduces the experience database artifacts.  First up is an experience profile watcher.  Some minor refactoring has also been done based on the experience profile watcher.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- onJoinedRoomListChange(): move the message watcher setup to the DatabaseListManager.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- Summary: introduce experience listeners; lots of RNF.
- onJoinedRoomListChange(): do main watcher setup here; tighten up the code using procedural abstractions.
- setExpProfileWatcher(): support experience listeners.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- getExpProfilePath(): new method starting support for experiences.

new file:   app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileChangeHandler.java
new file:   app/src/main/java/com/pajato/android/gamechat/game/event/ExpProfileChangeEvent.java
new file:   app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java

- New files supporting the experience profile watchers.