### PR TITLE
Ensure that returning from the background works (TTT).

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,5 +1,10 @@
 Short Term Issues needing resolution.  Longer term items should be logged on GitHub.
 
+Fixed for version 3:
+
+- Resolve Lifecycle bug whereby database handler are not being re-registered (apparently).
+- Move Chat fragments to a resume/pause registration model.
+
 Fixed for version 2:
 
 - Remove the "Register" button from the intro screen layout; change the text accordingly.
@@ -9,13 +14,11 @@ Fixed for version 2:
 - Make an implicit restart after a win or tie work correctly.
 
 Not fixed:
-- Resolve Lifecycle bug whereby database handler are not being re-registered (apparently).
 - Revive the connected tests towards an end of having broken tests fixed and a > 90% coverage level, an ongoing task.
 - Add connected checks for tablets.
 - Set up real web site for GameChat using Google Sites.
 - Add privacy policy to app ala Inbox (options menu Help and Feedback).
 - Add member rooms to the room list screens.
-- Move Chat fragments to a resume/pause registration model.
 - Make <experience> back press navigate to the optimal screen on the experience page.
 - Add long press context menus to player controls for experiences to provide alternative choices (computer, another user, a friend, change name, etc.)
 - Add a dynamic "goto" FAM option to quickly navigate to the optimal screen on the experience page.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         applicationId "com.pajato.android.gamechat"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
+        versionCode 3
         versionName "1.0"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -95,20 +95,10 @@ public abstract class BaseChatFragment extends BaseFragment {
 
     // Public instance methods.
 
-    @Override public void onAttach(Context context) {
-        super.onAttach(context);
-        AppEventManager.instance.register(this);
-    }
-
     /** Log the lifecycle event and kill the ads. */
     @Override public void onDestroy() {
         super.onDestroy();
         if (mAdView != null) mAdView.destroy();
-    }
-
-    @Override public void onDetach() {
-        super.onDetach();
-        AppEventManager.instance.unregister(this);
     }
 
     /** Handle an options menu choice. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -35,6 +35,7 @@ import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.adapter.MenuItemEntry;
 import com.pajato.android.gamechat.database.DatabaseListManager;
+import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.game.FragmentType;
 import com.pajato.android.gamechat.main.PaneManager;
 
@@ -144,6 +145,7 @@ public abstract class BaseFragment extends Fragment {
     @Override public void onPause() {
         super.onPause();
         logEvent("onPause");
+        AppEventManager.instance.unregister(this);
     }
 
     /** Log the lifecycle event and resume showing ads. */
@@ -152,6 +154,7 @@ public abstract class BaseFragment extends Fragment {
         // attempted.
         super.onResume();
         logEvent("onResume");
+        AppEventManager.instance.register(this);
     }
 
     /** Log the lifecycle event. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java
@@ -63,6 +63,7 @@ public enum DatabaseRegistrar {
     public void registerHandler(final DatabaseEventHandler handler) {
         // Determine if there is already a listener registered with this name.
         String name = handler.name;
+        Log.d(TAG, String.format(Locale.US, "Registering handler with name {%s].", name));
         DatabaseReference database = FirebaseDatabase.getInstance().getReference(handler.path);
         DatabaseEventHandler registeredHandler = mHandlerMap.get(name);
         removeEventListener(database, registeredHandler);
@@ -87,21 +88,25 @@ public enum DatabaseRegistrar {
         // Walk the set of registered handlers to remove them.  Leave them cached for possible reuse.
         DatabaseReference database;
         DatabaseEventHandler handler;
+        Log.d(TAG, "Unregistering all handlers.");
         for (String name : mHandlerMap.keySet()) {
             handler = mHandlerMap.get(name);
             database = FirebaseDatabase.getInstance().getReference(handler.path);
             removeEventListener(database, handler);
         }
+        mHandlerMap.clear();
     }
 
     /** Unregister a named listener. */
     public void unregisterHandler(final String name) {
         // Determine if there is a handler registered by the given name.
+        Log.d(TAG, String.format(Locale.US, "Unregistering handler with name {%s}.", name));
         DatabaseEventHandler handler = mHandlerMap.get(name);
         if (handler != null) {
             // There is.  Remove it as a listener but keep it cached for possible reuse.
             DatabaseReference database = FirebaseDatabase.getInstance().getReference(handler.path);
             removeEventListener(database, handler);
+            mHandlerMap.remove(name);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/event/RegistrationChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/RegistrationChangeEvent.java
@@ -1,0 +1,36 @@
+package com.pajato.android.gamechat.event;
+
+import com.pajato.android.gamechat.chat.model.Room;
+
+/**
+ * Provides an event class to encapsulate a registration change event for a given class name.
+ *
+ * @author Paul Michael Reilly
+ */
+public class RegistrationChangeEvent {
+
+    // Public constants.
+
+    /** The change type value for a registered event handler. */
+    public final static int REGISTERED = 1;
+
+    /** The change type value for an unregistered event handler. */
+    public final static int UNREGISTERED = 2;
+
+    // Public instance variables.
+
+    /** The type of registration change: either registered or unregistered. */
+    public final int changeType;
+
+    /** The fully qualified class name. */
+    public final String name;
+
+    // Public constructor.
+
+    /** Build the event for the generic type and it's push key. */
+    public RegistrationChangeEvent(final String name, final int changeType) {
+        this.name = name;
+        this.changeType = changeType;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java
@@ -75,25 +75,6 @@ public abstract class BaseGameFragment extends BaseFragment {
     /** Remove this after dealing with the chess and checkers fragments. */
     abstract public void messageHandler(final String message);
 
-    @Override public void onAttach(Context context) {
-        super.onAttach(context);
-        logEvent("onAttach");
-    }
-
-    /** Log the lifecycle event, stop showing ads and turn off the app event bus. */
-    @Override public void onPause() {
-        // Log the event and stop listening for app events.
-        super.onPause();
-        AppEventManager.instance.unregister(this);
-    }
-
-    /** Log the lifecycle event and resume showing ads. */
-    @Override public void onResume() {
-        // Log the event and start listening for app events.
-        super.onResume();
-        AppEventManager.instance.register(this);
-    }
-
     // Protected instance methods.
 
     /** Create a new experience to be displayed in this fragment. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
@@ -21,6 +21,11 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
+import com.pajato.android.gamechat.account.AccountManager;
+import com.pajato.android.gamechat.database.DatabaseListManager;
+import com.pajato.android.gamechat.database.DatabaseRegistrar;
+import com.pajato.android.gamechat.event.AppEventManager;
+
 import java.util.Locale;
 
 /**
@@ -73,6 +78,9 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override protected void onPause() {
         super.onPause();
         logEvent("onPause");
+        AppEventManager.instance.unregister(this);
+        AppEventManager.instance.unregisterAll();
+        DatabaseRegistrar.instance.unregisterAll();
     }
 
     /** Log the onRestart() state. */
@@ -85,6 +93,10 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override protected void onResume() {
         super.onResume();
         logEvent("onResume");
+        AppEventManager.instance.register(AccountManager.instance);
+        AppEventManager.instance.register(DatabaseListManager.instance);
+        AppEventManager.instance.register(NavigationManager.instance);
+        AppEventManager.instance.register(this);
     }
 
     /** Log the lifecycle event. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -72,7 +72,6 @@ public enum NavigationManager {
         // event manager.
         NavigationView navigationView = (NavigationView) activity.findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(activity);
-        AppEventManager.instance.register(this);
     }
 
     /** Handle a back press event. */


### PR DESCRIPTION
<h1>Rationale</h1>

When performing a foreground/background/foreground cycle the TTT fragment would lose the database handlers.  This commit corrects that problem.

<h1>File changes:</h1>

modified:   ISSUES.md

- Update for release 3.

modified:   app/build.gradle

- versionCode: bump to release version 3.

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- TAG: add a logcat tag.
- mIsFirebaseEnabled: new variable used to track the Firebase state, whether enabled or disabled.  During backgrounding, Firebase is disabled.  When returning to the foreground, Firebase is enabled.
- mRegistrationClassNameMap: a new map that helps to determine when it is time to enable Firebase.
- init(): setup the registration class name map with the classes that must be registered before Firebase can be enabled.
- onRegistrationChange(): capture the registration events to know when it is time to enable or disable Firebase.
- register(), unregister(): provide logging and maintain the Firebase enabled/disabled state.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- onAttach(), onDetach(): move the app event registering/unregistering to the base fragment during pause and resume.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java

- registerHandler(), unregisterHandler(), unregisterAll(): provide logging and clear the entries during unregistering.

modified:   app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java

- register(), unregister(), unregisterAll(): post a registration change event.

new file:   app/src/main/java/com/pajato/android/gamechat/event/RegistrationChangeEvent.java

- New file supporting app event registration change events.

modified:   app/src/main/java/com/pajato/android/gamechat/game/BaseGameFragment.java

- onAttach(), onPause(), onResume(): remove as all the work is done in the super class.

modified:   app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java

- onPause(), onResume(): deal with registering and unregistering app event handlers.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onDestroy(), onPause(), onResume(): use the base class.
- init(): tell the account manager which classes Firebase depends on.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- init(): do not deal with app event registration, as the main activity takes care of it.