### PR TITLE
Make tic-tac-toe work in sync on multiple devices.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -185,31 +185,35 @@ public abstract class BaseFragment extends Fragment {
 
     /** Set the title in the toolbar using the group name. */
     protected void setTitles(final String groupKey, final String roomKey) {
-        // Ensure that the action bar exists.
+        // Ensure that the activity is attached, aborting if not, which is entirely reasonable.
         String title;
         String subtitle = null;
-        ActionBar bar = ((AppCompatActivity) getActivity()).getSupportActionBar();
-        if (bar != null) {
-            // The action bar does exist, as expected.  Set the title and subtitle accordingly.
-            if (groupKey == null && roomKey == null) {
-                title = getResources().getString(R.string.app_name);
-            } else if (groupKey != null && roomKey == null) {
-                title = DatabaseListManager.instance.getGroupName(groupKey);
-            } else if (groupKey == null) {
-                title = DatabaseListManager.instance.getRoomName(roomKey);
-            } else {
-                title = DatabaseListManager.instance.getRoomName(roomKey);
-                subtitle = DatabaseListManager.instance.getGroupName(groupKey);
-            }
+        AppCompatActivity activity = (AppCompatActivity) getActivity();
+        if (activity == null) return;
 
-            // Apply the title and subtitle to the action bar.
-            bar.setTitle(title);
-            bar.setSubtitle(subtitle);
+        // The activity exists.  Ensure that the action bar does as well.  It should.
+        ActionBar bar = activity.getSupportActionBar();
+        if (bar == null) {
+            // The action bar does not exist!  Log this as an error.
+            Log.e(TAG, "The action bar does not exist to set the titles!", new Throwable());
             return;
         }
 
-        // The action bar does not exist!  Log the error.
-        Log.e(TAG, "The action bar is not accessible in order to set the titles!");
+        // The action bar does exist, as expected.  Set the title and subtitle accordingly.
+        if (groupKey == null && roomKey == null) {
+            title = getResources().getString(R.string.app_name);
+        } else if (groupKey != null && roomKey == null) {
+            title = DatabaseListManager.instance.getGroupName(groupKey);
+        } else if (groupKey == null) {
+            title = DatabaseListManager.instance.getRoomName(roomKey);
+        } else {
+            title = DatabaseListManager.instance.getRoomName(roomKey);
+            subtitle = DatabaseListManager.instance.getGroupName(groupKey);
+        }
+
+        // Apply the title and subtitle to the action bar.
+        bar.setTitle(title);
+        bar.setSubtitle(subtitle);
     }
 
     /** Provide a way to handle volunteer solicitations for unimplemented functions. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -259,6 +259,16 @@ public enum DatabaseListManager {
         roomMap.put(event.key, event.room);
     }
 
+    /** Setup a listener for experience changes in the given room. */
+    public void setExperienceWatcher(final ExpProfile profile) {
+        // Set up a watcher in the given room for experiences changes.
+        // Determine if a handle already exists. Abort if so.  Register a new handler if not.
+        String name = String.format(Locale.US, "experiencesChangeHandler{%s}", profile.expKey);
+        if (DatabaseRegistrar.instance.isRegistered(name)) return;
+        DatabaseEventHandler handler = new ExperienceChangeHandler(name, profile);
+        DatabaseRegistrar.instance.registerHandler(handler);
+    }
+
     // Private instance methods.
 
     /** Return the date header type most closely associated with the given message timestamp. */
@@ -382,16 +392,6 @@ public enum DatabaseListManager {
     }
 
     // Package private instance methods.
-
-    /** Setup a listener for experience changes in the given room. */
-    void setExperienceWatcher(final ExpProfile profile) {
-        // Set up a watcher in the given room for experiences changes.
-        // Determine if a handle already exists. Abort if so.  Register a new handler if not.
-        String name = String.format(Locale.US, "experiencesChangeHandler{%s}", profile.expKey);
-        if (DatabaseRegistrar.instance.isRegistered(name)) return;
-        DatabaseEventHandler handler = new ExperienceChangeHandler(name, profile);
-        DatabaseRegistrar.instance.registerHandler(handler);
-    }
 
     // Private instance methods.
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java
@@ -24,6 +24,8 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.database.DatabaseManager;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ExpProfileListChangeEvent;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 
 import java.util.HashMap;
@@ -116,7 +118,7 @@ public class ExpProfileListChangeHandler extends DatabaseEventHandler
                 // Not sure what a moved change means or what to do about it, so do nothing.
                 break;
         }
-        //AppEventManager.instance.post(new ExpProfileListChangeEvent(expProfile, type));
+        AppEventManager.instance.post(new ExpProfileListChangeEvent(expProfile, type));
     }
 
     /** Return a map of experience profiles for the room in the given experience profile. */

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -122,12 +122,17 @@ public abstract class BaseGameFragment extends BaseFragment {
         ExpType expType = dispatcher.type.expType;
         if (expType == null) return;
 
-        // Determine if an experience is available via the dispatcher and fetch it.
-        mExperience = dispatcher.expKey != null ? getExperience(dispatcher) : null;
-
-        // Determine if an experience should be created.  If so use the passed in context in setting
-        // up the experience as the current context for this fragment may not exist yet.
-        if (dispatcher.expKey == null) createExperience(context, dispatcher);
+        // Determine if the dispatcher has a single experience profile.
+        if (dispatcher.expProfile != null) {
+            // It does.  Either get the cached experience or fetch it from the database.
+            Experience exp = DatabaseListManager.instance.experienceMap.get(dispatcher.expKey);
+            if (exp == null) {
+                // Fetch the experience from the database.
+                DatabaseListManager.instance.setExperienceWatcher(dispatcher.expProfile);
+            }
+        } else
+            // Create a new experience.
+            createExperience(context, dispatcher);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
@@ -92,7 +92,7 @@ public class CheckersFragment extends BaseGameFragment {
             }
             String newGame = getString(R.string.NewGame);
             String message = String.format(Locale.US, "%s! %s's Turn!", newGame, player);
-            GameManager.instance.notify(this, message, false);
+            NotificationManager.instance.notify(this, message, false);
         }
 
     }
@@ -258,10 +258,10 @@ public class CheckersFragment extends BaseGameFragment {
         }
         // Verify win conditions. If one passes, return true and generate an endgame snackbar.
         if(yCount == 0) {
-            GameManager.instance.notify(this, "Game Over, Player 1 wins", true);
+            NotificationManager.instance.notify(this, "Game Over, Player 1 wins", true);
             return true;
         } else if (bCount == 0) {
-            GameManager.instance.notify(this, "Game Over, Player 2 wins", true);
+            NotificationManager.instance.notify(this, "Game Over, Player 2 wins", true);
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java
@@ -98,7 +98,7 @@ public class ChessFragment extends BaseGameFragment {
                 player = getString(R.string.player1);
             }
             handleTurnChange();
-            GameManager.instance.notify(this, getString(R.string.NewGame) + " "
+            NotificationManager.instance.notify(this, getString(R.string.NewGame) + " "
                     + player + "'s Turn!", false);
         }
 
@@ -277,10 +277,10 @@ public class ChessFragment extends BaseGameFragment {
         }
         // Verify win conditions. If one passes, return true and generate an endgame snackbar.
         if(secondaryKing == 0) {
-            GameManager.instance.notify(this, "Game Over! Player 1 Wins!", true);
+            NotificationManager.instance.notify(this, "Game Over! Player 1 Wins!", true);
             return true;
         } else if (primaryKing == 0) {
-            GameManager.instance.notify(this, "Game Over! Player 2 Wins!", true);
+            NotificationManager.instance.notify(this, "Game Over! Player 2 Wins!", true);
             return true;
         } else {
             return false;

--- a/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.game;
 
+import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 
 import java.util.List;
@@ -39,6 +41,9 @@ public class Dispatcher {
 
     /** The experience key. */
     public String expKey;
+
+    /** The one and only experience profile. */
+    public ExpProfile expProfile;
 
     /** A list of experience profiles. */
     public List<ExpProfile> profileList;
@@ -63,6 +68,11 @@ public class Dispatcher {
     /** Build an instance given an experience type. */
     Dispatcher(final FragmentType type) {
         this.type = type;
+        Room room = DatabaseListManager.instance.getMeRoom();
+        if (room != null) {
+            groupKey = room.groupKey;
+            roomKey = room.key;
+        }
     }
 
     /** Build an instance given an experience map. */
@@ -100,10 +110,10 @@ public class Dispatcher {
         this.profileList = profileList;
     }
 
-    /** Build an instance given a fragment type and an experiene key. */
-    Dispatcher(final FragmentType type, String expKey) {
+    /** Build an instance given a fragment type and an experiene profile. */
+    Dispatcher(final FragmentType type, ExpProfile expProfile) {
         this.type = type;
-        this.expKey = expKey;
+        this.expProfile = expProfile;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ExpType.java
@@ -26,12 +26,9 @@ import com.pajato.android.gamechat.R;
  * @author Paul Michael Reilly
  */
 public enum ExpType {
-    checkers (R.mipmap.ic_checkers, R.string.PlayCheckers, R.string.player1, R.string.player2,
-            FragmentType.checkers),
-    chess (R.mipmap.ic_chess, R.string.PlayChess, R.string.player1, R.string.player2,
-            FragmentType.chess),
-    ttt (R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe, R.string.xValue, R.string.oValue,
-            FragmentType.tictactoe);
+    checkers (R.mipmap.ic_checkers, R.string.PlayCheckers, R.string.player1, R.string.player2),
+    chess (R.mipmap.ic_chess, R.string.PlayChess, R.string.player1, R.string.player2),
+    ttt (R.mipmap.ic_tictactoe_red, R.string.PlayTicTacToe, R.string.xValue, R.string.oValue);
 
     // Instance variables.
 
@@ -53,12 +50,10 @@ public enum ExpType {
     // Constructor.
 
     /** Build an instance given the online, local and computer opponent fragment indexes. */
-    ExpType(final int iconId, final int titleId, final int primary, final int secondary,
-            final FragmentType fragmentType) {
+    ExpType(final int iconId, final int titleId, final int primary, final int secondary) {
         mIconResId = iconId;
         mTitleResId = titleId;
         mPrimaryIndex = primary;
         mSecondaryIndex = secondary;
-        mFragmentType = fragmentType;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameManager.java
@@ -17,21 +17,12 @@
 
 package com.pajato.android.gamechat.game;
 
-import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.content.ContextCompat;
-import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.AccountManager;
-import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.database.DatabaseListManager;
-import com.pajato.android.gamechat.event.AppEventManager;
-import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.game.model.ExpProfile;
 import com.pajato.android.gamechat.main.NetworkManager;
 
@@ -112,32 +103,6 @@ public enum GameManager {
         instructions.clear();
     }
 
-    /** Create and show a Snackbar notification based on the given parameters. */
-    public void notify(@NonNull final Fragment fragment, final String text, final boolean done) {
-        // Ensure that the fragment is attached and has a view.  Abort if it does not.
-        Snackbar notification;
-        if (fragment.getView() == null) return;
-
-        // Determine if the experience is finished.
-        if (done) {
-            // The game is ended so generate a notification that could start a new game.
-            notification = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_INDEFINITE);
-            final String playAgain = getFragment(getCurrent()).getString(R.string.PlayAgain);
-            notification.setAction(playAgain, new SnackbarActionHandler(fragment));
-        } else {
-            // The game hasn't ended so generate a notification without an action.
-            notification = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_SHORT);
-        }
-
-        // Use a primary color background with white text for the snackbar and hide the FAB button
-        // while the snackbar is presenting.
-        int color = ContextCompat.getColor(fragment.getContext(), R.color.colorPrimaryDark);
-        notification.getView().setBackgroundColor(color);
-        notification.setActionTextColor(ColorStateList.valueOf(Color.WHITE))
-                .setCallback(new SnackbarChangeHandler(fragment))
-                .show();
-    }
-
     /** Return true iff a fragment for the given experience is started. */
     public boolean startNextFragment(final FragmentActivity context) {
         // Ensure that the dispatcher has a valid type.  Abort if not. Set up the fragment using the
@@ -172,7 +137,7 @@ public enum GameManager {
         if (expProfileMap.size() > 1) return new Dispatcher(expProfileMap);
 
         // A signed in user with experiences in more than one room but only one group. Return a
-        // dispatcher identifying the group and room.
+        // dispatcher identifying the group and room map.
         String groupKey = expProfileMap.keySet().iterator().next();
         Map<String, Map<String, ExpProfile>> roomMap = expProfileMap.get(groupKey);
         if (roomMap.size() > 1) return new Dispatcher(groupKey, roomMap);
@@ -185,7 +150,7 @@ public enum GameManager {
 
         // A signed in User with one experience. Return a dispatcher to show the single experience.
         FragmentType fragmentType = getFragmentType(expProfileList.get(0));
-        return new Dispatcher(fragmentType, groupKey, roomKey, expProfileList.get(0).expKey);
+        return new Dispatcher(fragmentType, expProfileList.get(0));
     }
 
     /** Return a dispatcher object for a given fragment type. */
@@ -197,7 +162,7 @@ public enum GameManager {
 
         // Case: a signed in user with a single experience. Return a dispatcher with the experience
         // key.
-        if (list.size() == 1) return new Dispatcher(type, list.get(0).expKey);
+        if (list.size() == 1) return new Dispatcher(type, list.get(0));
 
         // A signed in user with more than one experience of the given type. Return a dispatcher
         // with the list of relevant experience keys.
@@ -226,7 +191,12 @@ public enum GameManager {
 
     /** Return the fragment type associated with the experience given by the experience key. */
     private FragmentType getFragmentType(final ExpProfile expProfile) {
-        return ExpType.values()[expProfile.type].mFragmentType;
+        ExpType expType = ExpType.values()[expProfile.type];
+        for (FragmentType fragmentType : FragmentType.values()) {
+            if (expType == fragmentType.expType) return fragmentType;
+        }
+
+        return null;
     }
 
     /** Return the string value associated with the two players based on the current turn. */
@@ -257,53 +227,4 @@ public enum GameManager {
         return true;
     }
 
-    // Inner classes.
-
-    /** Provide a handler to show/hide the FAB for snackbar messaging. */
-    private class SnackbarChangeHandler extends Snackbar.Callback {
-
-        // Instance variables.
-
-        /** The calling fragment. */
-        Fragment mFragment;
-
-        // Constructors
-
-        /** Build an instance with a given fragment. */
-        SnackbarChangeHandler(final Fragment fragment) {
-            mFragment = fragment;
-        }
-
-        @Override public void onDismissed(final Snackbar snackbar, final int event) {
-            FabManager.game.show(mFragment);
-        }
-
-        @Override public void onShown(final android.support.design.widget.Snackbar snackbar) {
-            FabManager.game.hide(mFragment);
-        }
-    }
-
-    /** Handle a snackbar action click. */
-    private class SnackbarActionHandler implements View.OnClickListener {
-
-        // Instance variables.
-
-        /** The tag value to post with the event to the app. */
-        String mClassName;
-
-        // Constructor.
-
-        /** Build an instance with a given tag value. */
-        SnackbarActionHandler(final Fragment fragment) {
-            mClassName = fragment.getClass().getSimpleName();
-        }
-
-        /** Handle an action click from the snackbar by posting the tag to the app. */
-        @Override public void onClick(final View view) {
-            // Post the saved tag (the originating fragment's tag) to the app.
-            view.setTag(mClassName);
-            AppEventManager.instance.post(new TagClickEvent(view));
-        }
-
-    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.game;
+
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
+import android.view.View;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.TagClickEvent;
+
+/**
+ * Manages the game related aspects of the GameChat application. These include the creation of new
+ * game instances, notifications, and game settings.
+ *
+ * @author Bryan Scott
+ */
+public enum NotificationManager {
+    instance;
+
+    // Private instance variables.
+
+    /** The notifcation snackbar. */
+    private Snackbar mNotifier;
+
+    // Public instance methods.
+
+    /** Dismiss the snackbar. */
+    public void dismiss() {
+        // Ensure that the snackbar exists and is being shown.
+        if (mNotifier != null && mNotifier.isShownOrQueued()) mNotifier.dismiss();
+    }
+
+    /** Create and show a Snackbar notification based on the given parameters. */
+    public void notify(@NonNull final Fragment fragment, final String text, final boolean done) {
+        // Ensure that the fragment is attached and has a view.  Abort if it does not.
+        if (fragment.getView() == null) return;
+
+        // Determine if the experience is finished.
+        if (done) {
+            // The game is ended so generate a notification that could start a new game.
+            mNotifier = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_LONG);
+            final String playAgain = fragment.getContext().getString(R.string.PlayAgain);
+            mNotifier.setAction(playAgain, new SnackbarActionHandler(fragment));
+        } else {
+            // The game hasn't ended so generate a notification without an action.
+            mNotifier = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_SHORT);
+        }
+
+        // Use a primary color background with white text for the snackbar and hide the FAB button
+        // while the snackbar is presenting.
+        int color = ContextCompat.getColor(fragment.getContext(), R.color.colorPrimaryDark);
+        mNotifier.getView().setBackgroundColor(color);
+        mNotifier.setActionTextColor(ColorStateList.valueOf(Color.WHITE))
+            .setCallback(new SnackbarChangeHandler(fragment))
+            .show();
+    }
+
+    // Inner classes.
+
+    /** Provide a handler to show/hide the FAB for snackbar messaging. */
+    private class SnackbarChangeHandler extends Snackbar.Callback {
+
+        // Instance variables.
+
+        /** The calling fragment. */
+        Fragment mFragment;
+
+        // Constructors
+
+        /** Build an instance with a given fragment. */
+        SnackbarChangeHandler(final Fragment fragment) {
+            mFragment = fragment;
+        }
+
+        @Override public void onDismissed(final Snackbar snackbar, final int event) {
+            FabManager.game.show(mFragment);
+        }
+
+        @Override public void onShown(final android.support.design.widget.Snackbar snackbar) {
+            FabManager.game.hide(mFragment);
+        }
+    }
+
+    /** Handle a snackbar action click. */
+    private class SnackbarActionHandler implements View.OnClickListener {
+
+        // Instance variables.
+
+        /** The tag value to post with the event to the app. */
+        String mClassName;
+
+        // Constructor.
+
+        /** Build an instance with a given tag value. */
+        SnackbarActionHandler(final Fragment fragment) {
+            mClassName = fragment.getClass().getSimpleName();
+        }
+
+        /** Handle an action click from the snackbar by posting the tag to the app. */
+        @Override public void onClick(final View view) {
+            // Post the saved tag (the originating fragment's tag) to the app.
+            view.setTag(mClassName);
+            AppEventManager.instance.post(new TagClickEvent(view));
+        }
+
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java
@@ -19,27 +19,35 @@ package com.pajato.android.gamechat.game;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.ExpProfileListChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
+import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
 import static com.pajato.android.gamechat.game.GameFragment.GAME_HOME_FAM_KEY;
 
 public class ShowNoExperiencesFragment extends BaseGameFragment {
 
     // Public instance methods.
 
-    /** A nop subscriber to satisfy the EventBus contract. */
-    @Subscribe public void onClick(final ClickEvent event) {
-        // Provide a logging placeholder.
-        logEvent("onClick (showNoGames)");
-    }
-
     /** Establish the layout file to indicate that no experiences are available. */
     @Override public int getLayout() {return R.layout.fragment_game_no_games;}
 
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
+
+    /** Handle an experience profile list change event. */
+    @Subscribe public void onExpProfileListChangeEvent(ExpProfileListChangeEvent event) {
+        switch (event.changeType) {
+            case CHANGED:
+            case NEW:
+                GameManager.instance.startNextFragment(getActivity());
+                break;
+            default:
+                break;
+        }
+    }
 
     /** Reset the FAM to use the game home menu. */
     @Override public void onResume() {


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit allows a game of TicTacToe to be player by the same User on multiple devices simultaneously such that all the devices stay in sync with moves, wins, ties and new games.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- setTitles(): make a little more robust by ensuring that the fragment is attached and using fail fast.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- setExperienceWatcher(): make public and move accordingly (per RNF).

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java

- Uncomment to enable the code.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- setupExperience(): use an experience profile instead of an experience key for handling a single experience.

modified:   app/src/main/java/com/pajato/android/gamechat/game/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/game/ChessFragment.java

- messageHandler(), onNewGame(): use the new NotificationManager class.

modified:   app/src/main/java/com/pajato/android/gamechat/game/Dispatcher.java

- expProfile: add to deal with a single experience.
- Dispatcher(): change the relevant constructors to deal with a profile instead of an experience key.

modified:   app/src/main/java/com/pajato/android/gamechat/game/ExpType.java

- Remove the fragment type from the constant values.  A race condition causes them to be null.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameManager.java

- notify, SnackbarActionHandler, SnackbarChangeHandler: move to new class NotificationHandler.
- getDispatcher(): handle the experience profile cases.
- getFragmentType(): rewrite to handle brute force conversion.

new file:   app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java

- use a separate class for app based notifications.

modified:   app/src/main/java/com/pajato/android/gamechat/game/ShowNoExperiencesFragment.java

- onClick(): remove since a placeholder is no longer required to appease the EventBus.
- onExpProfileListChangeEvent(): new handler allowing restarts for new experience profile objects.

modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- handleNewGame(): use a null board to trigger new board support/reset.
- initBoard(), setState(), setGameBoard(): deal with winner reset here.