### PR TITLE
Fix the join developer groups menu item.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -181,7 +181,7 @@ enum ChatManager {
         int index = dispatcher.type.ordinal();
         //mFragmentList[index].setupExperience(context, dispatcher);
         context.getSupportFragmentManager().beginTransaction()
-            .replace(R.id.gameFragmentContainer, mFragmentMap.get(index))
+            .replace(R.id.chatFragmentContainer, mFragmentMap.get(index))
             .commit();
         return true;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
+import com.pajato.android.gamechat.BuildConfig;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.account.AccountManager;
@@ -103,7 +104,8 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
         // declaring the use of the options menu, removing the FAB button, fetching any remote
         // configurations, setting up the list of messages, and by setting up the edit text field.
         super.onInitialize();
-        setTitles(null, mItem != null ? mItem.roomKey : null);
+        if (BuildConfig.DEBUG && mItem == null) throw new AssertionError("mitem is null!");
+        setTitles(mItem.groupKey, mItem.roomKey);
         mItemListType = DatabaseListManager.ChatListType.message;
         FabManager.chat.setState(this, View.GONE);
         initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), true);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowNoMessagesFragment.java
@@ -19,14 +19,13 @@ package com.pajato.android.gamechat.chat;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.event.ExpProfileListChangeEvent;
 import com.pajato.android.gamechat.event.MessageChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import static com.pajato.android.gamechat.chat.ChatFragment.CHAT_HOME_FAM_KEY;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
-import static com.pajato.android.gamechat.chat.ChatFragment.CHAT_HOME_FAM_KEY;
 
 public class ShowNoMessagesFragment extends BaseChatFragment {
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -34,23 +34,26 @@ import java.util.Map;
     public final static int STANDARD = 1;
     // TODO: add this real soon: public final static int PROTECTED = 2;
 
-    /** The member account identifer who posted the message. */
-    public String owner;
+    /** The creation timestamp. */
+    public long createTime;
+
+    /** The push key of the group to which the message belongs. */
+    public String groupKey;
 
     /** The message push key. */
     public String key;
 
+    /** The last modification timestamp. */
+    private long modTime;
+
     /** The poster's display name. */
     public String name;
 
-    /** The poster's url. */
-    public String url;
+    /** The member account identifer who posted the message. */
+    public String owner;
 
-    /** The creation timestamp. */
-    public long createTime;
-
-    /** The last modification timestamp. */
-    private long modTime;
+    /** The push key for the room in which the message was created. */
+    public String roomKey;
 
     /** The message text. */
     public String text;
@@ -60,6 +63,9 @@ import java.util.Map;
 
     /** A list of users (by account identifier) in the room, that have not yet read the message. */
     public List<String> unreadList;
+
+    /** The poster's url. */
+    public String url;
 
     // Public constructors.
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -141,7 +141,8 @@ public enum DatabaseListManager {
     }
 
     /** Get the list data given a list type. */
-    public List<ChatListItem> getList(final ChatListType type, final ChatListItem item) {
+    public List<ChatListItem> getList(@NonNull final ChatListType type,
+                                      @NonNull final ChatListItem item) {
         switch (type) {
             case group:
                 return getGroupListData();
@@ -333,7 +334,7 @@ public enum DatabaseListManager {
     }
 
     /** Return a list of messages, an empty list if there are none to be had, for a given item. */
-    private List<ChatListItem> getMessageListData(final ChatListItem item) {
+    private List<ChatListItem> getMessageListData(@NonNull final ChatListItem item) {
         // Generate a map of date header types to a list of messages, i.e. a chronological ordering
         // of the messages.
         String groupKey = item.groupKey;


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug whereby the developer menu item handler for the join developer groups function, was not being called.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onOptionsItemSelected(): rename to onMenuItem() and morph into a app event bus subscriber such that the event is canceled on a join developer groups menu choice.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- startNextFragment(): fix a typo so that the chat fragment container is used rather than the game fragment container.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java

- onInitialize(): catch cases of mItem not being set.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowNoMessagesFragment.java

- Summary: optimize imports.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java

- Summary: perform the initial work to maintain the room and group push keys in a message.  The next commit will flesh this out.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- getList(), getMessageListData(): declare the type and item arguments to be non-null.