### PR TITLE
Fix startup crash.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java
@@ -98,20 +98,6 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
         setItemState(menu, R.id.search, true);
     }
 
-    /** Handle the setup of the list of messages. */
-    @Override public void onInitialize() {
-        // Inflate the layout for this fragment and initialize by setting the app bar title text,
-        // declaring the use of the options menu, removing the FAB button, fetching any remote
-        // configurations, setting up the list of messages, and by setting up the edit text field.
-        super.onInitialize();
-        if (BuildConfig.DEBUG && mItem == null) throw new AssertionError("mitem is null!");
-        setTitles(mItem.groupKey, mItem.roomKey);
-        mItemListType = DatabaseListManager.ChatListType.message;
-        FabManager.chat.setState(this, View.GONE);
-        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), true);
-        initEditText(mLayout);
-    }
-
     /** Manage the list UI every time a message change occurs. */
     @Subscribe public void onChatListChange(final ChatListChangeEvent event) {
         // Log the event and update the list saving the result for a retry later.
@@ -122,6 +108,10 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
     /** Deal with the fragment's lifecycle by managing the FAB. */
     @Override public void onResume() {
         // Turn off the FAB and force a recycler view update.
+        if (BuildConfig.DEBUG && mItem == null) throw new AssertionError("mitem is null!");
+        mItemListType = DatabaseListManager.ChatListType.message;
+        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), true);
+        initEditText(mLayout);
         setTitles(mItem.groupKey, mItem.roomKey);
         FabManager.chat.setState(this, View.GONE);
         mUpdateOnResume = true;

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -89,6 +89,7 @@ public class Dispatcher<T, O> {
         this.groupKey = gKey;
         this.roomKey = rKey;
         this.list = list;
+        payload = list.size() > 0 ? list.get(0) : null;
     }
 
     /** Build an instance given a type, a group key, a room key and a message or experience key. */
@@ -103,6 +104,7 @@ public class Dispatcher<T, O> {
     public Dispatcher(final T type, List<O> list) {
         this.type = type;
         this.list = list;
+        payload = list.size() > 0 ? list.get(0) : null;
     }
 
     /** Build an instance given a fragment type and a message or experience profile. */


### PR DESCRIPTION
<h1>Rationale:</h1>

On certain accounts at startup, GC will crash.  The problem arises in accounts with more than one message in certain groups due to BaseChatFragment#onDispatch() failing to call doDispatch().  This failure, in turn was caused becasue the dispatcher did not set the payload in two cases.  This commmit fixes the problem by ensuring that those two cases are now fixed.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowMessageListFragment.java

- onInitialize(): move the content of the method to onResume().

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- Dispatcher(): ensure that the two overloads providing a list set the payload.