### PR TITLE
Make TicTacToe be event driven.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java
@@ -64,6 +64,12 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     /** A key used to access account available data. */
     public static final String ACCOUNT_AVAILABLE_KEY = "accountAvailable";
 
+    /** The sentinel value to use for indicating an offline cached database object owner. */
+    public static final String SIGNED_OUT_OWNER_ID = "signedOutOwnerId";
+
+    /** The sentinel value to use for indicating a signed out experience key. */
+    public static final String SIGNED_OUT_EXPERIENCE_KEY = "signedOutExperienceKey";
+
     // Private instance variables
 
     /** The current account key, null if there is no current account. */
@@ -194,7 +200,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         /** Get the current account using a list of account identifiers. */
         @Override public void onDataChange(final DataSnapshot dataSnapshot) {
             // Determine if the account exists.
-            Account account = null;
+            Account account;
             if (dataSnapshot.exists()) {
                 // It does.  Register it and notify the app that this is the new account of record.
                 account = dataSnapshot.getValue(Account.class);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -32,7 +32,7 @@ import java.util.Map;
     /** The message types. */
     public final static int SYSTEM = 0;
     public final static int STANDARD = 1;
-    public final static int PROTECTED = 2;
+    // TODO: add this real soon: public final static int PROTECTED = 2;
 
     /** The member account identifer who posted the message. */
     public String owner;
@@ -50,7 +50,7 @@ import java.util.Map;
     public long createTime;
 
     /** The last modification timestamp. */
-    public long modTime;
+    private long modTime;
 
     /** The message text. */
     public String text;
@@ -68,11 +68,11 @@ import java.util.Map;
 
     /** Build a default Message using all the parameters. */
     public Message(final String key, final String owner, final String name, final String url,
-                   final long createTime, final long modTime, final String text, final int type,
+                   final long createTime, final String text, final int type,
                    final List<String> unreadList) {
         this.createTime = createTime;
         this.key = key;
-        this.modTime = modTime;
+        this.modTime = 0;
         this.name = name;
         this.owner = owner;
         this.text = text;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.chat.model;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
+import com.pajato.android.gamechat.game.model.ExpProfile;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +41,7 @@ import java.util.Map;
     public final static int PUBLIC = 2;
 
     /** A room in which only two members can exist (a direct room in Slack). */
-    public final static int USER = 3;
+    public final static int MEMBER = 3;
 
     /** The creation timestamp. */
     public long createTime;
@@ -63,7 +64,10 @@ import java.util.Map;
     /** The room owner/creator, an account identifier. */
     public String owner;
 
-    /** The room type, one of "public", "private" or "me". */
+    /** The list of experience profiles.  One exists for each experience. */
+    @Exclude public List<ExpProfile> expProfileList;
+
+    /** The room type, one of "public", "private", "member" or "me". */
     public int type;
 
     /** Build an empty args constructor for the database. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -89,6 +89,14 @@ public enum FabManager {
         if (layout != null) dismissMenu(layout);
     }
 
+    /** Ensure that the FAb is not being shown. */
+    public void hide(@NonNull final Fragment fragment) {
+        View layout = getGameFragmentLayout(fragment);
+        if (layout == null) return;
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setVisibility(View.GONE);
+    }
+
     /** Initialize the fab state. */
     public void init(final Fragment fragment) {
         // Ensure that the layout exists. Abort if it does not.  Set the FAB state to closed if it
@@ -146,6 +154,14 @@ public enum FabManager {
     public void setTag(final String fragmentTag) {
         // Use the fragment tag string to find the main fragment and then in turn, the FAB.
         mTag = fragmentTag;
+    }
+
+    /** Ensure that the FAb is being shown. */
+    public void show(@NonNull final Fragment fragment) {
+        View layout = getGameFragmentLayout(fragment);
+        if (layout == null) return;
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setVisibility(View.VISIBLE);
     }
 
     /** Toggle the state of the FAB button using a given fragment to obtain the layout view. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -382,6 +382,20 @@ public enum DatabaseListManager {
         return result;
     }
 
+    // Package private instance methods.
+
+    /** Setup a listener for experience changes in the given room. */
+    void setExperienceWatcher(final ExpProfile profile) {
+        // Set up a watcher in the given room for experiences changes.
+        // Determine if a handle already exists. Abort if so.  Register a new handler if not.
+        String name = String.format(Locale.US, "experiencesChangeHandler{%s}", profile.key);
+        if (DatabaseRegistrar.instance.isRegistered(name)) return;
+        DatabaseEventHandler handler = new ExperienceChangeHandler(name, profile);
+        DatabaseRegistrar.instance.registerHandler(handler);
+    }
+
+    // Private instance methods.
+
     /** Setup a listener for experience changes in the given room. */
     private void setExpProfileWatcher(final String groupKey, final String roomKey) {
         // Obtain a room and set watchers on all the experience profiles in that room.
@@ -389,16 +403,6 @@ public enum DatabaseListManager {
         String name = String.format(Locale.US, "expProfilesChangeHandler{%s}", roomKey);
         if (DatabaseRegistrar.instance.isRegistered(name)) return;
         DatabaseEventHandler handler = new ExpProfilesChangeHandler(name, groupKey, roomKey);
-        DatabaseRegistrar.instance.registerHandler(handler);
-    }
-
-    /** Setup a listener for experience changes in the given room. */
-    private void setExperienceWatcher(final ExpProfile profile) {
-        // Set up a watcher in the given room for experiences changes.
-        // Determine if a handle already exists. Abort if so.  Register a new handler if not.
-        String name = String.format(Locale.US, "experiencesChangeHandler{%s}", profile.key);
-        if (DatabaseRegistrar.instance.isRegistered(name)) return;
-        DatabaseEventHandler handler = new ExperienceChangeHandler(name, profile);
         DatabaseRegistrar.instance.registerHandler(handler);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.game.ExpType;
 import com.pajato.android.gamechat.game.Experience;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static android.R.attr.type;
 import static com.pajato.android.gamechat.R.string.me;
 import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
 import static com.pajato.android.gamechat.chat.model.Room.ME;
@@ -134,7 +136,7 @@ public enum DatabaseManager {
 
         // Get the name and type for the given experience.  Abort if either does not exist.
         String name = experience.getName();
-        int type = experience.getType();
+        ExpType expType = experience.getExperienceType();
         if (name == null || type == -1) return;
 
         // Persist the experience.
@@ -150,7 +152,7 @@ public enum DatabaseManager {
         ref = mDatabase.child(path).push();
         String key = ref.getKey();
         String expKey = experience.getExperienceKey();
-        ExpProfile profile = new ExpProfile(key, name, type, groupKey, roomKey, expKey);
+        ExpProfile profile = new ExpProfile(key, name, expType, groupKey, roomKey, expKey);
         ref.setValue(profile.toMap());
         DatabaseListManager.instance.setExperienceWatcher(profile);
     }
@@ -183,7 +185,7 @@ public enum DatabaseManager {
         String url = type == SYSTEM ? systemUrl : account.url;
         long tstamp = new Date().getTime();
         List<String> members = room.memberIdList;
-        Message message = new Message(key, account.id, name, url, tstamp, 0, text, type, members);
+        Message message = new Message(key, account.id, name, url, tstamp, text, type, members);
 
         // Persist the message.
         path = String.format(Locale.US, MESSAGE_PATH, room.groupKey, room.key, key);
@@ -202,9 +204,8 @@ public enum DatabaseManager {
 
     /** Return the database path to an experience for a given experience profile. */
     public String getExperiencePath(final ExpProfile profile) {
-        String groupKey = profile.groupKey;
-        String roomKey = profile.roomKey;
-        return String.format(Locale.US, EXPERIENCE_PATH, groupKey, roomKey, profile.key);
+        String key = profile.expKey;
+        return String.format(Locale.US, EXPERIENCE_PATH, profile.groupKey, profile.roomKey, key);
     }
 
     /** Return the database path to a experience profile for a given room and profile key. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java
@@ -286,4 +286,14 @@ public enum DatabaseManager {
         DatabaseManager.instance.updateChildren(path, unreadMap);
     }
 
+    /** Perist the given experience. */
+    public void updateExperience(final Experience experience) {
+        // Persist the experience.
+        experience.setModTime(new Date().getTime());
+        String groupKey = experience.getGroupKey();
+        String roomKey = experience.getRoomKey();
+        String expKey = experience.getExperienceKey();
+        String path = String.format(Locale.US, EXPERIENCE_PATH, groupKey, roomKey, expKey);
+        mDatabase.child(path).setValue(experience.toMap());
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfilesChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfilesChangeHandler.java
@@ -22,10 +22,13 @@ import android.util.Log;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
+import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.event.MessageChangeEvent.CHANGED;
@@ -97,11 +100,14 @@ public class ExpProfilesChangeHandler extends DatabaseEventHandler implements Ch
         // A snapshot exists.  Extract the experience profile from it and handle it based on the
         // change type. Finally notify the app of the change.
         ExpProfile expProfile = snapshot.getValue(ExpProfile.class);
+        Room roomProfile = DatabaseListManager.instance.getRoomProfile(expProfile.roomKey);
         switch (type) {
             case NEW:
             case CHANGED:
-                // Update the database list experience profile map by adding or replacing the entry.
-                DatabaseListManager.instance.expProfileMap.put(expProfile.key, expProfile);
+                // Update the room's experience profile list by adding or replacing the profile.
+                List<ExpProfile> list = roomProfile.expProfileList;
+                if (list == null) list = new ArrayList<>();
+                list.add(expProfile);
                 break;
             case REMOVED:
                 // Update the database list experience profile map by removing the entry (key).

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperienceChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperienceChangeHandler.java
@@ -24,6 +24,8 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.ValueEventListener;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.game.ExpType;
 import com.pajato.android.gamechat.game.Experience;
 import com.pajato.android.gamechat.game.model.ExpProfile;
@@ -65,9 +67,10 @@ public class ExperienceChangeHandler extends DatabaseEventHandler implements Val
             Experience experience = getExperience(dataSnapshot);
             if (experience == null) return;
 
-            // Update the experience on the database list manager.
-            String key = experience.getExperienceKey();
-            DatabaseListManager.instance.experienceMap.put(key, experience);
+            // Update the experience on the database list manager and post the change event to the
+            // app.
+            DatabaseListManager.instance.experienceMap.put(mProfile.expKey, experience);
+            AppEventManager.instance.post(new ExperienceChangeEvent(experience));
         } else {
             // TODO: should we remove the key here?
             Log.e(TAG, "Invalid key.  No value returned.");

--- a/app/src/main/java/com/pajato/android/gamechat/event/BaseChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/BaseChangeEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+/**
+ * Provides a base class for change event classes created by Firebase child listeners.
+ *
+ * @author Paul Michael Reilly
+ */
+public abstract class BaseChangeEvent {
+
+    // Public type constants.
+    public static final int NEW = 0;
+    public static final int CHANGED = 1;
+    public static final int REMOVED = 2;
+    public static final int MOVED = 3;
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/event/ExpProfileListChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ExpProfileListChangeEvent.java
@@ -17,36 +17,27 @@
 
 package com.pajato.android.gamechat.event;
 
-import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.game.model.ExpProfile;
 
 /**
  * Provides a event class to encapsulate a message class along with the parent group and room keys.
  *
  * @author Paul Michael Reilly
  */
-public class MessageChangeEvent extends BaseChangeEvent {
+public class ExpProfileListChangeEvent extends BaseChangeEvent {
 
     // Public instance variables.
 
-    /** The push key for the group containing the message. */
-    public final String groupKey;
-
-    /** The push key for the room containing the message. */
-    public final String roomKey;
-
-    /** The value associated with the click event, either a tag value of the reoource id. */
-    public Message message;
+    /** The experience profile subject to the change. */
+    public ExpProfile expProfile;
 
     /** The change type. */
-    public int type;
+    public int changeType;
 
-    /** Build the event with the given list. */
-    public MessageChangeEvent(final String groupKey, final String roomKey, final Message message,
-                              final int type) {
-        this.groupKey = groupKey;
-        this.roomKey =  roomKey;
-        this.message = message;
-        this.type = type;
+    /** Build the event with the given experience profile and the change type. */
+    public ExpProfileListChangeEvent(final ExpProfile expProfile, final int changeType) {
+        this.expProfile = expProfile;
+        this.changeType = changeType;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/ExperienceChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ExperienceChangeEvent.java
@@ -17,36 +17,23 @@
 
 package com.pajato.android.gamechat.event;
 
-import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.game.Experience;
 
 /**
  * Provides a event class to encapsulate a message class along with the parent group and room keys.
  *
  * @author Paul Michael Reilly
  */
-public class MessageChangeEvent extends BaseChangeEvent {
+public class ExperienceChangeEvent {
 
     // Public instance variables.
 
-    /** The push key for the group containing the message. */
-    public final String groupKey;
+    /** The experience subject to the change. */
+    public Experience experience;
 
-    /** The push key for the room containing the message. */
-    public final String roomKey;
-
-    /** The value associated with the click event, either a tag value of the reoource id. */
-    public Message message;
-
-    /** The change type. */
-    public int type;
-
-    /** Build the event with the given list. */
-    public MessageChangeEvent(final String groupKey, final String roomKey, final Message message,
-                              final int type) {
-        this.groupKey = groupKey;
-        this.roomKey =  roomKey;
-        this.message = message;
-        this.type = type;
+    /** Build the event with the given experience. */
+    public ExperienceChangeEvent(final Experience experience) {
+        this.experience = experience;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -54,9 +54,6 @@ public abstract class BaseGameFragment extends BaseFragment {
     /** The experience being enjoyed. */
     Experience mExperience;
 
-    /** The fragment type. */
-    FragmentType mFragmentType;
-
     /** The current turn indicator: True = Player 1, False = Player 2. */
     boolean mTurn;
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -126,12 +126,23 @@ public abstract class BaseGameFragment extends BaseFragment {
         if (expType == null) return;
 
         // Determine if an experience is available via the dispatcher and fetch it.
-        mExperience = dispatcher.expKey != null
-            ? DatabaseListManager.instance.experienceMap.get(dispatcher.expKey) : null;
+        mExperience = dispatcher.expKey != null ? getExperience(dispatcher) : null;
 
         // Determine if an experience should be created.  If so use the passed in context in setting
         // up the experience as the current context for this fragment may not exist yet.
         if (dispatcher.expKey == null) createExperience(context, dispatcher);
+    }
+
+    // Private instance methods.
+
+    /** Return the experience using the given dispatcher, null if there is no experience. */
+    private Experience getExperience(Dispatcher dispatcher) {
+        // Ensure there is a room key to use.  Abort if not.
+        String key = dispatcher.expKey;
+        if (key == null) return null;
+
+        // There is a key. Use it to get the experience map.
+        return DatabaseListManager.instance.experienceMap.get(key);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -87,14 +87,12 @@ public class CheckersFragment extends BaseGameFragment {
             onNewGame();
             int color;
             if (player.equals(getString(R.string.player2))) {
-                color = ContextCompat.getColor(getContext(), R.color.colorAccent);
             } else {
                 player = getString(R.string.player1);
-                color = ContextCompat.getColor(getContext(), R.color.colorPrimary);
             }
             String newGame = getString(R.string.NewGame);
             String message = String.format(Locale.US, "%s! %s's Turn!", newGame, player);
-            GameManager.instance.notify(mLayout, message, color, false);
+            GameManager.instance.notify(this, message, false);
         }
 
     }
@@ -260,12 +258,10 @@ public class CheckersFragment extends BaseGameFragment {
         }
         // Verify win conditions. If one passes, return true and generate an endgame snackbar.
         if(yCount == 0) {
-            GameManager.instance.notify(mBoard, "Game Over! Player 1 Wins!",
-                    ContextCompat.getColor(getContext(), R.color.colorPrimary), true);
+            GameManager.instance.notify(this, "Game Over, Player 1 wins", true);
             return true;
         } else if (bCount == 0) {
-            GameManager.instance.notify(mBoard, "Game Over! Player 2 Wins!",
-                    ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
+            GameManager.instance.notify(this, "Game Over, Player 2 wins", true);
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -94,14 +94,12 @@ public class ChessFragment extends BaseGameFragment {
 
             int color;
             if(player.equals(getString(R.string.player2))) {
-                color = ContextCompat.getColor(getContext(), R.color.colorAccent);
             } else {
                 player = getString(R.string.player1);
-                color = ContextCompat.getColor(getContext(), R.color.colorPrimary);
             }
             handleTurnChange();
-            GameManager.instance.notify(mLayout, getString(R.string.NewGame) + " "
-                    + player + "'s Turn!", color, false);
+            GameManager.instance.notify(this, getString(R.string.NewGame) + " "
+                    + player + "'s Turn!", false);
         }
 
     }
@@ -279,12 +277,10 @@ public class ChessFragment extends BaseGameFragment {
         }
         // Verify win conditions. If one passes, return true and generate an endgame snackbar.
         if(secondaryKing == 0) {
-            GameManager.instance.notify(mBoard, "Game Over! Player 1 Wins!",
-                    ContextCompat.getColor(getContext(), R.color.colorPrimary), true);
+            GameManager.instance.notify(this, "Game Over! Player 1 Wins!", true);
             return true;
         } else if (primaryKing == 0) {
-            GameManager.instance.notify(mBoard, "Game Over! Player 2 Wins!",
-                    ContextCompat.getColor(getContext(), R.color.colorPrimaryDark), true);
+            GameManager.instance.notify(this, "Game Over! Player 2 Wins!", true);
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
@@ -17,7 +17,7 @@
 
 package com.pajato.android.gamechat.game;
 
-import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.game.model.ExpProfile;
 
 import java.util.List;
 import java.util.Map;
@@ -40,11 +40,11 @@ public class Dispatcher {
     /** The experience key. */
     public String expKey;
 
-    /** A list of experience keys. */
-    public List<String> list;
+    /** A list of experience profiles. */
+    public List<ExpProfile> profileList;
 
-    /** The map of experiences: associates a group key with a map of rooms in the group. */
-    public Map<String, Map<String, List<String>>> expMap;
+    /** Associates groups, rooms and experience profiles. */
+    public Map<String, Map<String, Map<String, ExpProfile>>> groupMap;
 
     /** The group key. */
     public String groupKey;
@@ -52,8 +52,8 @@ public class Dispatcher {
     /** The room key. */
     public String roomKey;
 
-    /** The map associating a room key with experiences in the room. */
-    public Map<String, List<String>> roomMap;
+    /** The map associating a room key with experience profiles in the room. */
+    public Map<String, Map<String, ExpProfile>> roomMap;
 
     /** The fragment type denoting the fragment index and the experience type. */
     public FragmentType type;
@@ -66,57 +66,44 @@ public class Dispatcher {
     }
 
     /** Build an instance given an experience map. */
-    Dispatcher(final Map<String, Map<String, List<String>>> expMap) {
+    Dispatcher(final Map<String, Map<String, Map<String, ExpProfile>>> groupMap) {
         this.type = groupList;
-        this.expMap = expMap;
+        this.groupMap = groupMap;
     }
 
     /** Build an instance given a group key and room map. */
-    Dispatcher(final String groupKey, final Map<String, List<String>> roomMap) {
+    Dispatcher(final String groupKey, final Map<String, Map<String, ExpProfile>> roomMap) {
         this.type = roomList;
         this.groupKey = groupKey;
         this.roomMap = roomMap;
     }
 
     /** Build an instance given a group key, room key, and an experience list. */
-    Dispatcher(final String groupKey, final String roomKey, final List<String> list) {
+    Dispatcher(final String groupKey, final String roomKey, final List<ExpProfile> profileList) {
         this.type = expList;
         this.groupKey = groupKey;
         this.roomKey = roomKey;
-        this.list = list;
+        this.profileList = profileList;
     }
 
     /** Build an instance given a fragment type, a group key, a room key and an experience key. */
-    Dispatcher(final FragmentType type, final String group, final String room, final String exp) {
+    Dispatcher(final FragmentType type, final String group, final String room, final String key) {
         this.type = type;
         groupKey = group;
         roomKey = room;
-        expKey = exp;
-    }
-
-    /** Build an instance given a fragment type and a room. */
-    public Dispatcher(FragmentType type, Room room) {
-        this.type = type;
-        this.groupKey = room != null ? room.groupKey : null;
-        this.roomKey = room != null ? room.key : null;
+        expKey = key;
     }
 
     /** Build an instance given a fragment type and a list of experience keys. */
-    public Dispatcher(final FragmentType type, List<String> expKeyList) {
+    Dispatcher(final FragmentType type, List<ExpProfile> profileList) {
         this.type = type;
-        list = expKeyList;
+        this.profileList = profileList;
     }
 
     /** Build an instance given a fragment type and an experiene key. */
-    public Dispatcher(final FragmentType type, String expKey) {
+    Dispatcher(final FragmentType type, String expKey) {
         this.type = type;
         this.expKey = expKey;
     }
 
-    /** Build an instance given a fragment type and an experience map (to show off vs on line.) */
-    public Dispatcher(final FragmentType type,
-                      final Map<String, Map<String, List<String>>> mExpMap) {
-        this.type = type;
-        this.expMap = expMap;
-    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
@@ -26,31 +26,39 @@ import com.pajato.android.gamechat.R;
  * @author Paul Michael Reilly
  */
 public enum ExpType {
-    checkers (R.mipmap.ic_checkers, R.string.PlayCheckers, R.string.player1, R.string.player2),
-    chess (R.mipmap.ic_chess, R.string.PlayChess, R.string.player1, R.string.player2),
-    ttt (R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe, R.string.xValue, R.string.oValue);
+    checkers (R.mipmap.ic_checkers, R.string.PlayCheckers, R.string.player1, R.string.player2,
+            FragmentType.checkers),
+    chess (R.mipmap.ic_chess, R.string.PlayChess, R.string.player1, R.string.player2,
+            FragmentType.chess),
+    ttt (R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe, R.string.xValue, R.string.oValue,
+            FragmentType.tictactoe);
 
     // Instance variables.
 
+    /** The fragment type handling this experience type. */
+    FragmentType mFragmentType;
+
     /** The primary player index. */
-    int primaryIndex;
+    int mPrimaryIndex;
 
     /** The secondary player index. */
-    int secondaryIndex;
+    int mSecondaryIndex;
 
     /** The game icon resource id. */
-    int iconResId;
+    int mIconResId;
 
     /** The game title resource id. */
-    int titleResId;
+    int mTitleResId;
 
     // Constructor.
 
     /** Build an instance given the online, local and computer opponent fragment indexes. */
-    ExpType(final int iconId, final int titleId, final int primary, final int secondary) {
-        iconResId = iconId;
-        titleResId = titleId;
-        primaryIndex = primary;
-        secondaryIndex = secondary;
+    ExpType(final int iconId, final int titleId, final int primary, final int secondary,
+            final FragmentType fragmentType) {
+        mIconResId = iconId;
+        mTitleResId = titleId;
+        mPrimaryIndex = primary;
+        mSecondaryIndex = secondary;
+        mFragmentType = fragmentType;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/Experience.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Experience.java
@@ -27,8 +27,6 @@ import java.util.Map;
  */
 public interface Experience {
 
-    FragmentType getFragmentType();
-
     String getGroupKey();
 
     String getRoomKey();
@@ -37,7 +35,7 @@ public interface Experience {
 
     String getName();
 
-    int getType();
+    ExpType getExperienceType();
 
     void setExperienceKey(String key);
 

--- a/app/src/main/java/com/pajato/android/gamechat/game/Experience.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Experience.java
@@ -20,25 +20,38 @@ package com.pajato.android.gamechat.game;
 import java.util.Map;
 
 /**
- * Each experience is expected to provide the associated fragment type, group push key, room push
- * key and experience push key as well as a map of the experience properties.
+ * Each experience is expected to provide a name, the associated experience type, group push key,
+ * room push key and experience push key as well as a map of the experience properties. And
+ * experience must also be able to set the modification timestamp and the win count.
  *
  * @author Paul Michael Reilly
  */
 public interface Experience {
 
+    /** Return the experience group push key. */
     String getGroupKey();
 
+    /** Return the experience room push key. */
     String getRoomKey();
 
+    /** Return the experience push key. */
     String getExperienceKey();
 
+    /** Return the experience name. */
     String getName();
 
+    /** Return the experience type. */
     ExpType getExperienceType();
 
+    /** Set the experience push key. */
     void setExperienceKey(String key);
 
-    Map<String, Object> toMap();
+    /** Set the modification timestamp. */
+    void setModTime(long value);
 
+    /** Set the win count. */
+    void setWinCount();
+
+    /** Provide a map of experience properties. */
+    Map<String, Object> toMap();
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -20,6 +20,7 @@ package com.pajato.android.gamechat.game;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -64,26 +65,41 @@ import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_OWNER_ID;
  */
 public class TTTFragment extends BaseGameFragment {
 
+    // Private constants.
+
+    /** The logcat TAG. */
+    private static final String TAG = TTTFragment.class.getSimpleName();
+
     // Private instance variables.
 
-    /** A map used to help manage the board... */
-    private HashMap<String, Integer> mLayoutMap;
+    /* A convenience array that simplifies win determination. */
+    private int[][] mBoardValues = new int[3][3];
 
     // Public instance methods.
 
     /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_ttt;}
+    @Override public int getLayout() {return R.layout.fragment_game_ttt;}
 
     /** Placeholder while message handler stays relevant for chess and checkers. */
     @Override public void messageHandler(final String msg) {}
 
     /** Handle a tile click event by sending a message to the current tic-tac-toe fragment. */
     @Subscribe public void onClick(final TagClickEvent event) {
-        // Determine if the payload exists and is a string. Abort if not.  Handle it as a tile click
-        // if it does.
+        // Determine if the payload exists and is not a string, in which case, abort as the event is
+        // of no interest here.
         Object payload = event.view.getTag();
         if (!(payload instanceof String)) return;
-        handleTileClick((String) payload);
+
+        // Determine if the payload is a board position encoding.
+        String tag = (String) payload;
+        if (tag.startsWith("button")) {
+            // It is an encoded button position.  Deal with it.
+            handleTileClick(tag);
+            return;
+        }
+
+        // Determine if the tag is this fragment's classname, in which case we play another game.
+        if (this.getClass().getSimpleName().equals(tag)) handleNewGame();
     }
 
     @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -91,14 +107,14 @@ public class TTTFragment extends BaseGameFragment {
         inflater.inflate(R.menu.ttt_menu, menu);
     }
 
-    /** Handle an experience posting event to see if this is one for us. */
+    /** Handle an experience posting event to see if this is a tictactoe experience. */
     @Subscribe public void onExperienceChange(final ExperienceChangeEvent event) {
-        // Check the payload to see if this is an experience event we are waiting for.  If so, stop
-        // the spinner and show the game.
-        if (event.experience.getExperienceType() == ttt) mExperience = event.experience;
+        // Check the payload to see if this is not a tictactoe.  Abort if not.
+        if (event.experience == null || event.experience.getExperienceType() != ttt) return;
 
         // The experience is a tictactoe experience.  Start the game.
-        if (ProgressManager.instance.isShowing() && mExperience != null) resume();
+        mExperience = event.experience;
+        resume();
     }
 
     /** Handle taking the foreground by updating the UI based on the current expeience. */
@@ -110,20 +126,7 @@ public class TTTFragment extends BaseGameFragment {
         resume();
     }
 
-    /** Process a resumption by testing and waiting for the experience. */
-    private void resume() {
-        if (mExperience == null) {
-            // Disable the layout and startup the spinner.
-            mLayout.setVisibility(View.GONE);
-            String title = "TicTacToe";
-            String message = "Waiting for the database to provide the game...";
-            ProgressManager.instance.show(getContext(), title, message);
-        } else {
-            // Hide the spinner and start the game.
-            ProgressManager.instance.hide();
-            mLayout.setVisibility(View.VISIBLE);
-        }
-    }
+    // Protected instance methods.
 
     /** Return an experience for a given dispatcher instance. */
     @Override protected void createExperience(@NonNull final Context context,
@@ -133,64 +136,13 @@ public class TTTFragment extends BaseGameFragment {
         createExperience(context, players);
     }
 
-    // Private instance methods.
-
-    /**
-     * Evaluates the state of the board, determining if there are three in a row of either X or O.
-     *
-     * @return false if a player has won or if the full number of turns has occurred, true otherwise.
-     */
-    private boolean checkNotFinished(@NonNull final TicTacToe model) {
-        // First, we need to check on the buttons' states.
-        int[][] boardValues = evaluateBoard(model);
-
-        // Evaluate all possible lines of 3.
-        int topRow = boardValues[0][0] + boardValues[0][1] + boardValues[0][2];
-        int midRow = boardValues[1][0] + boardValues[1][1] + boardValues[1][2];
-        int botRow = boardValues[2][0] + boardValues[2][1] + boardValues[2][2];
-        int startCol = boardValues[0][0] + boardValues[1][0] + boardValues[2][0];
-        int centerCol = boardValues[0][1] + boardValues[1][1] + boardValues[2][1];
-        int endCol = boardValues[0][2] + boardValues[1][2] + boardValues[2][2];
-        int leftDiag = boardValues[0][0] + boardValues[1][1] + boardValues[2][2];
-        int rightDiag = boardValues[2][0] + boardValues[1][1] + boardValues [0][2];
-
-        // If any lines of 3 are equal to 3, X wins.
-        boolean xWins = (topRow == 3 || midRow == 3 || botRow == 3 || startCol == 3
-                || centerCol == 3 || endCol == 3 || leftDiag == 3 || rightDiag == 3);
-
-        // If any lines of 3 are equal to 6, O wins.
-        boolean oWins = (topRow == 6 || midRow == 6 || botRow == 6 || startCol == 6
-                || centerCol == 6 || endCol == 6 || leftDiag == 6 || rightDiag == 6);
-
-        // If we have a win condition, reveal the winning messages.
-        if (xWins || oWins || mLayoutMap.size() == 10) {
-            // Setup the winner TextView and snackbar messages.
-            TextView Winner = (TextView) super.getActivity().findViewById(R.id.winner);
-            Winner.setText("");
-            Winner.setVisibility(View.VISIBLE);
-
-            // If there is a winner, output winning messages and ensure that the appropriate
-            // player's icon has been highlighted.
-            if (xWins) {
-                updateWinCount(0);
-                Winner.setText(R.string.winner_x);
-                handlePlayerIcons(true);
-            } else if (oWins) {
-                updateWinCount(1);
-                Winner.setText(R.string.winner_o);
-                handlePlayerIcons(false);
-
-            // If no one has won, the turn timer has run out. End the game.
-            } else {
-                // Reveal Tie Messages
-                Winner.setText(R.string.winner_tie);
-                GameManager.instance.notify(mLayout, "It's a Tie!", -1, true);
-            }
-            return false;
-        }
-        // If none of the conditions are met, the game has not yet ended, and we can continue it.
-        return true;
+    /** Handle a requrest to setup the experience by initializing the convenience board values. */
+    @Override protected void setupExperience(final Context context, final Dispatcher dispatcher) {
+        super.setupExperience(context, dispatcher);
+        initBoard();
     }
+
+    // Private instance methods.
 
     /** Return a default, partially populated, TicTacToe experience. */
     private void createExperience(final Context context, final List<Account> playerAccounts) {
@@ -208,53 +160,20 @@ public class TTTFragment extends BaseGameFragment {
         String id = getOwnerId();
         TicTacToe model = new TicTacToe(key, id, name, tstamp, groupKey, roomKey, players);
         DatabaseManager.instance.createExperience(model);
-
-        // Lastly, if there is a valid key, use it to cache an offline experience.  Abort if no
-        // such key is available.
-        //if (key == null  || exp == null) return null;
-        //exp.setExperienceKey(key);
-        //DatabaseListManager.instance.experienceMap.put(key, exp);
-        //return exp;
     }
 
-    /**
-     * Evaluates the current state of the individual tiles of the board and stores them as a HashMap
-     * in the Firebase Database.
-     */
-    private int[][] evaluateBoard(@NonNull final TicTacToe model) {
-        int[][] boardValues = new int[3][3];
-        if (mLayoutMap == null) mLayoutMap = new HashMap<>();
-        // Go through all the buttons.
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 3; j++) {
-                String text = "button" + Integer.toString(i) + Integer.toBinaryString(j);
-                Button currTile = (Button) mLayout.findViewWithTag(text);
-                String tileValue = currTile.getText().toString();
+    /** Return a done message text to show in a snackbar.  The given model provides the state. */
+    private String getDoneMessage(final TicTacToe model) {
+        // Determine if there is a winner.  If not, return the "tie" message.
+        String name = model.getWiningPlayerName();
+        if (name == null) return getString(R.string.TieMessage);
 
-                // Assign each possible state for each tile as a value. The only possible values
-                // of each row (that indicate and endgame state) are 3 in a row of X or O. There
-                // is no way to get a value of 3 without getting 3 Xs, and there's no way to get a
-                // value of 6 without getting 3 Os.
-
-                // If there's an X in this button, store a 1
-                if (tileValue.equals(model.getSymbolValue(0))) {
-                    boardValues[i][j] = 1;
-                    if(!(mLayoutMap.containsKey(i + "-" + j))) mLayoutMap.put(i + "-" + j, 1);
-                    // If there's an O in this button, store a 2
-                } else if (tileValue.equals(model.getSymbolValue(1))) {
-                    boardValues[i][j] = 2;
-                    if(!(mLayoutMap.containsKey(i + "-" + j))) mLayoutMap.put(i + "-" + j, 2);
-                    // Otherwise, there's a space. -5 was chosen arbitrarily to keep row values unique.
-                } else {
-                    boardValues[i][j] = -5;
-                }
-            }
-        }
-        //mRef.setValue(mLayoutMap);
-        return boardValues;
+        // There was a winner.  Return a congratulatory message.
+        String format = getString(R.string.WinMessage);
+        return String.format(Locale.getDefault(), format, name);
     }
 
-    // Return either a null placeholder key value or a sentinel value as the experience key. */
+    /** Return either a null placeholder key value or a sentinel value as the experience key. */
     private String getExperienceKey() {
         // Determine if there is a signed in account.  If so use the null placeholder.
         String accountId = AccountManager.instance.getCurrentAccountId();
@@ -315,7 +234,7 @@ public class TTTFragment extends BaseGameFragment {
         String name = getPlayerName(getPlayer(players, 0), "Player1");
         String symbol = context.getString(R.string.xValue);
         result.add(new Player(name, symbol));
-        name = getPlayerName(getPlayer(players, 0), "Player2");
+        name = getPlayerName(getPlayer(players, 1), context.getString(R.string.friend));
         symbol = context.getString(R.string.oValue);
         result.add(new Player(name, symbol));
 
@@ -341,22 +260,147 @@ public class TTTFragment extends BaseGameFragment {
     }
 
     /** Handle the turn indicator management by manipulating the turn icon size and decorations. */
-    private void handlePlayerIcons(final boolean turn) {
-        // Alternate the decorations on each player sigil/symbol.
-        if (turn) {
+    private void setPlayerIcons(final boolean turn) {
+        // Alternate the decorations on each player symbol.
+        if (turn)
             // Make player1's decorations the more prominent.
-            handlePlayerIcons(R.id.player1Sigil, R.id.leftIndicator1, R.id.rightIndicator1,
-                              R.id.player2Sigil, R.id.leftIndicator2, R.id.rightIndicator2);
-        } else {
+            setPlayerIcons(R.id.player1Symbol, R.id.leftIndicator1, R.id.rightIndicator1,
+                           R.id.player2Symbol, R.id.leftIndicator2, R.id.rightIndicator2);
+        else
             // Make player2's decorations the more prominent.
-            handlePlayerIcons(R.id.player2Sigil, R.id.leftIndicator2, R.id.rightIndicator2,
-                              R.id.player1Sigil, R.id.leftIndicator1, R.id.rightIndicator1);
+            setPlayerIcons(R.id.player2Symbol, R.id.leftIndicator2, R.id.rightIndicator2,
+                           R.id.player1Symbol, R.id.leftIndicator1, R.id.rightIndicator1);
+    }
+
+    /**
+     * Evaluates the state of the board, determining if there are three in a row of either X or O.
+     *
+     * @return false if a player has won or if the full number of turns has occurred, true otherwise.
+     */
+    private int getState(@NonNull final TicTacToe model, String buttonTag) {
+        // Update the array of moves with the value of button tag from the model.  The button tag
+        // has been vetted and will cause no exceptions.
+        int value = model.getSymbolValue();
+        int i = Integer.parseInt(buttonTag.substring(6, 7));
+        int j = Integer.parseInt(buttonTag.substring(7, 8));
+        mBoardValues[i][j] = value;
+
+        // Evaluate all possible lines of 3.
+        int topRow = mBoardValues[0][0] + mBoardValues[0][1] + mBoardValues[0][2];
+        int midRow = mBoardValues[1][0] + mBoardValues[1][1] + mBoardValues[1][2];
+        int botRow = mBoardValues[2][0] + mBoardValues[2][1] + mBoardValues[2][2];
+        int startCol = mBoardValues[0][0] + mBoardValues[1][0] + mBoardValues[2][0];
+        int centerCol = mBoardValues[0][1] + mBoardValues[1][1] + mBoardValues[2][1];
+        int endCol = mBoardValues[0][2] + mBoardValues[1][2] + mBoardValues[2][2];
+        int leftDiag = mBoardValues[0][0] + mBoardValues[1][1] + mBoardValues[2][2];
+        int rightDiag = mBoardValues[2][0] + mBoardValues[1][1] + mBoardValues[0][2];
+
+        // If any lines of 3 are equal to 3, X wins.
+        boolean xWins = (topRow == 3 || midRow == 3 || botRow == 3 || startCol == 3
+                || centerCol == 3 || endCol == 3 || leftDiag == 3 || rightDiag == 3);
+        if (xWins) return TicTacToe.X_WINS;
+
+        // If any lines of 3 are equal to 6, O wins.
+        boolean oWins = (topRow == 6 || midRow == 6 || botRow == 6 || startCol == 6
+                || centerCol == 6 || endCol == 6 || leftDiag == 6 || rightDiag == 6);
+        if (oWins) return TicTacToe.O_WINS;
+
+        // Determine if there is a tie.
+        if (model.board.size() == 9) return TicTacToe.TIE;
+
+        return TicTacToe.ACTIVE;
+    }
+
+    /** Handle a new game by resetting the data model. */
+    private void handleNewGame() {
+        // Ensure that the data model exists and is valid.
+        TicTacToe model = getModel();
+        if (model == null) {
+            Log.e(TAG, "Null TTT data model.", new Throwable());
+            return;
+        }
+
+        // Reset the data model and update the database.
+        initBoard();
+        TextView winner = (TextView) mLayout.findViewById(R.id.winner);
+        if (winner != null) winner.setText("");
+        model.board = null;
+        model.state = TicTacToe.ACTIVE;
+        DatabaseManager.instance.updateExperience(mExperience);
+
+
+    }
+
+    /** Handle a click on a given tile by updating the value on the tile and start the next turn. */
+    private void handleTileClick(final String buttonTag) {
+        // Ensure that the click occurred on a grid button.  Abort if not.
+        View view = mLayout.findViewWithTag(buttonTag);
+        if (view == null || !(view instanceof Button)) return;
+
+        // The click occurred on a grid button.  Ensure that the data model exists, aborting if not.
+        TicTacToe model = getModel();
+        if (model == null) {
+            Log.e(TAG, "Null experience model detected", new Throwable());
+            return;
+        }
+
+        // Ensure that the game is still active, providing a "Play again?" snackbar message if not.
+        if (model.state != TicTacToe.ACTIVE) {
+            // Use the coordinator view to manage the FAB button movement and notify the User via a
+            // snackbar that the game is over.
+            GameManager.instance.notify(this, getDoneMessage(model), true);
+            return;
+        }
+
+        // Update the database with the collected changes.
+        if (model.board == null) model.board = new HashMap<>();
+        model.board.put(buttonTag, model.getSymbolText());
+        model.state = getState(model, buttonTag);
+        model.setWinCount();
+        model.toggleTurn();
+        DatabaseManager.instance.updateExperience(mExperience);
+    }
+
+    /** Initialize the board values array to all -5 values. */
+    private void initBoard() {
+        mBoardValues = new int[3][3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                // Seed the array with a value that will guarantee the X vs O win and a tie will be
+                // calculated correctly.
+                mBoardValues[i][j] = -5;
+
+                // Determine if the grid button needs to be reset.  Continue if not.
+                if (mLayout == null) continue;
+
+                // Reset the grid button.
+                String tag = String.format(Locale.US, "button%d%d", i, j);
+                TextView button = (TextView) mLayout.findViewWithTag(tag);
+                if (button != null) button.setText("");
+            }
+        }
+    }
+
+    /** Process a resumption by testing and waiting for the experience. */
+    private void resume() {
+        if (mExperience == null) {
+            // Disable the layout and startup the spinner.
+            mLayout.setVisibility(View.GONE);
+            String title = "TicTacToe";
+            String message = "Waiting for the database to provide the game...";
+            ProgressManager.instance.show(getContext(), title, message);
+        } else {
+            // Hide the spinner, start the game and update the views using the current state of the
+            // experience.
+            ProgressManager.instance.hide();
+            mLayout.setVisibility(View.VISIBLE);
+            updateExperience();
         }
     }
 
     /** Manage a particular player's sigil decorations. */
-    private void handlePlayerIcons(final int large, final int largeLeft, final int largeRight,
-                                   final int small, final int smallLeft, final int smallRight) {
+    private void setPlayerIcons(final int large, final int largeLeft, final int largeRight,
+                                final int small, final int smallLeft, final int smallRight) {
         final float LARGE = 60.0f;
         final float SMALL = 45.0f;
 
@@ -381,29 +425,94 @@ public class TTTFragment extends BaseGameFragment {
         tvSmallRight.setVisibility(View.INVISIBLE);
     }
 
-    /** Handle a click on a given tile by updating the value on the tile and start the next turn. */
-    private void handleTileClick(final String buttonTag) {
-        // Ensure that a model object exists, the given button exists, is empty and the game is
-        // still in progress.  Abort otherwise.
-        Button button = (Button) mLayout.findViewWithTag(buttonTag);
-        boolean invalidButton = button == null || button.getText().length() > 0;
-        TicTacToe model = getModel();
-        if (model == null || invalidButton || !(checkNotFinished(model))) return;
-
-        // The move is valid. Update the board and toggle the turn.
-        button.setText(model.getSymbolValue());
-        handlePlayerIcons(model.toggleTurn());
-        checkNotFinished(model);
+    /** Set the name for a given player index. */
+    private void setPlayerName(final int resId, final int index, final TicTacToe model) {
+        // Ensure that the name text view exists. Abort if not.  Set the value from the model if it
+        // does.
+        TextView name = (TextView) mLayout.findViewById(resId);
+        if (name == null) return;
+        name.setText(model.players.get(index).name);
     }
 
-    /** Update the win count model. */
-    private void updateWinCount(final int index) {
-        TicTacToe model = getModel();
-        if (model == null) return;
+    /** Set the sigil (X or O) for a given player. */
+    private void setPlayerSymbol(final int resId, final int index, final TicTacToe model) {
+        // Ensure that the sigil text view exists.  Abort if not, set the value from the data
+        // model if it does.
+        TextView symbol = (TextView) mLayout.findViewById(resId);
+        if (symbol == null) return;
+        symbol.setText(model.players.get(index).symbol);
+    }
 
-        // Update the data model.
-        model.players.get(index).winCount++;
-        //DatabaseManager.instance.updateExperience(mExperience);
+    /** Set the name for a given player index. */
+    private void setPlayerWinCount(final int resId, final int index, final TicTacToe model) {
+        // Ensure that the win count text view exists. Abort if not.  Set the value from the model
+        // if it does.
+        TextView winCount = (TextView) mLayout.findViewById(resId);
+        if (winCount == null) return;
+        winCount.setText(String.valueOf(model.players.get(index).winCount));
+    }
+
+    /** Update the game state. */
+    private void setState(final TicTacToe model) {
+        TextView winner = (TextView) mLayout.findViewById(R.id.winner);
+        String value = null;
+        switch (model.state) {
+            case TicTacToe.X_WINS:
+                // do some stuff.
+                value = getString(R.string.winner_x);
+                break;
+            case TicTacToe.O_WINS:
+                // do other stuff.
+                value = getString(R.string.winner_o);
+                break;
+            case TicTacToe.TIE:
+                // Reveal Tie Messages
+                value = getString(R.string.winner_tie);
+                break;
+            default:
+                // keeep playing.
+                break;
+        }
+
+        // Determine if the game has ended (winner or tie).  Abort if not.
+        if (value == null) return;
+
+        // Update the winner text view.
+        winner.setText(value);
+        winner.setVisibility(View.VISIBLE);
+        GameManager.instance.notify(this, getDoneMessage(model), true);
+    }
+
+    /** Set up the game board based on the data model state. */
+    private void setGameBoard(@NonNull final TicTacToe model) {
+        // Determine if the board has any pieces to put on the board.  If not reset the board.
+        if (model.board != null)
+            for (String tag : model.board.keySet()) {
+                // Determine if the position denoted by the suffix is valid and has mot yet been
+                // updated.  If so, then update the position.
+                String value = model.board.get(tag);
+                Button button = (Button) mLayout.findViewWithTag(tag);
+                if (button != null && button.getText().equals("")) button.setText(value);
+            }
+    }
+
+    /** Update the UI using the current experience state from the database. */
+    private void updateExperience() {
+        // Ensure that a valid experience exists.  Abort if not.
+        if (mExperience == null || !(mExperience instanceof TicTacToe)) return;
+
+        // A valid experience is available. Use the data model to populate the UI and check if the
+        // game is finished.
+        TicTacToe model = (TicTacToe) mExperience;
+        setPlayerName(R.id.player1Name, 0, model);
+        setPlayerName(R.id.player2Name, 1, model);
+        setPlayerWinCount(R.id.player1WinCount, 0, model);
+        setPlayerWinCount(R.id.player2WinCount, 1, model);
+        setPlayerSymbol(R.id.player1Symbol, 0, model);
+        setPlayerSymbol(R.id.player2Symbol, 1, model);
+        setPlayerIcons(model.turn);
+        setGameBoard(model);
+        setState(model);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java
@@ -279,7 +279,7 @@ public class TTTFragment extends BaseGameFragment {
         Room room = key != null ? DatabaseListManager.instance.roomMap.get(key) : null;
         int type = room != null ? room.type : -1;
         switch (type) {
-            //case USER:
+            //case MEMBER:
                 // Handle another User by providing their account.
             //    break;
             default:

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.game.model;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
+import com.pajato.android.gamechat.game.ExpType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,20 +49,20 @@ public class ExpProfile {
     /** The room key. */
     public String roomKey;
 
-    /** The experience type value. */
+    /** The experience type ordinal value. */
     public int type;
 
     // Public constructors.
 
     /** Build an empty args constructor for the database. */
-    public ExpProfile() {}
+    @SuppressWarnings("unused") public ExpProfile() {}
 
     /** Build a experience profile with a full set of values. */
-    public ExpProfile(final String key, final String name, final int type, final String groupKey,
-                      final String roomKey, final String expKey) {
+    public ExpProfile(final String key, final String name, final ExpType expType,
+                      final String groupKey, final String roomKey, final String expKey) {
         this.key = key;
         this.name = name;
-        this.type = type;
+        this.type = expType.ordinal();
         this.groupKey = groupKey;
         this.roomKey = roomKey;
         this.expKey = expKey;

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/ExpProfile.java
@@ -33,10 +33,13 @@ import java.util.Map;
 @IgnoreExtraProperties
 public class ExpProfile {
 
+    /** The experience key. */
+    public String expKey;
+
     /** The group key. */
     public String groupKey;
 
-    /** The experience key. */
+    /** The profile key (self reference). */
     public String key;
 
     /** The experience's display name. */
@@ -55,17 +58,19 @@ public class ExpProfile {
 
     /** Build a experience profile with a full set of values. */
     public ExpProfile(final String key, final String name, final int type, final String groupKey,
-                      final String roomKey) {
+                      final String roomKey, final String expKey) {
         this.key = key;
         this.name = name;
         this.type = type;
         this.groupKey = groupKey;
         this.roomKey = roomKey;
+        this.expKey = expKey;
     }
 
     /** Provide a default map for a Firebase create/update. */
     @Exclude public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
+        result.put("expKey", expKey);
         result.put("groupKey", groupKey);
         result.put("key", key);
         result.put("name", name);

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/Player.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/Player.java
@@ -17,21 +17,17 @@
 
 package com.pajato.android.gamechat.game.model;
 
-import com.google.firebase.database.Exclude;
-import com.google.firebase.database.IgnoreExtraProperties;
-
 import java.util.HashMap;
 import java.util.Map;
 
-/** Provide a Firebase model class repesenting a tictactoe game experience, an icon, a name and text. */
-@IgnoreExtraProperties
+/** Provide a pojo repesenting a tictactoe player: a name, a symbol (sigil), and a count. */
 public class Player {
 
     /** The player's display name. */
     public String name;
 
-    /** The player's sigil (for lack of a better term). */
-    public int sigilId;
+    /** The player's symbol (either X or O). */
+    public String symbol;
 
     /** The player's win count. */
     public int winCount;
@@ -42,17 +38,24 @@ public class Player {
     public Player() {}
 
     /** Build a default game player using all the parameters. */
-    public Player(final String name, final int sigilId) {
+    public Player(final String name, final String symbol) {
         this.name = name;
-        this.sigilId = sigilId;
+        this.symbol = symbol;
         this.winCount = 0;
     }
 
+    /** Build an instance accepting Object values for all fields. */
+    public Player(final Object name, final Object symbol, final Object winCount) {
+        this.name = name instanceof String ? (String) name : "anonymous";
+        this.symbol = symbol instanceof String ? (String) symbol : "?";
+        this.winCount = winCount instanceof Integer ? (Integer) winCount : 0;
+    }
+
     /** Provide a default map for a Firebase create/update. */
-    @Exclude public Map<String, Object> toMap() {
+    public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("name", name);
-        result.put("sigilId", sigilId);
+        result.put("symbol", symbol);
         result.put("winCount", winCount);
 
         return result;

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
@@ -21,11 +21,12 @@ import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
 import com.pajato.android.gamechat.game.ExpType;
 import com.pajato.android.gamechat.game.Experience;
-import com.pajato.android.gamechat.game.FragmentType;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.pajato.android.gamechat.game.ExpType.ttt;
 
 /** Provide a Firebase model class for a tictactoe game experience. */
 @IgnoreExtraProperties public class TicTacToe implements Experience {
@@ -33,9 +34,9 @@ import java.util.Map;
     // Public class constants.
 
     /** The level types. */
-    public final static int EASY = 0;
-    public final static int INTERMEDIATE = 1;
-    public final static int IMPOSSIBLE = 2;
+    //public final static int EASY = 0;
+    //public final static int INTERMEDIATE = 1;
+    //public final static int IMPOSSIBLE = 2;
 
     /** A list of board positions that have been filled by either an X or an O. */
     public List<String> board;
@@ -50,7 +51,7 @@ import java.util.Map;
     public String groupKey;
 
     /** The game level. */
-    public int level;
+    //public int level;
 
     /** The last modification timestamp. */
     public long modTime;
@@ -73,13 +74,13 @@ import java.util.Map;
     /** The current turn. */
     public boolean turn;
 
-    /** The experience type. */
+    /** The experience type ordinal value. */
     public int type = -1;
 
     // Public constructors.
 
     /** Build an empty args constructor for the database. */
-    public TicTacToe() {}
+    @SuppressWarnings("unused") public TicTacToe() {}
 
     /** Build a default TicTacToe using the given parameters and defaulting the rest. */
     public TicTacToe(final String key, final String id, final String name, final long createTime,
@@ -93,7 +94,7 @@ import java.util.Map;
         this.players = players;
         this.roomKey = roomKey;
         turn = true;
-        type = ExpType.ttt.ordinal();
+        type = ttt.ordinal();
         url = "android.resource://com.pajato.android.gamechat/drawable/ic_tictactoe_red";
     }
 
@@ -116,16 +117,16 @@ import java.util.Map;
         return result;
     }
 
-    /** Return the fragment type value or null if no such fragment type exists. */
-    @Exclude @Override public FragmentType getFragmentType() {
-        if (type < 0 || type >= FragmentType.values().length) return null;
-
-        return FragmentType.values()[type];
-    }
-
     /** Return the experience push key. */
     @Exclude @Override public String getExperienceKey() {
         return key;
+    }
+
+    /** Return the fragment type value or null if no such fragment type exists. */
+    @Exclude @Override public ExpType getExperienceType() {
+        if (type < 0 || type >= ExpType.values().length) return null;
+
+        return ExpType.values()[type];
     }
 
     /** Return the group push key. */
@@ -151,11 +152,6 @@ import java.util.Map;
     /** Return the symbol text value for the player whose turn is current. */
     @Exclude public String getSymbolValue() {
         return turn ? players.get(0).symbol : players.get(1).symbol;
-    }
-
-    /** Return the type to satisfy the Experience contract. */
-    @Exclude @Override public int getType() {
-        return type;
     }
 
     /** Set the experience key to satisfy the Experience contract. */

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
@@ -38,11 +38,27 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
     //public final static int INTERMEDIATE = 1;
     //public final static int IMPOSSIBLE = 2;
 
-    /** A list of board positions that have been filled by either an X or an O. */
-    public List<String> board;
+    // The game state values.
+
+    /** The game is still active. */
+    public final static int ACTIVE = 0;
+
+    /** The game has been won by player using X. */
+    public final static int X_WINS = 1;
+
+    /** The game has been won by player using O. */
+    public final static int O_WINS = 2;
+
+    /** The game has ended in a tie. */
+    public final static int TIE = 3;
+
+    // Public instance variables.
+
+    /** The board positions that have been filled by either an X or an O. */
+    public Map<String, String> board;
 
     /** The creation timestamp. */
-    public long createTime;
+    private long createTime;
 
     /** The experience push key. */
     public String key;
@@ -54,7 +70,7 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
     //public int level;
 
     /** The last modification timestamp. */
-    public long modTime;
+    private long modTime;
 
     /** The experience display name. */
     public String name;
@@ -68,14 +84,17 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
     /** The room push key. */
     public String roomKey;
 
-    /** The experience icon url. */
-    public String url;
+    /** The game state. */
+    public int state;
 
     /** The current turn. */
     public boolean turn;
 
     /** The experience type ordinal value. */
     public int type = -1;
+
+    /** The experience icon url. */
+    public String url;
 
     // Public constructors.
 
@@ -93,6 +112,7 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
         this.owner = id;
         this.players = players;
         this.roomKey = roomKey;
+        state = ACTIVE;
         turn = true;
         type = ttt.ordinal();
         url = "android.resource://com.pajato.android.gamechat/drawable/ic_tictactoe_red";
@@ -110,6 +130,7 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
         result.put("owner", owner);
         result.put("players", players);
         result.put("roomKey", roomKey);
+        result.put("state", state);
         result.put("turn", turn);
         result.put("type", type);
         result.put("url", url);
@@ -144,13 +165,14 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
         return roomKey;
     }
 
-    /** Return the symbol text value for the player at the given index. */
-    @Exclude public String getSymbolValue(final int index) {
-        return players.get(index).symbol;
+    /** Return the value associated with the current player: 1 == X, 2 == O. */
+    @Exclude public int getSymbolValue() {
+        // This implies that player 1 is always X and player 2 is always O.
+        return turn ? 1 : 2;
     }
 
     /** Return the symbol text value for the player whose turn is current. */
-    @Exclude public String getSymbolValue() {
+    @Exclude public String getSymbolText() {
         return turn ? players.get(0).symbol : players.get(1).symbol;
     }
 
@@ -159,10 +181,43 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
         this.key = key;
     }
 
+    /** Set the modification timestamp. */
+    @Exclude @Override public void setModTime(final long value) {
+        modTime = value;
+    }
+
+    /** Update the win count based on the current state. */
+    @Exclude @Override public void setWinCount() {
+        switch (state) {
+            case X_WINS:
+                players.get(0).winCount++;
+                break;
+            case O_WINS:
+                players.get(1).winCount++;
+                break;
+            default:
+                break;
+        }
+    }
+
     /** Toggle the turn state. */
     @Exclude public boolean toggleTurn() {
         turn = !turn;
         return turn;
+    }
+
+    /** Return the winning player's name or null if the game is active or ended in a tie. */
+    @Exclude public String getWiningPlayerName() {
+        switch (state) {
+            case X_WINS:
+                return players.get(0).name;
+            case O_WINS:
+                return players.get(1).name;
+            case ACTIVE:
+            case TIE:
+            default:
+                return null;
+        }
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
@@ -23,7 +23,6 @@ import com.pajato.android.gamechat.game.ExpType;
 import com.pajato.android.gamechat.game.Experience;
 import com.pajato.android.gamechat.game.FragmentType;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,7 @@ import java.util.Map;
     public long createTime;
 
     /** The experience push key. */
-    public String experienceKey;
+    public String key;
 
     /** The group push key. */
     public String groupKey;
@@ -64,9 +63,6 @@ import java.util.Map;
 
     /** The list of players, for tictactoe, two of them. */
     public List<Player> players;
-
-    /** The list of players in a form the Firebase updateChildren() can grok. */
-    public List<Map<String, Object>> playerList;
 
     /** The room push key. */
     public String roomKey;
@@ -89,7 +85,7 @@ import java.util.Map;
     public TicTacToe(final String key, final String id, final String name, final long createTime,
                      final String groupKey, final String roomKey, final List<Player> players) {
         this.createTime = createTime;
-        this.experienceKey = key;
+        this.key = key;
         this.groupKey = groupKey;
         this.modTime = 0;
         this.name = name;
@@ -106,12 +102,12 @@ import java.util.Map;
         Map<String, Object> result = new HashMap<>();
         result.put("board", board);
         result.put("createTime", createTime);
-        result.put("expKey", experienceKey);
+        result.put("key", key);
         result.put("groupKey", groupKey);
         result.put("modTime", modTime);
         result.put("name", name);
         result.put("owner", owner);
-        result.put("players", getPlayerList());
+        result.put("players", players);
         result.put("roomKey", roomKey);
         result.put("turn", turn);
         result.put("type", type);
@@ -129,7 +125,7 @@ import java.util.Map;
 
     /** Return the experience push key. */
     @Exclude @Override public String getExperienceKey() {
-        return experienceKey;
+        return key;
     }
 
     /** Return the group push key. */
@@ -140,25 +136,6 @@ import java.util.Map;
     /** Return the experience name. */
     @Exclude @Override public String getName() {
         return name;
-    }
-
-    /** Convert the list of players to a list of maps to pacify the Firebase parser. */
-    @Exclude public List<Map<String, Object>> getPlayerList() {
-        List<Map<String, Object>> result = new ArrayList<>();
-        for (Player player : players) {
-            // Determine if the player needs to be added.  Just continue if it does not.
-            if (player == null) continue;
-
-            // Add the player as a map to the list to keep the firebase parser content.
-            result.add(player.toMap());
-        }
-
-        return result;
-    }
-
-    /** Provide a getter for the players to satisfy the Firebase contract. */
-    @Exclude public List<Player> getPlayers() {
-        return players;
     }
 
     /** Return the room push key. */
@@ -183,17 +160,7 @@ import java.util.Map;
 
     /** Set the experience key to satisfy the Experience contract. */
     @Exclude @Override public void setExperienceKey(final String key) {
-        experienceKey = key;
-    }
-
-    /** Set the player map. */
-    public void setPlayers(final List<Map<String, Object>> list) {
-        players = new ArrayList<>();
-        for (int index = 0; index < list.size(); index++) {
-            Map<String, Object> map = list.get(index);
-            Player player = new Player(map.get("name"), map.get("symbol"), map.get("winCount"));
-            players.add(player);
-        }
+        this.key = key;
     }
 
     /** Toggle the turn state. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java
@@ -30,8 +30,18 @@ import android.net.NetworkInfo;
 public enum NetworkManager {
     instance;
 
+    // Public constants.
+
+    /** The sentinel value used to indicate an offline, cached database object. */
+    public static final String OFFLINE_OWNER_ID = "offlineOwnerId";
+
+    /** The sentinel value used to indicate an offline, cached experience key. */
+    public static final String OFFLINE_EXPERIENCE_KEY = "offlineExperienceKey";
+
     // Private instance variables.
 
+
+    /** The network state. */
     private boolean online;
 
     // Public instance methods

--- a/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
@@ -43,17 +43,22 @@ public enum ProgressManager {
 
     /** Show the initial loading dialog. */
     public void show(@NonNull final Context context) {
-        if (mProgressDialog != null) {
-            // A progress dialog already exists!  Generate a stack trace to help debug this.
-            Log.e(TAG, "A progress dialog already exists.  Generate a stack trace!");
-            Thread.dumpStack();
-        }
-
         // Create and display the progress dialog.
         Log.d(TAG, "Turning on progress spinner now.");
         mProgressDialog = new ProgressDialog(context);
         mProgressDialog.setTitle("Starting...");
         mProgressDialog.setMessage("Please wait while the app starts up...");
+        mProgressDialog.show();
+        mIsShowing = true;
+    }
+
+    /** Show a loading dialog with a given message. */
+    public void show(@NonNull final Context context, final String title, final String message) {
+        // Create and display the progress dialog.
+        Log.d(TAG, "Turning on progress spinner now.");
+        mProgressDialog = new ProgressDialog(context);
+        mProgressDialog.setTitle(title);
+        mProgressDialog.setMessage(message);
         mProgressDialog.show();
         mIsShowing = true;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
@@ -41,6 +41,21 @@ public enum ProgressManager {
 
     // Public instance methods
 
+    /** Dismiss the initial loading dialog if one is showing. */
+    public void hide() {
+        Log.d(TAG, "Attempting to hide the progress dialog.");
+        if (mIsShowing && mProgressDialog != null) {
+            mProgressDialog.dismiss();
+            mProgressDialog = null;
+            mIsShowing = false;
+        }
+    }
+
+    /** Return TRUE iff the progress spinner is being shown. */
+    public boolean isShowing() {
+        return mIsShowing;
+    }
+
     /** Show the initial loading dialog. */
     public void show(@NonNull final Context context) {
         // Create and display the progress dialog.
@@ -63,13 +78,4 @@ public enum ProgressManager {
         mIsShowing = true;
     }
 
-    /** Dismiss the initial loading dialog if one is showing. */
-    public void hide() {
-        Log.d(TAG, "Attempting to hide the progress dialog.");
-        if (mIsShowing && mProgressDialog != null) {
-            mProgressDialog.dismiss();
-            mProgressDialog = null;
-            mIsShowing = false;
-        }
-    }
 }

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -20,41 +20,54 @@ http://www.gnu.org/licenses
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/gamePaneLayout">
 
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/game_pane_fragment_container">
-    </FrameLayout>
+        android:id="@+id/game_pane_fragment_container"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <View style="@style/DimmerTheme"
         android:id="@+id/gameDimmer"
-        tools:visibility="visible"/>
-
-    <FrameLayout style="@style/FabMenu"
-        android:layout_marginBottom="8dp"
-        android:id="@+id/gameFabMenu"
+        tools:visibility="visible"
+        android:layout_height="0dp"
+        android:layout_width="0dp"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/gameFab">
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/gameList"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-    </FrameLayout>
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-    <android.support.design.widget.FloatingActionButton
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:gravity="bottom|start"
-        android:id="@+id/gameFab"
-        android:src="@drawable/ic_add_white_24dp"
-        android:onClick="onClick"
+        android:id="@+id/clayout"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:fabSize="normal"
-        tools:visibility="visible"/>
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <FrameLayout style="@style/FabMenu"
+            android:layout_marginBottom="88dp"
+            android:id="@+id/gameFabMenu"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/gameFab">
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/gameList"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </FrameLayout>
+
+        <android.support.design.widget.FloatingActionButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_gravity="bottom|end"
+            android:id="@+id/gameFab"
+            android:src="@drawable/ic_add_white_24dp"
+            android:onClick="onClick"
+            app:fabSize="normal"
+            tools:visibility="visible"/>
+
+    </android.support.design.widget.CoordinatorLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_game_ttt.xml
+++ b/app/src/main/res/layout/fragment_game_ttt.xml
@@ -116,7 +116,7 @@ http://www.gnu.org/licenses
         android:layout_marginEnd="52dp"
         android:text="@string/xValue"
         android:textSize="60sp"
-        android:id="@+id/player1Sigil"
+        android:id="@+id/player1Symbol"
         android:textColor="@color/colorAccent"
         app:layout_constraintCenterY_toCenterY="@id/turn"
         app:layout_constraintRight_toLeftOf="@+id/turn" />
@@ -129,9 +129,9 @@ http://www.gnu.org/licenses
         android:textColor="@color/colorAccent"
         android:textSize="20sp"
         android:layout_marginEnd="8dp"
-        app:layout_constraintTop_toTopOf="@+id/player1Sigil"
-        app:layout_constraintRight_toLeftOf="@+id/player1Sigil"
-        app:layout_constraintBottom_toBottomOf="@+id/player1Sigil"/>
+        app:layout_constraintTop_toTopOf="@+id/player1Symbol"
+        app:layout_constraintRight_toLeftOf="@+id/player1Symbol"
+        app:layout_constraintBottom_toBottomOf="@+id/player1Symbol"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -141,9 +141,9 @@ http://www.gnu.org/licenses
         android:textColor="@color/colorAccent"
         android:textSize="20sp"
         android:layout_marginStart="8dp"
-        app:layout_constraintTop_toTopOf="@+id/player1Sigil"
-        app:layout_constraintLeft_toRightOf="@+id/player1Sigil"
-        app:layout_constraintBottom_toBottomOf="@+id/player1Sigil"/>
+        app:layout_constraintTop_toTopOf="@+id/player1Symbol"
+        app:layout_constraintLeft_toRightOf="@+id/player1Symbol"
+        app:layout_constraintBottom_toBottomOf="@+id/player1Symbol"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -151,7 +151,7 @@ http://www.gnu.org/licenses
         android:layout_marginStart="52dp"
         android:text="@string/oValue"
         android:textSize="45sp"
-        android:id="@+id/player2Sigil"
+        android:id="@+id/player2Symbol"
         android:textColor="@color/colorPrimaryDark"
         app:layout_constraintCenterY_toCenterY="@+id/turn"
         app:layout_constraintLeft_toRightOf="@+id/turn" />
@@ -165,9 +165,9 @@ http://www.gnu.org/licenses
         android:textSize="20sp"
         android:layout_marginEnd="8dp"
         android:visibility="invisible"
-        app:layout_constraintTop_toTopOf="@+id/player2Sigil"
-        app:layout_constraintRight_toLeftOf="@+id/player2Sigil"
-        app:layout_constraintBottom_toBottomOf="@+id/player2Sigil"/>
+        app:layout_constraintTop_toTopOf="@+id/player2Symbol"
+        app:layout_constraintRight_toLeftOf="@+id/player2Symbol"
+        app:layout_constraintBottom_toBottomOf="@+id/player2Symbol"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -178,9 +178,9 @@ http://www.gnu.org/licenses
         android:textSize="20sp"
         android:layout_marginStart="8dp"
         android:visibility="invisible"
-        app:layout_constraintTop_toTopOf="@+id/player2Sigil"
-        app:layout_constraintLeft_toRightOf="@+id/player2Sigil"
-        app:layout_constraintBottom_toBottomOf="@+id/player2Sigil"/>
+        app:layout_constraintTop_toTopOf="@+id/player2Symbol"
+        app:layout_constraintLeft_toRightOf="@+id/player2Symbol"
+        app:layout_constraintBottom_toBottomOf="@+id/player2Symbol"/>
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings_game.xml
+++ b/app/src/main/res/values/strings_game.xml
@@ -10,13 +10,16 @@
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
-    <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>
     <string name="SignIn">Sign In</string>
+    <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>
     <string name="TicTacToeImageDesc">TicTacToe image.</string>
+    <string name="TieMessage">It\'s a tie, nice game</string>
+    <string name="WinMessage">Congratulations %s, you win</string>
     <string name="chess_promotion_bishop">Bishop</string>
     <string name="chess_promotion_knight">Knight</string>
     <string name="chess_promotion_queen">Queen</string>
     <string name="chess_promotion_rook">Rook</string>
+    <string name="friend">Friend</string>
     <string name="game">Game</string>
     <string name="new_game_checkers">New Game (Checkers)</string>
     <string name="new_game_chess">New Game (Chess)</string>
@@ -24,12 +27,11 @@
     <string name="oValue">O</string>
     <string name="player1">Player 1</string>
     <string name="player2">Player 2</string>
+    <string name="turn">turn</string>
+    <string name="vs">vs</string>
     <string name="winner_o">O Wins!</string>
     <string name="winner_tie">Tie!</string>
     <string name="winner_x">X Wins!</string>
-    <string name="xValue">X</string>
-    <string name="vs">vs</string>
     <string name="wins">wins</string>
-    <string name="turn">turn</string>
-    <string name="friend">Friend</string>
+    <string name="xValue">X</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'
 


### PR DESCRIPTION
<h1>Rationale:</h1>

The original TTT implementation was done stand-alone, i.e. no database.  While a subsequent version used the database, the model was to have the database be more of a slave rather than a master.  With this commit, the database is the master and the app is a slave which is a better fit for the Firebase realtime database.  This commit is the first of two.  This one creates a new tictactoe experience on the database and awaits the arrival of the experience from the database before displaying the board and handling User interactions.  Event handling and board changes are the province of the second, forthcoming, commit.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- SIGNED_OUT_OWNER_ID, SIGNED_OUT_EXPERIENCE_KEY: new constants supporting offline use.
- AccountChangeHandler#onDataChange(): fix an Android Studio warning.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- createAccount(): remove a stale comment.
- createExperience(): make void; use the standard updateChildren() method to update the database.
- getExperience(): move to the BaseGameFragment class.
- getPlayers(): move to TTTFragment class.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- getDefaultExperience(): remove.
- createExperience(): add support for creating new arbitrary experiences.
- setupExperience(): add a context argument to be used in handling resources during the time between the fragment creation and the activity attachment; handle error states; use the dispatcher to discriminate between new and existing experiences.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameManager.java

- getDispatcher(): enhance comments; fix the case of an empty list to not pass the experience map into the dispatcher constructor.
- startNextFragment(): pass in the current context to setupExperience().

modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- onResume(): show a spinner while there is no experience to show.
- getDefaultExperience(): morph into the private createExperience().
- createExperience(): new (protected) method morphed from the DatabaseManager.
- checkNotFinished(): do not pass the win count resource id into updateWinCount().
- evaluateBoard(): cosmetic change to fit 100 character line constraint; rename "sigil" to symbol.
- getExperienceKey(), getOwnerId(), getPlayers(): add support for creating a new tictactoe experience.
- getDefaultPlayers(): add the context argument.
- handleTileClick(), recreateExistingBoard(): rename sigil to symbol.
- setPlayerName(), setPlayerWinCount(), setPlayerSigil(), setupGameBoard(), updateExperience(), updateWinCount(): use improved Player class.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/Player.java

- Player: turn into a pojo rather than a Firebase model class.
- sigil: rename to symbol.
- Player(), toMap(): rename sigil to symbol.
- Player(): add a constructor taking objects and converting to the field types.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java

- players, playerList: use and convert Player <-> Map<String, Object>.
- TicTacToe(): pare down the constructor to essential arguments, default the rest to reasonable values.
- toMap(): use a Map instead of Player (not supported with Firebase updateChildren() but OK with setValue().
- getPlayers(), getPlayerList(), setPlayers(): new methods supporting conversion between forms.
- getSigilValue(): renamed to getSymbolValue().

modified:   app/src/main/java/com/pajato/android/gamechat/main/NetworkManager.java

- OFFLINE_OWNER_ID, OFFLINE_EXERIENCE_KEY: add support for offline keys.

modified:   app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java

- show(): provide a variant accepting title and message arguments.