### PR TITLE
Fix chat layout breakage.

### DIFF
--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -21,22 +21,22 @@ http://www.gnu.org/licenses
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/PaneLayout">
+    android:id="@+id/chatPaneLayout">
 
     <FrameLayout
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:id="@+id/chatFragmentContainer"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
 
     <View style="@style/DimmerTheme"
         android:id="@+id/chatDimmer"
-        tools:visibility="visible"
         android:layout_height="0dp"
         android:layout_width="0dp"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible" />
 
     <android.support.design.widget.CoordinatorLayout style="@style/FamTheme"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -32,11 +32,11 @@ http://www.gnu.org/licenses
 
     <View style="@style/DimmerTheme"
         android:id="@+id/gameDimmer"
-        tools:visibility="visible"
         android:layout_height="0dp"
         android:layout_width="0dp"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible" />
 
     <android.support.design.widget.CoordinatorLayout style="@style/FamTheme"
         android:layout_width="wrap_content"


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug whereby the layout of the chat screens was broken.  The chat and game panel layouts have been made identical but for id prefixes.

<h1>File changes:</h1>

modified:   app/src/main/res/layout/fragment_chat.xml

- chatFragmentContainer.layout_width, layout_height: use match_parent instead of 0dp.
- chatDimmer.visibility: move this attribute to the bottom to comply with RNF.

modified:   app/src/main/res/layout/fragment_game.xml

- chatDimmer.visibility: move this attribute to the bottom to comply with RNF.