### PR TITLE
Move the TicTacToe experience in the database.

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,19 @@
+Short Term Issues needing resolution.  Longer term itesm should be logged on GitHub.
+
+- Revive the connected tests towards an end of having broken tests fixed and a > 90% coverage level, an ongoing task.
+- Determine if DatabaseManager#updateExperience() is needed or if the updateChildren() will work directly.
+- Do SVG homework in preparation to start replacing all PNG icons.
+- Automate bug reporting process as on overflow menu item.  Send reports to Pajato Support and to GitHub issues for GameChat.
+- Add member rooms to the room list screens.
+- Replace Chat FAM model with the new Experience one.
+- Move Chat fragments to a resume/pause registration model.
+- Make <experience> back press navigate to the optimal screen on the experience page.
+- Add long press context menus to player controls for experiences to provide alternative choices (computer, another user, a friend, change name, etc.)
+- Add a dynamic "goto" FAM option to quickly navigate to the optimal screen on the experience page.
+- Use SVG or Unicode chess and checkers pieces.
+- Address an AS warning for CheckersFragment#onNewGame().
+- Fix Chat sign out crock:
+  Signing out works OK but signing back in does not display the correct result in either the chat or experience pages.
+- Overhaul "Winner" notifications/animations starting with TicTacToe.
+- Add an icon (preferable SVG) to the sign in button on the signed out screen.
+- Provide complete entry in TAG for FAM.

--- a/app/src/main/java/com/pajato/android/gamechat/account/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/Account.java
@@ -84,6 +84,16 @@ import java.util.Map;
         return defaultName;
     }
 
+    /** Return the first (and possibly only) part of the display name or the given default. */
+    @Exclude public String getFirstName(final String defaultName) {
+        // Determine if there is a display name.  Use the default if not.
+        if (displayName == null) return defaultName;
+
+        // Use the first part of the display name.
+        String[] split = displayName.split(" ");
+        return split[0];
+    }
+
     /** Generate the map of data to persist into Firebase. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();

--- a/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
@@ -233,20 +233,20 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
         // Obtain the default room name, create the default room, update the group's room map and
         // add the group key to the account's group id list.
         String name = getString(R.string.DefaultRoomName);
-        Room room = new Room(null, mGroup.owner, name, groupKey, 0, 0, PUBLIC, null);
+        Room room = new Room(roomKey, mGroup.owner, name, groupKey, 0, 0, PUBLIC, null);
         mGroup.roomMap.put(name, roomKey);
         account.groupIdList.add(groupKey);
 
         // Persist the group and room to the database and update the account with the new joined
         // list entry.
-        DatabaseManager.instance.createGroupProfile(groupKey, mGroup);
-        DatabaseManager.instance.createRoomProfile(groupKey, roomKey, room);
+        DatabaseManager.instance.createGroupProfile(mGroup);
+        DatabaseManager.instance.createRoomProfile(room);
         DatabaseManager.instance.appendDefaultJoinedRoomEntry(account, mGroup);
         DatabaseManager.instance.updateAccount(account);
 
         // Post a welcome message to the default room from the owner.
         String text = "Welcome to my new group!";
-        DatabaseManager.instance.createMessage(text, STANDARD, account, groupKey, roomKey, room);
+        DatabaseManager.instance.createMessage(text, STANDARD, account, room);
     }
 
     /** Send email to the support address. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java
@@ -166,10 +166,9 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         // inform the User that the message has been sent.
         String text = editText.getText().toString();
         int type = STANDARD;
-        String groupKey = mItem.groupKey;
         String roomKey = mItem.roomKey;
         Room room = DatabaseListManager.instance.getRoomProfile(roomKey);
-        DatabaseManager.instance.createMessage(text, type, account, groupKey, roomKey, room);
+        DatabaseManager.instance.createMessage(text, type, account, room);
         editText.setText("");
         Snackbar.make(layout, "Message sent.", Snackbar.LENGTH_SHORT);
         hideSoftKeyBoard(view);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -28,10 +28,19 @@ import java.util.Map;
 /** Provide a Firebase model class for representing a chat room. */
 @IgnoreExtraProperties public class Room {
 
-    /** The room types. */
+    // The room types.
+
+    /** A room no one can join. */
     public final static int ME = 0;
+
+    /** A room in which only invited members may join. */
     public final static int PRIVATE = 1;
+
+    /** A room in which any User can join. */
     public final static int PUBLIC = 2;
+
+    /** A room in which only two members can exist (a direct room in Slack). */
+    public final static int USER = 3;
 
     /** The creation timestamp. */
     public long createTime;
@@ -61,7 +70,7 @@ import java.util.Map;
     public Room() {}
 
     /** Build a default room. */
-    public Room(final String key, final String owner, final String name, final String groupkey,
+    public Room(final String key, final String owner, final String name, final String groupKey,
                 final long createTime, final long modTime, final int type,
                 final List<String> members) {
         this.createTime = createTime;

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
@@ -28,6 +28,13 @@ import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.game.BaseGameFragment;
+import com.pajato.android.gamechat.game.Dispatcher;
+import com.pajato.android.gamechat.game.ExpType;
+import com.pajato.android.gamechat.game.Experience;
+import com.pajato.android.gamechat.game.model.ExpProfile;
+import com.pajato.android.gamechat.game.model.TicTacToe;
+import com.pajato.android.gamechat.main.NetworkManager;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -57,7 +64,10 @@ public enum DatabaseManager {
     private static final String JOINED_ROOM_LIST_PATH = ACCOUNT_PATH + "joinedRoomList";
     private static final String ROOMS_PATH = GROUPS_PATH + "%s/rooms/";
     private static final String ROOM_PROFILE_PATH = ROOMS_PATH + "%s/profile/";
-    private static final String EXP_PROFILE_PATH = ROOMS_PATH + "/exp/profiles/";
+    private static final String EXP_PROFILES_PATH = ROOMS_PATH + "%s/exp/profiles/";
+    private static final String EXP_PROFILE_PATH = EXP_PROFILES_PATH + "%s/";
+    private static final String EXPERIENCES_PATH = ROOMS_PATH + "%s/exp/experiences/";
+    private static final String EXPERIENCE_PATH = EXPERIENCES_PATH + "%s/";
     private static final String MESSAGES_PATH = ROOMS_PATH + "%s/messages/";
     private static final String MESSAGE_PATH = MESSAGES_PATH + "%s/";
     private static final String UNREAD_LIST_PATH = MESSAGES_PATH + "%s/unreadList";
@@ -119,22 +129,62 @@ public enum DatabaseManager {
 
         // Update the "me" room default message on the database.
         String text = "Welcome to your own private group and room.  Enjoy!";
-        createMessage(text, SYSTEM, account, groupKey, roomKey, room);
+        createMessage(text, SYSTEM, account, room);
+    }
+
+    /** Persist the given experience to the database. */
+    public Experience createExperience(final Experience experience) {
+        // Ensure that the requisite keys exist.  Abort if either key does not exist.
+        String groupKey = experience.getGroupKey();
+        String roomKey = experience.getRoomKey();
+        if (groupKey == null || roomKey == null) return null;
+
+        // Get the name and type for the given experience.  Abort if either does not exist.
+        String name = experience.getName();
+        int type = experience.getType();
+        if (name == null || type == -1) return null;
+
+        // Setup the keys to persist the experience profile and the experience.
+        String experiencesPath = String.format(Locale.US, EXPERIENCES_PATH, groupKey, roomKey);
+        String experienceKey = mDatabase.child(experiencesPath).push().getKey();
+        ExpProfile profile = new ExpProfile(experienceKey, name, type, groupKey, roomKey);
+        String expProfilesPath = String.format(Locale.US, EXP_PROFILES_PATH, groupKey, roomKey);
+        String profileKey = mDatabase.child(expProfilesPath).push().getKey();
+
+        // Create and persist first the experience profile object and then the experience object.
+        String path = String.format(Locale.US, EXP_PROFILE_PATH, groupKey, roomKey, profileKey);
+        updateChildren(path, profile.toMap());
+        path = String.format(Locale.US, EXPERIENCE_PATH, groupKey, roomKey, experienceKey);
+        experience.setExperienceKey(experienceKey);
+        updateExperience(path, experience);
+
+        // Cache both the profile and the experience then return the experience.
+        DatabaseListManager.instance.expProfileMap.put(profileKey, profile);
+        DatabaseListManager.instance.experienceMap.put(experienceKey, experience);
+        return experience;
     }
 
     /** Persist a given group object using the given key. */
-    public void createGroupProfile(final String groupKey, final Group group) {
-        String profilePath = String.format(Locale.US, GROUP_PROFILE_PATH, groupKey);
+    public void createGroupProfile(final Group group) {
+        // Ensure that a valid group key exists.  Abort quietly (for now) if not.
+        // TODO: do something about a null group key.
+        if (group.key == null) return;
+        String profilePath = String.format(Locale.US, GROUP_PROFILE_PATH, group.key);
         group.createTime = new Date().getTime();
         updateChildren(profilePath, group.toMap());
     }
 
     /** Persist a standard message (one sent from a standard user) to the database. */
     public void createMessage(final String text, final int type, @NonNull final Account account,
-                              final String groupKey, final String roomKey, final Room room) {
-        String path = String.format(Locale.US, MESSAGES_PATH, groupKey, roomKey);
+                              final Room room) {
+        // Ensure database consistency.  Abort quietly (for now) if any path parts are invalid.
+        // If the parts are valid, get a push key.
+        // TODO: say saomething about an onvalid path piece.
+        if (room.groupKey == null || room.key == null) return;
+        String path = String.format(Locale.US, MESSAGES_PATH, room.groupKey, room.key);
         String key = mDatabase.child(path).push().getKey();
-        String id = account.id;
+
+        // The room is valid.  Create the message.
         String systemName = mResourceMap.get(SYSTEM_NAME_KEY);
         String anonymousName = mResourceMap.get(ANONYMOUS_NAME_KEY);
         String name = type == SYSTEM ? systemName : account.getDisplayName(anonymousName);
@@ -142,21 +192,60 @@ public enum DatabaseManager {
         String url = type == SYSTEM ? systemUrl : account.url;
         long tstamp = new Date().getTime();
         List<String> members = room.memberIdList;
-        Message message = new Message(key, id, name, url, tstamp, 0, text, type, members);
-        path = String.format(Locale.US, MESSAGE_PATH, groupKey, roomKey, key);
+        Message message = new Message(key, account.id, name, url, tstamp, 0, text, type, members);
+
+        // Persist the message.
+        path = String.format(Locale.US, MESSAGE_PATH, room.groupKey, room.key, key);
         updateChildren(path, message.toMap());
     }
 
     /** Return a room push key resulting from persisting the given room on the database. */
-    public void createRoomProfile(final String groupKey, final String roomKey, final Room room) {
-        String profilePath = String.format(Locale.US, ROOM_PROFILE_PATH, groupKey, roomKey);
+    public void createRoomProfile(final Room room) {
+        // Ensure that a valid group key exists.  Abort quietly (for now) if not.
+        // TODO: do something about a null group key.
+        if (room.groupKey == null || room.key == null) return;
+        String profilePath = String.format(Locale.US, ROOM_PROFILE_PATH, room.groupKey, room.key);
         room.createTime = new Date().getTime();
         updateChildren(profilePath, room.toMap());
     }
 
+    /** Return an experience for a given dispatcher instance. */
+    public Experience getExperience(@NonNull final BaseGameFragment fragment,
+                                    @NonNull final Dispatcher dispatcher) {
+        // Use a cached, online experience if one is available.
+        String key = dispatcher.expKey;
+        if (key != null) return DatabaseListManager.instance.experienceMap.get(key);
+
+        // Use a cached, offline experience if one is available.
+        key = dispatcher.type.expType != null ? dispatcher.type.expType.name() : null;
+        Experience exp = key != null ? DatabaseListManager.instance.experienceMap.get(key) : null;
+        boolean offline = !NetworkManager.instance.isConnected();
+        if (offline && exp != null) return exp;
+
+        // Handle the case of a signed in User wanting to create a new game.
+        List<Account> players = getPlayers(dispatcher);
+        exp = fragment.getDefaultExperience(players);
+        boolean hasAccount = AccountManager.instance.hasAccount();
+        if (hasAccount && exp != null) return createExperience(exp);
+
+        // Lastly, if there is a valid key, use it to cache an offline experience.  Abort if no
+        // such key is available.
+        if (key == null  || exp == null) return null;
+        exp.setExperienceKey(key);
+        DatabaseListManager.instance.experienceMap.put(key, exp);
+        return exp;
+    }
+
+    /** Return the database path to an experience for a given experience profile. */
+    public String getExperiencePath(final ExpProfile profile) {
+        String groupKey = profile.groupKey;
+        String roomKey = profile.roomKey;
+        return String.format(Locale.US, EXPERIENCE_PATH, groupKey, roomKey, profile.key);
+    }
+
     /** Return the database path to a experience profile for a given room and profile key. */
-    public String getExpProfilePath(final String groupKey, final String roomKey) {
-        return String.format(Locale.US, EXP_PROFILE_PATH, groupKey, roomKey);
+    public String getExpProfilesPath(final String groupKey, final String roomKey) {
+        return String.format(Locale.US, EXP_PROFILES_PATH, groupKey, roomKey);
     }
 
     /** Return a room push key to use with a subsequent room object persistence. */
@@ -234,35 +323,50 @@ public enum DatabaseManager {
 
     // Private instance methods.
 
-    //private void hideAndFixMe() {
-        // TODO: Fix this to handle experiences.
-        // Setup our Firebase database reference and a listener to keep track of the board.
-        //Firebase.setAndroidContext(getContext());
-        //Firebase mRef = new Firebase(FIREBASE_URL);
-        //mRef.addValueEventListener(new ValueEventListener() {
+    /** Return a possibly null list of player information for a two participant experience. */
+    private List<Account> getPlayers(final Dispatcher dispatcher) {
+        // Determine if this is an offline experience in which no accounts are provided.
+        Account player1 = AccountManager.instance.getCurrentAccount();
+        if (player1 == null) return null;
 
-            /** Capture and replicate the board locally. */
-            //@Override public void onDataChange(DataSnapshot dataSnapshot) {
-                //GenericTypeIndicator<HashMap<String, Integer>> t =
-                //        new GenericTypeIndicator<HashMap<String, Integer>>() {};
-                //GenericTypeInicator<HashMap<String, Integer>> mLayoutMap = dataSnapshot.getValue(t);
-                // If there is a board to be had, fill our board out with it and adjust the turn.
-                //if (mLayoutMap != null) {
-                    //recreateExistingBoard();
-                    //checkNotFinished();
-                    //mTurn = (mLayoutMap.get(TURN_INDICATOR) == 1);
-                    //handlePlayerIcons(mTurn);
-                //} else {
-                //    mLayoutMap = new HashMap<>();
-                //}
-            //}
+        // This is an online experience.  Use the current signed in User as the first player.
+        List<Account> players = new ArrayList<>();
+        players.add(player1);
 
-            /** Deal with a canceled game. */
-            //@Override public void onCancelled(FirebaseError firebaseError) {
-            //    Log.e(TAG, "Error reading Firebase board data: " + firebaseError.toString());
-            //}
-        //});
+        // Determine the second account, if any, based on the room.
+        String key = dispatcher.roomKey;
+        Room room = key != null ? DatabaseListManager.instance.roomMap.get(key) : null;
+        int type = room != null ? room.type : -1;
+        switch (type) {
+            //case USER:
+                // Handle another User by providing their account.
+            //    break;
+            default:
+                // Only one online player.  Just return.
+                break;
+        }
 
-    //}
+        return players;
+    }
+
+    /** Update a given experience to the database by converting it to a concrete type. */
+    private void updateExperience(final String path, final Experience experience) {
+        // Case on the experience type to actually do the database update as the experience must be
+        // converted (cast) to a concreate class instead of an interface since Firebase uses
+        // reflection.
+        ExpType type = ExpType.values()[experience.getType()];
+        switch (type) {
+            case ttt:
+                // Update the database using the actual concreate experience class.
+                if (!(experience instanceof TicTacToe)) return;
+
+                // Update the database.
+                TicTacToe tictactoe = (TicTacToe) experience;
+                updateChildren(path, tictactoe.toMap());
+                break;
+            default:
+                break;
+        }
+    }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfilesChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfilesChangeHandler.java
@@ -22,40 +22,40 @@ import android.util.Log;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
-import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
-import com.pajato.android.gamechat.event.AppEventManager;
-import com.pajato.android.gamechat.game.event.ExpProfileChangeEvent;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.database.DatabaseListManager.ChatListType.room;
 import static com.pajato.android.gamechat.event.MessageChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.MessageChangeEvent.MOVED;
 import static com.pajato.android.gamechat.event.MessageChangeEvent.NEW;
 import static com.pajato.android.gamechat.event.MessageChangeEvent.REMOVED;
 
 /**
- * Provide a class to handle new and changed experiences inside a group and room.
+ * Provide a class to handle new and changed experience profiles inside a room.
  *
  * @author Paul Michael Reilly
  */
-public class ExpProfileChangeHandler extends DatabaseEventHandler implements ChildEventListener {
+public class ExpProfilesChangeHandler extends DatabaseEventHandler implements ChildEventListener {
+
+    // Public constants.
 
     /** The logcat format string. */
     private static final String LOG_FORMAT = "%s: {%s, %s}.";
 
     /** The logcat TAG. */
-    private static final String TAG = ExpProfileChangeHandler.class.getSimpleName();
+    private static final String TAG = ExpProfilesChangeHandler.class.getSimpleName();
 
     // Public constructors.
 
     /** Build a handler with the given name and path. */
-    public ExpProfileChangeHandler(final String name, final String groupKey, final String roomKey) {
-        super(name, DatabaseManager.instance.getExpProfilePath(groupKey, roomKey));
+    public ExpProfilesChangeHandler(final String name, final String groupKey, final String roomKey) {
+        super(name, DatabaseManager.instance.getExpProfilesPath(groupKey, roomKey));
     }
+
+    // Public instance methods.
 
     /** Deal with a new message. */
     @Override public void onChildAdded(DataSnapshot dataSnapshot, String s) {
@@ -81,7 +81,7 @@ public class ExpProfileChangeHandler extends DatabaseEventHandler implements Chi
         process(dataSnapshot, MOVED);
     }
 
-    /** ... */
+    /** TODO: get a grip on these... */
     @Override public void onCancelled(DatabaseError error) {
         // Failed to read value
         Log.w(TAG, "Failed to read value.", error.toException());
@@ -105,13 +105,13 @@ public class ExpProfileChangeHandler extends DatabaseEventHandler implements Chi
                 break;
             case REMOVED:
                 // Update the database list experience profile map by removing the entry (key).
-                DatabaseListManager.instance.expProfileMap.put(expProfile.key, expProfile);
+                DatabaseListManager.instance.expProfileMap.remove(expProfile.key);
                 break;
             case MOVED:
             default:
                 // Not sure what a moved change means or what to do about it, so do nothing.
                 break;
         }
-        AppEventManager.instance.post(new ExpProfileChangeEvent(expProfile, type));
     }
+
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperienceChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperienceChangeHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.database.handler;
+
+import android.util.Log;
+
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.ValueEventListener;
+import com.pajato.android.gamechat.database.DatabaseListManager;
+import com.pajato.android.gamechat.database.DatabaseManager;
+import com.pajato.android.gamechat.game.ExpType;
+import com.pajato.android.gamechat.game.Experience;
+import com.pajato.android.gamechat.game.model.ExpProfile;
+import com.pajato.android.gamechat.game.model.TicTacToe;
+
+/**
+ * Provide a class to handle new and changed experiences inside a group and room.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ExperienceChangeHandler extends DatabaseEventHandler implements ValueEventListener {
+
+    // Private constants.
+
+    /** The logcat TAG. */
+    private static final String TAG = ExperienceChangeHandler.class.getSimpleName();
+
+    // Private instance variables.
+
+    /** The experience key value. */
+    private ExpProfile mProfile;
+
+    // Public constructors.
+
+    /** Build a handler with the given name and path. */
+    public ExperienceChangeHandler(final String name, final ExpProfile profile) {
+        super(name, DatabaseManager.instance.getExperiencePath(profile));
+        mProfile = profile;
+    }
+
+    // Public instance methods.
+
+    /** Get the current set of active rooms using a list of room identifiers. */
+    @Override public void onDataChange(final DataSnapshot dataSnapshot) {
+        // Ensure that some data exists.
+        if (dataSnapshot.exists()) {
+            // There is data.  Ensure that it will map to a valid experience.  Fail quietly for now.
+            // TODO: handle an invalid data snapshot.
+            Experience experience = getExperience(dataSnapshot);
+            if (experience == null) return;
+
+            // Update the experience on the database list manager.
+            String key = experience.getExperienceKey();
+            DatabaseListManager.instance.experienceMap.put(key, experience);
+        } else {
+            // TODO: should we remove the key here?
+            Log.e(TAG, "Invalid key.  No value returned.");
+        }
+    }
+
+    @Override
+    public void onCancelled(DatabaseError databaseError) {
+        // TODO: deal with this...
+        Log.e(TAG, "some kind of error");
+    }
+
+    // Private instance methods.
+
+    /** Return a class to hold the new experience, null for an invalid profile. */
+    private Experience getExperience(final DataSnapshot snapshot) {
+        if (mProfile == null) return null;
+
+        // Case on the profile type to get the desired class.
+        ExpType type = ExpType.values()[mProfile.type];
+        switch (type) {
+            case ttt: return snapshot.getValue(TicTacToe.class);
+            //case checkers: return snapshot.getValue(Checkers.class);
+            //case chess: return snapshot.getValue(Chess.class);
+            default:
+                break;
+        }
+
+        return null;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -21,9 +21,12 @@ import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.common.BaseFragment;
+import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -66,14 +69,19 @@ public abstract class BaseGameFragment extends BaseFragment {
 
     // Public instance methods.
 
+    /** Provide a default experience via the subclass providing a list of player accounts. */
+    public Experience getDefaultExperience(final List<Account> players) {
+        // TODO: By default, log that the subclass does not provide a default experience, generate a
+        // Toast or Snackbar for the User and let the User bail via default controls.
+        return null;
+    }
+
     /** Return the current turn indicator. */
     public boolean getTurn() {
         return mTurn;
     }
 
-    /**
-     * not sure yet what this is all about.
-     */
+    /** Remove this after dealing with the chess and checkers fragments. */
     abstract public void messageHandler(final String message);
 
     @Override public void onAttach(Context context) {
@@ -112,8 +120,14 @@ public abstract class BaseGameFragment extends BaseFragment {
     }
 
     /** Provide a default implementation for setting up an experience. */
-    protected void setupExperience() {
+    protected void setupExperience(final Dispatcher dispatcher) {
+        // Ensure that the dispatcher is valid.  Abort if not.
+        // TODO: might be better to show a toast or snackbar on error.
         mExperience = null;
+        if (dispatcher == null) return;
+
+        // Use the dispatcher data to set up the default experience.
+        mExperience = DatabaseManager.instance.getExperience(this, dispatcher);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.game;
 
+import com.pajato.android.gamechat.chat.model.Room;
+
 import java.util.List;
 import java.util.Map;
 
@@ -31,14 +33,14 @@ import static com.pajato.android.gamechat.game.FragmentType.roomList;
  *
  * @author Paul Michael Reilly
  */
-class Dispatcher {
+public class Dispatcher {
 
     // Public instance variables.
 
     /** The experience key. */
     public String expKey;
 
-    /** A list of experiences. */
+    /** A list of experience keys. */
     public List<String> list;
 
     /** The map of experiences: associates a group key with a map of rooms in the group. */
@@ -53,7 +55,7 @@ class Dispatcher {
     /** The map associating a room key with experiences in the room. */
     public Map<String, List<String>> roomMap;
 
-    /** The experience type. */
+    /** The fragment type denoting the fragment index and the experience type. */
     public FragmentType type;
 
     // Public Constructors.
@@ -92,4 +94,29 @@ class Dispatcher {
         expKey = exp;
     }
 
+    /** Build an instance given a fragment type and a room. */
+    public Dispatcher(FragmentType type, Room room) {
+        this.type = type;
+        this.groupKey = room != null ? room.groupKey : null;
+        this.roomKey = room != null ? room.key : null;
+    }
+
+    /** Build an instance given a fragment type and a list of experience keys. */
+    public Dispatcher(final FragmentType type, List<String> expKeyList) {
+        this.type = type;
+        list = expKeyList;
+    }
+
+    /** Build an instance given a fragment type and an experiene key. */
+    public Dispatcher(final FragmentType type, String expKey) {
+        this.type = type;
+        this.expKey = expKey;
+    }
+
+    /** Build an instance given a fragment type and an experience map (to show off vs on line.) */
+    public Dispatcher(final FragmentType type,
+                      final Map<String, Map<String, List<String>>> mExpMap) {
+        this.type = type;
+        this.expMap = expMap;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
@@ -25,7 +25,7 @@ import com.pajato.android.gamechat.R;
  *
  * @author Paul Michael Reilly
  */
-enum ExpType {
+public enum ExpType {
     checkers (R.mipmap.ic_checkers, R.string.PlayCheckers, R.string.player1, R.string.player2),
     chess (R.mipmap.ic_chess, R.string.PlayChess, R.string.player1, R.string.player2),
     ttt (R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe, R.string.xValue, R.string.oValue);

--- a/app/src/main/java/com/pajato/android/gamechat/game/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/FragmentType.java
@@ -24,13 +24,17 @@ package com.pajato.android.gamechat.game;
  */
 public enum FragmentType {
     signedOut (ShowSignedOutFragment.class),
-    noExp (ShowNoGamesFragment.class),
+    offline (ShowOfflineFragment.class),
+    noExp (ShowNoExperiencesFragment.class),
     groupList (ShowExpGroupListFragment.class),
     roomList (ShowExpRoomListFragment.class),
     expList (ShowExpListFragment.class),
-    tictactoe (TTTFragment.class, ExpType.ttt),
-    checkers (CheckersFragment.class, ExpType.checkers),
-    chess (ChessFragment.class, ExpType.chess);
+    tictactoeList (ShowExpTypeListFragment.class),
+    tictactoe (TTTFragment.class, ExpType.ttt, tictactoeList),
+    checkersList (ShowExpTypeListFragment.class),
+    checkers (CheckersFragment.class, ExpType.checkers, checkersList),
+    chessList(ShowExpTypeListFragment.class),
+    chess (ChessFragment.class, ExpType.chess, chessList);
 
     // Private instance variables.
 
@@ -40,15 +44,20 @@ public enum FragmentType {
     /** The experience type for this value. */
     public ExpType expType;
 
+    /** The show list fragment type for a particular game. */
+    public FragmentType showType;
+
     /** Build an instance with only a given fragment class. */
     FragmentType(final Class<? extends BaseGameFragment> fragmentClass) {
         this.fragmentClass = fragmentClass;
     }
 
     /** Build an instance with both a given fragment class and an experience type. */
-    FragmentType(final Class<? extends BaseGameFragment> fragmentClass, final ExpType expType) {
+    FragmentType(final Class<? extends BaseGameFragment> fragmentClass, final ExpType expType,
+                 final FragmentType showType) {
         this.fragmentClass = fragmentClass;
         this.expType = expType;
+        this.showType = showType;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -108,6 +108,7 @@ public class GameFragment extends BaseGameFragment {
                 break;
         }
 
+        // TODO: figure out how to get the experience into the db.
         if (type != null) GameManager.instance.startNextFragment(getActivity(), type);
     }
 
@@ -143,7 +144,7 @@ public class GameFragment extends BaseGameFragment {
 
     /** Dispatch to a more suitable fragment. */
     @Override public void onResume() {
-        // The experience manager will load a fragemnt to view into this envelope fragment.
+        // The experience manager will load a fragment to view into this envelope fragment.
         super.onResume();
         GameManager.instance.startNextFragment(getActivity());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowExpTypeListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowExpTypeListFragment.java
@@ -1,46 +1,34 @@
 /*
- * Copyright (C) 2016 Pajato Technologies, Inc.
+ * Copyright (C) 2016 Pajato Technologies LLC.
  *
  * This file is part of Pajato GameChat.
 
  * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- *
+
  * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
 
  * You should have received a copy of the GNU General Public License along with GameChat.  If not,
- * see <http://www.gnu.org/licenses/>.
+ * see http://www.gnu.org/licenses
  */
 
 package com.pajato.android.gamechat.game;
 
-import java.util.Map;
-
 /**
- * Each experience is expected to provide the associated fragment type, group push key, room push
- * key and experience push key as well as a map of the experience properties.
+ * Show a list of experiences of a particular type.
  *
- * @author Paul Michael Reilly
+ * Created by pmr on 10/5/16.
  */
-public interface Experience {
+public class ShowExpTypeListFragment extends BaseGameFragment {
+    @Override public void messageHandler(String message) {
 
-    FragmentType getFragmentType();
+    }
 
-    String getGroupKey();
-
-    String getRoomKey();
-
-    String getExperienceKey();
-
-    String getName();
-
-    int getType();
-
-    void setExperienceKey(String key);
-
-    Map<String, Object> toMap();
-
+    @Override protected int getLayout() {
+        // TODO: Add a real layout for this class.
+        return 0;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.game;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import static com.pajato.android.gamechat.game.GameFragment.GAME_HOME_FAM_KEY;
+
+public class ShowNoExperiencesFragment extends BaseGameFragment {
+
+    // Public instance methods.
+
+    /** A nop subscriber to satisfy the EventBus contract. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        // Provide a logging placeholder.
+        logEvent("onClick (showNoGames)");
+    }
+
+    /** Establish the layout file to indicate that no experiences are available. */
+    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
+
+    /** Satisfy the base game fragment contract with a nop message handler. */
+    @Override public void messageHandler(final String message) {}
+
+    /** Reset the FAM to use the game home menu. */
+    @Override public void onResume() {
+        super.onResume();
+        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowOfflineFragment.java
@@ -25,23 +25,21 @@ import org.greenrobot.eventbus.Subscribe;
 
 import static com.pajato.android.gamechat.game.GameFragment.GAME_HOME_FAM_KEY;
 
-public class ShowNoGamesFragment extends BaseGameFragment {
+public class ShowOfflineFragment extends BaseGameFragment {
 
+    // Public instance methods.
+
+    /** Provide a placeholder subscriber to satisfy the event bus contract. */
     @Subscribe public void onClick(final ClickEvent event) {
-        // todo add some code here.
-        logEvent("onClick (showNoGames)");
+        // Use a logging placeholder.
+        logEvent("onClick (showOffline)");
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
+    /** Establish the layout file to show that the app is offline due to network loss. */
+    @Override public int getLayout() {return R.layout.fragment_game_offline;}
 
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
-
-    /** Initialize the fragment by setting in the FAB. */
-    @Override public void onInitialize() {
-        FabManager.game.init(this);
-    }
 
     /** Reset the FAM to use the game home menu. */
     @Override public void onResume() {

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
@@ -33,11 +33,17 @@ import java.util.Map;
 @IgnoreExtraProperties
 public class ExpProfile {
 
+    /** The group key. */
+    public String groupKey;
+
     /** The experience key. */
     public String key;
 
     /** The experience's display name. */
     public String name;
+
+    /** The room key. */
+    public String roomKey;
 
     /** The experience type value. */
     public int type;
@@ -47,18 +53,23 @@ public class ExpProfile {
     /** Build an empty args constructor for the database. */
     public ExpProfile() {}
 
-    /** Build a default TicTacToe using all the parameters. */
-    public ExpProfile(final String key, final String name, final int type) {
+    /** Build a experience profile with a full set of values. */
+    public ExpProfile(final String key, final String name, final int type, final String groupKey,
+                      final String roomKey) {
         this.key = key;
         this.name = name;
         this.type = type;
+        this.groupKey = groupKey;
+        this.roomKey = roomKey;
     }
 
     /** Provide a default map for a Firebase create/update. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
+        result.put("groupKey", groupKey);
         result.put("key", key);
         result.put("name", name);
+        result.put("roomKey", roomKey);
         result.put("type", type);
 
         return result;

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/Player.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/Player.java
@@ -41,11 +41,11 @@ public class Player {
     /** Build an empty args constructor for the database. */
     public Player() {}
 
-    /** Build a default TicTacToe using all the parameters. */
-    public Player(final String name, final int sigilId, final int winCount) {
+    /** Build a default game player using all the parameters. */
+    public Player(final String name, final int sigilId) {
         this.name = name;
         this.sigilId = sigilId;
-        this.winCount = winCount;
+        this.winCount = 0;
     }
 
     /** Provide a default map for a Firebase create/update. */

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.game.model;
 
-import android.content.Context;
-
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
 import com.pajato.android.gamechat.game.Experience;
@@ -45,7 +43,7 @@ import java.util.Map;
     public long createTime;
 
     /** The experience push key. */
-    public String expKey;
+    public String experienceKey;
 
     /** The group push key. */
     public String groupKey;
@@ -62,7 +60,7 @@ import java.util.Map;
     /** The member account identifer who created the experience. */
     public String owner;
 
-    public List<Player> players;
+    public List<Map<String, String>> players;
 
     /** The room push key. */
     public String roomKey;
@@ -85,10 +83,10 @@ import java.util.Map;
     public TicTacToe(final String key, final String owner, final String name, final String url,
                      final long createTime, final long modTime, final boolean turn, final int type,
                      final String groupKey, final String roomKey, final List<String> board,
-                     final List<Player> players) {
+                     final List<Map<String, String>> players) {
         this.board = board;
         this.createTime = createTime;
-        this.expKey = key;
+        this.experienceKey = key;
         this.groupKey = groupKey;
         this.modTime = modTime;
         this.name = name;
@@ -101,11 +99,11 @@ import java.util.Map;
     }
 
     /** Provide a default map for a Firebase create/update. */
-    @Exclude public Map<String, Object> toMap() {
+    @Exclude @Override public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("board", board);
         result.put("createTime", createTime);
-        result.put("expKey", expKey);
+        result.put("expKey", experienceKey);
         result.put("groupKey", groupKey);
         result.put("modTime", modTime);
         result.put("name", name);
@@ -120,20 +118,25 @@ import java.util.Map;
     }
 
     /** Return the fragment type value or null if no such fragment type exists. */
-    @Exclude @Override public FragmentType getFragType() {
+    @Exclude @Override public FragmentType getFragmentType() {
         if (type < 0 || type >= FragmentType.values().length) return null;
 
         return FragmentType.values()[type];
     }
 
     /** Return the experience push key. */
-    @Exclude @Override public String getExpKey() {
-        return expKey;
+    @Exclude @Override public String getExperienceKey() {
+        return experienceKey;
     }
 
     /** Return the group push key. */
     @Exclude @Override public String getGroupKey() {
         return groupKey;
+    }
+
+    /** Return the experience name. */
+    @Exclude @Override public String getName() {
+        return name;
     }
 
     /** Return the room push key. */
@@ -142,19 +145,27 @@ import java.util.Map;
     }
 
     /** Return the sigil text value for the given player. */
-    @Exclude public String getSigilValue(final Context context, final int index) {
+    @Exclude public String getSigilValue(final int index) {
         // Ensure that the index is valid. Return the sentinal value "?" if not.
         if (index < 0 || index > 1) return "?";
 
         // The index is valid. Return the sigil value.
-        int resId = players.get(index).sigilId;
-        return context.getString(resId);
+        return players.get(index).get("sigil");
     }
 
     /** Return the sigil text value for the player whose turn is current. */
-    @Exclude public String getSigilValue(final Context context) {
-        int resId = turn ? players.get(0).sigilId : players.get(1).sigilId;
-        return context.getString(resId);
+    @Exclude public String getSigilValue() {
+        return turn ? getSigilValue(0) : getSigilValue(1);
+    }
+
+    /** Return the type to satisfy the Experience contract. */
+    @Exclude @Override public int getType() {
+        return type;
+    }
+
+    /** Set the experience key to satisfy the Experience contract. */
+    @Exclude @Override public void setExperienceKey(final String key) {
+        experienceKey = key;
     }
 
     /** Toggle the turn state. */
@@ -162,5 +173,4 @@ import java.util.Map;
         turn = !turn;
         return turn;
     }
-
 }

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -247,6 +247,7 @@ public class MainActivity extends BaseActivity
         setSupportActionBar(toolbar);
         DatabaseManager.instance.init(this);
         NavigationManager.instance.init(this, toolbar);
+        NetworkManager.instance.init(this);
         PaneManager.instance.init(this);
         GameManager.instance.init();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.main;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+/**
+ * Provide a singleton to monitor the network state. For now the state is always assumed to be
+ * connected.  In the future the class should be enhanced to smooth out network disconnects.
+ *
+ * @author Paul Michael Reilly
+ */
+public enum NetworkManager {
+    instance;
+
+    // Private instance variables.
+
+    private boolean online;
+
+    // Public instance methods
+
+    /** Return TRUE iff the network is connected. */
+    public boolean isConnected() {
+        // TODO: enhance this to smooth out short term fluctuations, like less than 30 seconds.
+        return online;
+    }
+
+    /** Set the current network connection state. */
+    public void init(final Context context) {
+        ConnectivityManager manager =
+                (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = manager.getActiveNetworkInfo();
+        online = activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+    }
+
+}

--- a/app/src/main/res/layout/fragment_game_offline.xml
+++ b/app/src/main/res/layout/fragment_game_offline.xml
@@ -55,17 +55,8 @@ http://www.gnu.org/licenses
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="24dp"
-        android:text="@string/SignedOutMessageText"
+        android:text="@string/OfflineMessageText"
         android:textAlignment="center"
         android:textSize="24sp" />
-
-    <Button style="@style/FabMenuButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:id="@+id/expSignIn"
-        android:textSize="20sp"
-        android:text="@string/SignIn"
-        android:onClick="onClick"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="switch_account">\u25bc Switch account</string>
     <string name="me">me</string>
     <string name="anonymous">Anonymous</string>
+    <string name="OfflineMessageText">The network is not available.  You can continue to play games while offline.</string>
 </resources>


### PR DESCRIPTION
<h1>Rationale</h1>

With this commit, the experience overhaul has reached the point where the TicTacToe game is in the me room such that related fragments can be made to work correctly such as showing group and room lists.  This also marks the point at which alpha testing can commence.

<h1>File changes:</h1>

new file:   ISSUES.md

- New file added to track short term issues.  Long term issues and filed bugs are the province of GitHub issues.

modified:   app/src/main/java/com/pajato/android/gamechat/account/Account.java

- getFirstName(): provide a helper method to get a friendly name for the player controls.

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- hasAccount(): new method simplifying process of determining the logged in state.
- onAuthStateChanged(): use the isRegistered() method to determine the registration state.
- AccountChangeHandler#onDataChange(): update the account variable to be added to the event.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- processGroup(): add a self reference key value prior to the database update; do not provide the group and room keys when creating the room profile or the message in the database.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessagesFragment.java

- postMessage(): use the shortened createMessage() signature to persist the message to the new group.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- ME, PRIVATE, PUBLIC: add doc comments.
- USER: new room type.  'member' is probably a better name.
- Room(): fix the spelling (capitalization) of the group key to fix a bug.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- experienceMap, groupMap, roomMap, currentRoom: add public variables.
- mGroupProfileMap, mRoomProfileMap: rename and make public.
- getList(): move per RNF.
- getGroupKey(): new method that gets the group associated with the current room.
- getGroupName(), getGroupProfile(), getRoomName(), getRoomProfile(), onAccountStateChange(), onRoomProfileChange(): use the renamed group and room maps.
- setExpProfileWatcher(): fix the format constant spelling.
- setExperienceWatcher(): new function that will be used when a list entry containing an experience profile is tapped.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- EXP_PROFILE_PATH: fix this to provide the key.
- EXP_PROFILES_PATH, EXPERIENCE_PATH, EXPERIENCES_PATH: flesh out the experience related path constants.
- createAccount(): use the shortened createMessage() interface.
- createExperience(): new method installing a tictactoe experience to the database.
- createGroupProfile(): remove the group key from the signature; ensure that the key exists to avoid database corruption.
- createMessage(): remove the group and room keys from the method signature; add a check to avoid database corruption; enhance the commenting.
- createRoomProfile(): do not supply the group and room keys (put them into the room argument); add a check to prevent database corruption.
- getExperience(), getExperiencePath(): new methods providing support for handling the retrieval and creation of experiences.
- getExpPofilePath(): use the correct format constant.
- hideAndFixMe(): remove this stale detritus.
- getPlayers(), updateExperience(): new methods supporting experience integration to the database.

renamed:    app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileChangeHandler.java -> app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfilesChangeHandler.java

- Change the name to reflect the "child" nature of the handler.

new file:   app/src/main/java/com/pajato/android/gamechat/database/handler/ExperienceChangeHandler.java

- Add support for experiences in the database.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- getDefaultExperience(): satisfy the default experience fragment contract.
- setupExperience(): use a dispatcher to do a little more for all fragments, like obtaining the experience from the database.

modified:   app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java

- Enhance the commenting; provide more constructors.

modified:   app/src/main/java/com/pajato/android/gamechat/game/ExpType.java

- ExpType(): make public.

modified:   app/src/main/java/com/pajato/android/gamechat/game/Experience.java

- getExpKey(): rename to getExperienceKey().
- getFragType(): rename to getFragmentType();
- getName(), getType(), setExperienceKey(), toMap(): new methods supporting experience integration to the database.

modified:   app/src/main/java/com/pajato/android/gamechat/game/FragmentType.java

noExp: rename showNoGamesFragment to showNoExperiencesFragment.
offline, tictactoeList, checkersList, chessList: add new values.
tictactoe, chess, checkers: add the list fragment type.
showType: new variable.
FragmentType() overload to handle a show type argument.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- Bogus benign commenting changes that slipped through the cracks.  Ignore.  Will be removed in next commit.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameManager.java

- mExpMap, mExperienceMap: initialize these variables at class load time instead of using the null state of these variables to indicate logged in status.
- currentGroupKey, currentRoomKey: new variables to implement a default room model.
- init(): do not register with the app event manager.
- onAccountStateChange(): remove as map initialization is now done by default.
- startNextFragment(): use the dispatcher and common code.
- getDispatcher(): overload with a fragment type argument.

new file:   app/src/main/java/com/pajato/android/gamechat/game/ShowExpTypeListFragment.java
new file:   app/src/main/java/com/pajato/android/gamechat/game/ShowOfflineFragment.java

- Placeholders.

renamed:    app/src/main/java/com/pajato/android/gamechat/game/ShowNoGamesFragment.java -> app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java

- An early move to use "experience" in names rather than "game".  Lots more coming over time.

modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- getDefaultExperience(): make public; move per RNF;
- evaluateBoard(), handleTileClick(), recreateExistingBoard(): do not try to use the context in setting up the players ... yet.
- getDefaultPlayers(): reimplement without using a Player type ... for now.
- getExperienceFromDatabase(): removed.
- getPlayer(), getPlayerName(): new methods not using the Player class.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java

- groupKey, roomKey: new convenience variables.
- ExpProfile(), toMap(): add the group and room keys.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/Player.java

- Player(): only provide the name and symbol; initialize the count to 0.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java

- expKey: rename to experienceKey.
- players: simplify the type to avoid dealing with a Firebase exception ... for now.
- TicTacToe(), toMap(): deal with the previous two changes (expKey renaming and players retyping).
- getFragType(): rename to getFragmentType().
- getExpKey(): rename to getExperienceKey().
- getName(), getType(), setExperienceKey(): satisfy the Experience interface.
- getSigilValue(): do not use the context as there may not be one if the fragment is just created.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- init(): initialize the network manager object.

new file:   app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java

- New class to deal with offline/online detection.

modified:   app/src/main/res/layout/fragment_exp_signed_out.xml

- Cosmetic change to eliminate the tools attributes since they are no longer relevant.

new file:   app/src/main/res/layout/fragment_game_offline.xml

- New layout to copy the signed out layout minus the signin button.

modified:   app/src/main/res/values/strings.xml

- OfflineMessageText: provide initial stab.