### PR TITLE
Simplify win calculations.

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,8 +1,5 @@
 Short Term Issues needing resolution.  Longer term items should be logged on GitHub.
 
-- Fix menu breakage (they no longer show up).
-- Automate bug reporting process as on overflow menu item.  Send reports to Pajato Support and to GitHub issues for GameChat.
-- Update TTT FAM to show Play Again, Goto My Groups/Room/Experiences, Play Chess, Play Checkers as a first stab.  If it is not currently implemented make the item show "Future Feature".
 - Do Play Store alpha release.
 - Revive the connected tests towards an end of having broken tests fixed and a > 90% coverage level, an ongoing task.
 - Do SVG homework in preparation to start replacing all PNG icons.

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java
@@ -152,9 +152,9 @@ public class MenuAdapter extends RecyclerView.Adapter<ViewHolder> implements Vie
         Context context = holder.title.getContext();
         String text = context.getString(entry.titleResId);
         holder.title.setText(Html.fromHtml(text));
-        holder.itemView.setTag(entry.fragmentTypeIndex);
-        holder.title.setTag(entry.fragmentTypeIndex);
-        holder.icon.setTag(entry.fragmentTypeIndex);
+        holder.itemView.setTag(entry);
+        holder.title.setTag(entry);
+        holder.icon.setTag(entry);
 
         // Set the icon on the holder.
         if (loadUrl(holder, entry)) return;

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java
@@ -30,19 +30,19 @@ public class MenuEntry {
     final static int MENU_ITEM_TYPE = 0;
     final static int MENU_HEADER_TYPE = 1;
 
-    // Public instance variables.
+    // Public and package private instance variables.
 
     /** A description of the item. */
-    public String desc;
+    String desc;
 
     /** The fragment type associated with the menu item, if any. */
-    int fragmentTypeIndex;
+    public int fragmentTypeIndex;
 
     /** The menu item icon resource id. */
     int iconResId;
 
     /** The list of rooms or groups with messages to show, or the text of a message. */
-    int titleResId;
+    public int titleResId;
 
     /** The entry type, provided by the item. */
     public int type;

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java
@@ -24,7 +24,7 @@ package com.pajato.android.gamechat.common.adapter;
  */
 public class MenuItemEntry {
 
-    // Public instance variables.
+    // Package private instance variables.
 
     /** The fragment type associated with the menu item, if any. */
     int fragmentTypeIndex;
@@ -54,4 +54,9 @@ public class MenuItemEntry {
         this.fragmentTypeIndex = fragmentTypeIndex;
     }
 
+    public MenuItemEntry(final int titleResId, final int iconResId) {
+        this.titleResId = titleResId;
+        this.iconResId = iconResId;
+        fragmentTypeIndex = -1;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -21,7 +21,10 @@ import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.BaseFragment;
+import com.pajato.android.gamechat.common.adapter.MenuEntry;
+import com.pajato.android.gamechat.common.adapter.MenuItemEntry;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 
@@ -96,6 +99,24 @@ public abstract class BaseGameFragment extends BaseFragment {
     /** Create a new experience to be displayed in this fragment. */
     protected void createExperience(final Context context, final Dispatcher dispatcher) {
         // nop; the subclass should handle this.
+    }
+
+    /** Return a menu entry for with given title, icon resource items and fragment type. */
+    protected MenuEntry getEntry(final int titleId, final int iconId, final int fragmentIndex) {
+        return new MenuEntry(new MenuItemEntry(titleId, iconId, fragmentIndex));
+    }
+
+    /** Return a menu entry for with given title and icon resource items. */
+    protected MenuEntry getEntry(final int titleId, final int iconId) {
+        return new MenuEntry(new MenuItemEntry(titleId, iconId));
+    }
+
+    /** Return TRUE iff the User has requested to play again. */
+    protected boolean isPlayAgain(final Object tag, final String className) {
+        // Determine if the given tag is the class name, i.e. a snackbar action request to play
+        // again.
+        return ((tag instanceof String && className.equals(tag)) ||
+                (tag instanceof MenuEntry && ((MenuEntry) tag).titleResId == R.string.PlayAgain));
     }
 
     /** Log a lifecycle event that has no bundle. */

--- a/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java
@@ -26,7 +26,6 @@ import android.view.View;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
-import com.pajato.android.gamechat.common.adapter.MenuItemEntry;
 import com.pajato.android.gamechat.event.AccountStateChangeHandled;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
@@ -68,10 +67,10 @@ public class GameFragment extends BaseGameFragment {
     /** Process a button click event with a tag value. */
     @Subscribe public void onClick(final TagClickEvent event) {
         Object payload = event.view.getTag();
-        if (payload == null || !(payload instanceof Integer)) return;
+        if (payload == null || !(payload instanceof MenuEntry)) return;
 
-        // Process the payload assuming it is a fragment type index.
-        int index = (Integer) payload;
+        // Process the payload assuming it is a valid fragment type index.  Abort on a bad assumption.
+        int index = ((MenuEntry) payload).fragmentTypeIndex;
         if (index < 0 || index > FragmentType.values().length) return;
 
         // The index represents an experience type.  Start the appropriate fragment after
@@ -150,11 +149,6 @@ public class GameFragment extends BaseGameFragment {
     }
 
     // Private instance methods.
-
-    /** Return a menu entry for with given title and icon resource items. */
-    private MenuEntry getEntry(final int titleId, final int iconId, final int index) {
-        return new MenuEntry(new MenuItemEntry(titleId, iconId, index));
-    }
 
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getHomeMenu() {

--- a/app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java
@@ -39,22 +39,7 @@ import com.pajato.android.gamechat.event.TagClickEvent;
 enum NotificationManager {
     instance;
 
-    // Private instance variables.
-
-    /** The notifcation snackbar. */
-    private Snackbar mNotifier;
-
     // Public instance methods.
-
-    /** Dismiss the snackbar. */
-    public void dismiss() {
-        // Ensure that the snackbar exists and is being shown.
-        if (mNotifier != null && mNotifier.isShownOrQueued()) mNotifier.dismiss();
-        if (mNotifier != null) {
-            mNotifier.setCallback(null);
-            mNotifier = null;
-        }
-    }
 
     /** Create and show a Snackbar notification based on the given parameters. */
     public void notify(@NonNull final Fragment fragment, final String text, final boolean done) {
@@ -62,23 +47,31 @@ enum NotificationManager {
         if (fragment.getView() == null) return;
 
         // Determine if the experience is finished.
+        /* The notifcation snackbar. */
+        Snackbar snackbar;
         if (done) {
             // The game is ended so generate a notification that could start a new game.
-            mNotifier = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_LONG);
+            snackbar = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_LONG);
             final String playAgain = fragment.getContext().getString(R.string.PlayAgain);
-            mNotifier.setAction(playAgain, new SnackbarActionHandler(fragment));
+            snackbar.setAction(playAgain, new SnackbarActionHandler(fragment));
         } else {
             // The game hasn't ended so generate a notification without an action.
-            mNotifier = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_SHORT);
+            snackbar = Snackbar.make(fragment.getView(), text, Snackbar.LENGTH_SHORT);
         }
 
         // Use a primary color background with white text for the snackbar and hide the FAB button
         // while the snackbar is presenting.
         int color = ContextCompat.getColor(fragment.getContext(), R.color.colorPrimaryDark);
-        mNotifier.getView().setBackgroundColor(color);
-        mNotifier.setActionTextColor(ColorStateList.valueOf(Color.WHITE))
+        snackbar.getView().setBackgroundColor(color);
+        snackbar.setActionTextColor(ColorStateList.valueOf(Color.WHITE))
             .setCallback(new SnackbarChangeHandler(fragment))
             .show();
+    }
+
+    /** Put up a snackbar for the given fragment and resource string. */
+    public void notify(final Fragment fragment, final int resId) {
+        String message = fragment.getContext().getString(resId);
+        notify(fragment, message, false);
     }
 
     // Inner classes.

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/Board.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/Board.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.game.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provide a pojo repesenting a tictactoe board: a map associating buttons and player symbols (X's
+ * and O's) and a map providing a running tally of the win possibilities.
+ *
+ * There are eight win possibilities in TicTacToe: three consecutive identical symbols in each row,
+ * each column or along one of the two diagonals.  The app detects one of these eight states by
+ * assigning a value of 1 to each X symbol and a value of 4 to each O value.  For X to win, one of
+ * the eight tallies must add up to 3 and for O to win one of the eight tallies must add up to 12.
+ *
+ * Credit for the basic algorithm goes to Bryan Scott.
+ *
+ * @author Paul Michael Reilly
+ */
+public class Board {
+
+    // Public win state key constants.
+
+    /** The top row tally key. */
+    public static final String TOP_ROW = "topRow";
+
+    /** The middle row tally key. */
+    public static final String MID_ROW = "midRow";
+
+    /** The bottom row tally key. */
+    public static final String BOT_ROW = "botRow";
+
+    /** The start column tally key. */
+    public static final String BEG_COL = "begCol";
+
+    /** The center column tally key. */
+    public static final String MID_COL = "midCol";
+
+    /** The end column tally key. */
+    public static final String END_COL = "endCol";
+
+    /** The left diagonal tally key. */
+    public static final String LEFT_DIAG = "leftDiag";
+
+    /** The right diagonal tally key. */
+    public static final String RIGHT_DIAG = "rightDiag";
+
+    // Public instance variables.
+
+    /** The board grid as a map of button tag to symbol value (X or O). */
+    public Map<String, String> grid = new HashMap<>();
+
+    /** The board tallies as a map associating key with running integer values. */
+    public Map<String, Integer> tallies = new HashMap<>();
+
+    // Public instance methods.
+
+    /** Provide a convenience method to reset the maps. */
+    public void clear() {
+        grid.clear();
+        tallies.clear();
+    }
+
+    /** Provide a default map for a Firebase create/update. */
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("grid", grid);
+        result.put("tallies", tallies);
+
+        return result;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java
@@ -52,10 +52,13 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
     /** The game has ended in a tie. */
     public final static int TIE = 3;
 
+    /** The game has ended, been celebrated and is pending a new game. */
+    public final static int PENDING = 4;
+
     // Public instance variables.
 
-    /** The board positions that have been filled by either an X or an O. */
-    public Map<String, String> board;
+    /** A POJO encapsulating the board moves and wining tallies. */
+    public Board board;
 
     /** The creation timestamp. */
     private long createTime;
@@ -168,7 +171,7 @@ import static com.pajato.android.gamechat.game.ExpType.ttt;
     /** Return the value associated with the current player: 1 == X, 2 == O. */
     @Exclude public int getSymbolValue() {
         // This implies that player 1 is always X and player 2 is always O.
-        return turn ? 1 : 2;
+        return turn ? 1 : 4;
     }
 
     /** Return the symbol text value for the player whose turn is current. */

--- a/app/src/main/res/values/strings_game.xml
+++ b/app/src/main/res/values/strings_game.xml
@@ -2,7 +2,9 @@
     <string name="CheckersImageDesc">Checkers image.</string>
     <string name="ChessImageDesc">Chess image.</string>
     <string name="FutureSelectRooms">Select rooms</string>
+    <string name="InvalidButton">You must click on an empty button!  Try again.</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
+    <string name="MyRooms">Go To My Rooms</string>
     <string name="NewGame">New Game</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="PlayAgain">Play again</string>
@@ -11,6 +13,7 @@
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
     <string name="SignIn">Sign In</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>
+    <string name="StartNewGame">Starting a new game.  Enjoy!</string>
     <string name="TicTacToeImageDesc">TicTacToe image.</string>
     <string name="TieMessage">It\'s a tie, nice game</string>
     <string name="WinMessage">Congratulations %s, you win</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'
 


### PR DESCRIPTION
<h1>Rationale:</h1>

During lifecycle testing, it became clear there were two important issues: 1) the calculations of a win were based on data not captured in the database making this a weak link and prone to the second issue; 2) unregistering and re-registering handlers across a backgroun/foreground lifecycle switch does not work correctly.  This commit fixes the first issue.

<h1>File changes:</h1>

modified:   ISSUES.md

- Update with recent fixes.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuAdapter.java

- updateMenuItemHolder(): put the entire menu entry into the tag rather than just the fragment type index value.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuEntry.java

- desc: make package private to silence an AS warning.
- fragmentTypeIndex, titleResId: make public to provide access to other packages.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/MenuItemEntry.java

- MenuItemEntry(): add a constructor overload that defaults the fragment type index to -1 to show that it is not relevant.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- getEntry(): add convenience overloads for building a menu entry for FAM objects.
- isPlayAgain(): add convenience method for handling a play again request.

modified:   app/src/main/java/com/pajato/android/gamechat/game/GameFragment.java

- onClick(): deal with a menu entry rather than an integer payload.
- getEntry(): move to the base class.

modified:   app/src/main/java/com/pajato/android/gamechat/game/NotificationManager.java

- mNotifier: remove and replace with a local variable, snackbar.
- dismiss(): remove as it is no longer used.
- notify(): simplify and use the local variable snackbar instead of the mNotifier property; and an overload to accept resource ids.

modified:   app/src/main/java/com/pajato/android/gamechat/game/TTTFragment.java

- TIC_TAC_TOE_FAM_KEY: provide a Floating Action Menu (FAM) key.
- mBoardValues: remove and replace with a map stored in the database.
- onClick(): handle both a FAM click and a snackbar action click to play again.
- onInitialize(): set up a FAM menu.
- setupExperience(): remove.
- getState() overhaul (into overloaded functions) to use maps provided by the database in order to determine one of three end game states.
- handleTileClick(): handle invalid button click notifications; start a new game automagically on a button click while in an endgame state; use the new Board pojo in the data model updates.
- initBoard(): use the new board abstraction; simplify notifications; remove operations on the mBoardValues array.
- setGameBoard(): pass the mode to initBoard(); use the new Board abstraction.
- getTTTMenu(): build a new FAM tailored to TTT.

new file:   app/src/main/java/com/pajato/android/gamechat/game/model/Board.java

- New file used to encapsulate the board moves and tallies that assist in win calculations.

modified:   app/src/main/java/com/pajato/android/gamechat/game/model/TicTacToe.java

- Add a new state, PENDING to reflect that period after a win or tie has been detected and an new game has been started.

modified:   app/src/main/res/values/strings_game.xml

- InvalidButton, MyRooms, StartNewGame: new strings to for the TTT FAM and the snackbar messages.

modified:   build.gradle

- Upgrade to next version.