### PR TITLE
Fix a duplicate messages issue.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
@@ -63,10 +63,11 @@ public class GroupItem {
         Group group = DatabaseListManager.instance.getGroupProfile(groupKey);
         name = group.name;
         Map<String, Integer> roomMap = new HashMap<>();
-        Map<String, List<Message>> roomMessageListMap = DatabaseListManager.instance.getGroupMessages(groupKey);
-        for (String roomKey : roomMessageListMap.keySet()) {
+        Map<String, Map<String, Message>> roomMessageMap;
+        roomMessageMap = DatabaseListManager.instance.getGroupMessages(groupKey);
+        for (String roomKey : roomMessageMap.keySet()) {
             int roomNewCount = 0;
-            for (Message message : roomMessageListMap.get(roomKey)) {
+            for (Message message : roomMessageMap.get(roomKey).values()) {
                 if (isUnseen(message)) {
                     roomNewCount++;
                     count++;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
@@ -65,8 +65,9 @@ public class RoomItem {
         Map<String, Boolean> memberNameMap = new HashMap<>();
         Room room = DatabaseListManager.instance.getRoomProfile(roomKey);
         name = room.name;
-        Map<String, List<Message>> rooms = DatabaseListManager.instance.getGroupMessages(groupKey);
-        for (Message message : rooms.get(roomKey)) {
+        Map<String, Map<String, Message>> rooms;
+        rooms = DatabaseListManager.instance.messageMap.get(groupKey);
+        for (Message message : rooms.get(roomKey).values()) {
             // Ensure that the member who posted the message is in the member display name map.
             String displayName = message.owner.equals(accountId) ? "me" : message.name;
             if (!memberNameMap.containsKey(displayName)) memberNameMap.put(displayName, false);

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java
@@ -94,33 +94,6 @@ public class ExpProfileListChangeHandler extends DatabaseEventHandler
 
     // Private instance methods.
 
-    /** Process the change by updating the database list and notifying the app. */
-    private void process(final DataSnapshot snapshot, final int type) {
-        // Abort if the data snapshot does not exist.
-        if (!snapshot.exists()) return;
-
-        // A snapshot exists.  Extract the experience profile from it and determine if the profile
-        // has been handled already.  If not, then case on the change type and notify the app.
-        ExpProfile expProfile = snapshot.getValue(ExpProfile.class);
-        Map<String, ExpProfile> expProfileMap = getExpProfileMap(expProfile);
-        switch (type) {
-            case NEW:
-            case CHANGED:
-                // Add the profile to the list manager (or replace it if it already exists.)
-                expProfileMap.put(expProfile.key, expProfile);
-                break;
-            case REMOVED:
-                // Update the database list experience profile map by removing the entry (key).
-                expProfileMap.remove(expProfile.key);
-                break;
-            case MOVED:
-            default:
-                // Not sure what a moved change means or what to do about it, so do nothing.
-                break;
-        }
-        AppEventManager.instance.post(new ExpProfileListChangeEvent(expProfile, type));
-    }
-
     /** Return a map of experience profiles for the room in the given experience profile. */
     private Map<String, ExpProfile> getExpProfileMap(final ExpProfile expProfile) {
         // Ensure that the room map exists for the group in the master map, creating it if need be.
@@ -153,5 +126,32 @@ public class ExpProfileListChangeHandler extends DatabaseEventHandler
         }
 
         return expProfileMap;
+    }
+
+    /** Process the change by updating the database list and notifying the app. */
+    private void process(final DataSnapshot snapshot, final int type) {
+        // Abort if the data snapshot does not exist.
+        if (!snapshot.exists()) return;
+
+        // A snapshot exists.  Extract the experience profile from it and determine if the profile
+        // has been handled already.  If not, then case on the change type and notify the app.
+        ExpProfile expProfile = snapshot.getValue(ExpProfile.class);
+        Map<String, ExpProfile> expProfileMap = getExpProfileMap(expProfile);
+        switch (type) {
+            case NEW:
+            case CHANGED:
+                // Add the profile to the list manager (or replace it if it already exists.)
+                expProfileMap.put(expProfile.key, expProfile);
+                break;
+            case REMOVED:
+                // Update the database list experience profile map by removing the entry (key).
+                expProfileMap.remove(expProfile.key);
+                break;
+            case MOVED:
+            default:
+                // Not sure what a moved change means or what to do about it, so do nothing.
+                break;
+        }
+        AppEventManager.instance.post(new ExpProfileListChangeEvent(expProfile, type));
     }
 }


### PR DESCRIPTION
<h1>Rationale:</h1>

On a foreground to background to foreground cycle, duplicate messages are created in the messages list view.  This commit fixes that problem by using the same approach used to manage experience profiles: process the database list manager's message map directly to do the right thing at the right time.  In this approach duplicate messages overwrite each other rather than create new ones.  The duplicates arise from the database module re-reading all the messages in a room.  This is sub-optimal but now is not the time to fix it, IMHO.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/GroupItem.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java

- GroupItem(), RoomItem(): apply the List<Message> to Map<String, Message> change.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- mGroupMessageMap: make public; rename to messageMap; apply the List<Message> to Map<String, Message> change.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/ExpProfileListChangeHandler.java

- process(): move per RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/MessagesChangeHandler.java

- Use the ExpProfileChangeHandler design as a model.