### PR TITLE
Add tests for AddGroupActivity; take 1

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
@@ -1,16 +1,7 @@
 package com.pajato.android.gamechat;
 
-import android.app.Instrumentation;
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingResource;
 import android.support.test.runner.AndroidJUnit4;
 
-import com.pajato.android.gamechat.event.AppEventManager;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/app/src/androidTest/java/com/pajato/android/gamechat/chat/AddGroupActivityTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/chat/AddGroupActivityTest.java
@@ -1,0 +1,115 @@
+package com.pajato.android.gamechat.chat;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.NoActivityResumedException;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.pajato.android.gamechat.R;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.fail;
+
+
+/** Test the group add activty. */
+@RunWith(AndroidJUnit4.class) public class AddGroupActivityTest {
+
+    // Public instance variables.
+
+    /** Set up the rule instance variable to allow for having intent extras passed in. */
+    @Rule public ActivityTestRule<AddGroupActivity> mRule =
+            new ActivityTestRule<>(AddGroupActivity.class, true, false);
+
+    @Before public void setup() {
+        Intent intent = new Intent();
+        mRule.launchActivity(intent);
+    }
+
+    /** Test the button click operations with a null account. */
+    @Test public void testButtonClickHandlerNoAccount() throws Exception {
+        // Exercise the placeholder functions.
+        onView(withId(R.id.addGroupMembers)).check(matches(isDisplayed())).perform(click());
+        onView(withId(R.id.setGroupIcon)).check(matches(isDisplayed())).perform(click());
+
+        // Test that the group name edit text field is visible and empty by default, and that the
+        // save button is not clickable.
+        onView(withId(R.id.groupNameText)).check(matches(isDisplayed()));
+        onView(withId(R.id.groupNameText)).check(matches(withText("")));
+        onView(withId(R.id.saveGroupButton)).check(matches(isDisplayed()));
+        onView(withId(R.id.saveGroupButton)).check(matches(not(isEnabled())));
+
+        // Set the group name field value to non empty and ensure that the save button is enabled.
+        onView(withId(R.id.groupNameText)).perform(replaceText("Test Group"));
+        onView(withId(R.id.saveGroupButton)).check(matches(isEnabled()));
+
+        // Reset the group name field value using the clear button and ensure that the save button
+        // is disabled again.
+        onView(withId(R.id.clearGroupName)).check(matches(isDisplayed())).perform(click());
+        onView(withId(R.id.saveGroupButton)).check(matches(not(isEnabled())));
+
+        // Finally enable the save button again and click on it to ensure the add group activity
+        // finishes.
+        onView(withId(R.id.groupNameText)).perform(replaceText("Test Group"));
+        onView(withId(R.id.saveGroupButton)).perform(click());
+    }
+
+    /** Use a back press to cancel out of the activity. */
+    @Test public void testOnBackPressed() throws Exception {
+        try {
+            Espresso.pressBack();
+            fail("Did not take the expected NoActivityResumedException.");
+        } catch (NoActivityResumedException exc) {
+            // Quietly pass the test.
+        }
+    }
+
+    /** Test that the learn more overflow menu item does the right thing. */
+    @Test public void testLearnMoreOverflowMenuItem() throws Exception {
+        Context context = getInstrumentation().getTargetContext();
+        String text = context.getString(R.string.MenuItemLearnMore);
+        Espresso.openActionBarOverflowOrOptionsMenu(context);
+        onView(withText(text)).check(matches(isDisplayed()));
+    }
+
+    /** Test that the learn more overflow menu item does the right thing. */
+    @Test public void testHomeOverflowMenuItem() throws Exception {
+        // TODO: implement this test using UIAutomator rather than an unreliable solution.
+        // onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click());
+    }
+
+    /** ... */
+    @Test public void onOptionsItemSelected() throws Exception {
+        //fail("Not yet fully implemented.");
+    }
+
+    /** ... */
+    @Test public void onCreate() throws Exception {
+        //fail("Not yet fully implemented.");
+    }
+
+    /** ... */
+    @Test public void onPause() throws Exception {
+        //fail("Not yet fully implemented.");
+    }
+
+    /** ... */
+    @Test public void onResume() throws Exception {
+        //fail("Not yet fully implemented.");
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java
@@ -174,7 +174,7 @@ public class AddGroupActivity extends AppCompatActivity implements View.OnClickL
     private String getDefaultAccountName() {
         // Ensure that the account exists.
         Account account = AccountManager.instance.getCurrentAccount();
-        if (account == null) return null;
+        if (account == null) return "";
 
         // Obtain a sane default group name.
         String group = getResources().getString(R.string.Group);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
@@ -99,11 +99,11 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
 
     /** Handle the setup of the list of messages. */
     @Override public void onInitialize() {
-        // Inflate the layout for this fragment and initialize by setting the titles, declaring the
-        // use of the options menu, removing the FAB button, fetching any remote configurations,
-        // setting up the list of messages, and by setting up the edit text field.
+        // Inflate the layout for this fragment and initialize by setting the app bar title text,
+        // declaring the use of the options menu, removing the FAB button, fetching any remote
+        // configurations, setting up the list of messages, and by setting up the edit text field.
         super.onInitialize();
-        setTitles(null, mItem.roomKey);
+        setTitles(null, mItem != null ? mItem.roomKey : null);
         mItemListType = DatabaseListManager.ChatListType.message;
         FabManager.chat.setState(this, View.GONE);
         initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), true);

--- a/doc/Issues.md
+++ b/doc/Issues.md
@@ -1,10 +1,12 @@
 Short Term Issues needing resolution.  Longer term items should be logged on GitHub.
 
-- Revive the connected tests towards an end of having broken tests fixed and a > 90% coverage level, an ongoing task.
+- Fix the "Join Developer Groups" bug.
+- Implement AddGroupActivityTest#testHomeOverflowMenuItem avoiding the use of the AOSP Navigate Up string resource.
+- Create AddGroupActivityTest#testButtonClickHandlerWithAccount() to exercices process().
+- Rename the "game" package to "exp".
 - Change the FAM for signed out and offline screens to allow for sign in, switch accounts and connecting to the network; fix tests accordingly.
-- Add connected checks for tablets.
+- Morph the options overflow menu items to behave like the Inbox app; Add privacy policy while doing this.
 - Set up real web site for GameChat using Google Sites.
-- Add privacy policy to app ala Inbox (options menu Help and Feedback).
 - Add member rooms to the room list screens.
 - Make <experience> back press navigate to the optimal screen on the experience page.
 - Add long press context menus to player controls for experiences to provide alternative choices (computer, another user, a friend, change name, etc.)
@@ -14,13 +16,18 @@ Short Term Issues needing resolution.  Longer term items should be logged on Git
 - Fix Chat sign out crock:  Signing out works OK but signing back in does not display the correct result in either the chat or experience pages.
 - Overhaul "Winner" notifications/animations starting with TicTacToe.
 - Add an icon (preferable SVG) to the sign in button on the signed out screen.
+- Implement invites that allow a User to join a group.
 - Implement join a room.
 - Implement add a room.
 - Setup daily jenkins releases, i.e. release an update every day at a prescribed time when a new feature or fix is in master.
-- Do Play Store Beta release.
+- Add connected checks for tablets.
+
+- Do Play Store V1/Beta release.
+
 - Optimize message fetching to start from the last message read in a room.
 - Consolidate ExpDispatcher and ChatDispatcher into a single class using generics.
 - Consolidate the offline, no account/signed out, and no experiences/messages layout files into a single layout file.
 - Consoldiate ExpFragmentType and ChatFragmentType.
 - Rename the "game" package to "exp".
+
 - Do Production release.


### PR DESCRIPTION
<h1>Rationale:</h1>

The connected check tests are in a deplorable state.  The fix is to start adding a steady stream of tests (3 days worth per week is the plan) to fix broken tests and add new ones.  This commit provides a first pass at adding some tests for the AddGroupActivity class.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java

- Summary: address AS warning on unused imports.

new file:   app/src/androidTest/java/com/pajato/android/gamechat/chat/AddGroupActivityTest.java

- Summary: add tests using a template generated by AS as a starting point.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- getDefaultAccountName(): do not return null, instead return an empty string.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java

- onInitialize(): fix an NPE due to mItem being null.

modified:   doc/Issues.md

- update based on a planning session with Sandy to address the work tasks for the next week (starts on Sunday, November 13th).