### PR TITLE
Make the room list be the default (HOME) chat list.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -32,13 +32,10 @@ import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.main.NetworkManager;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static com.pajato.android.gamechat.chat.ChatFragmentType.groupList;
-import static com.pajato.android.gamechat.chat.ChatFragmentType.messageList;
 import static com.pajato.android.gamechat.chat.ChatFragmentType.noMessages;
 import static com.pajato.android.gamechat.chat.ChatFragmentType.offline;
 import static com.pajato.android.gamechat.chat.ChatFragmentType.roomList;
@@ -76,7 +73,7 @@ enum ChatManager {
 
     // Private instance methods.
 
-    /** Return a dispatcher object based on the current experience state. */
+    /** Return a dispatcher object based on the current message list state. */
     private Dispatcher<ChatFragmentType, Message> getDispatcher() {
         // Deal with an off line user, a signed out user, or no messages at all, in that order.
         // In each case, return an empty dispatcher but for the fragment type of the next screen to
@@ -95,16 +92,7 @@ enum ChatManager {
         // dispatcher identifying the group and room map.
         String groupKey = messageMap.keySet().iterator().next();
         Map<String, Map<String, Message>> roomMap = messageMap.get(groupKey);
-        if (roomMap.size() > 1) return new Dispatcher<>(roomList, groupKey, roomMap);
-
-        // A signed in user with multiple messages in a single room.  Return a dispatcher that
-        // identifies the group, room and the list of messages.
-        String roomKey = roomMap.keySet().iterator().next();
-        List<Message> list = new ArrayList<>(roomMap.get(roomKey).values());
-        if (list.size() > 1) return new Dispatcher<>(messageList, groupKey, roomKey, list);
-
-        // A signed in User with one message. Return a dispatcher to show the single message.
-        return new Dispatcher<>(messageList, list.get(0));
+        return new Dispatcher<>(roomList, groupKey, roomMap);
     }
 
     /** Attach a drill down fragment identified by a type, creating that fragment as necessary. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -52,18 +52,6 @@ public class ShowGroupListFragment extends BaseChatFragment {
         setItemState(menu, R.id.search, true);
     }
 
-    /** Handle the setup for the groups panel. */
-    @Override public void onInitialize() {
-        // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
-        // view and the listeners for backend data changes.
-        super.onInitialize();
-        setTitles(null, null);
-        mItemListType = DatabaseListManager.ChatListType.group;
-        initAdView(mLayout);
-        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), false);
-        FabManager.chat.init(this);
-    }
-
     /** Manage the list UI every time a message change occurs. */
     @Subscribe public void onChatListChange(final ChatListChangeEvent event) {
         // Log the event and update the list saving the result for a retry later.
@@ -73,11 +61,14 @@ public class ShowGroupListFragment extends BaseChatFragment {
 
     /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
     @Override public void onResume() {
-        // Turn on the FAB, shut down the progress bar (if it is showing), and force a recycle view
-        // update.
+        // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
+        // the group list display.
         setTitles(null, null);
-        FabManager.chat.setState(this, View.VISIBLE);
-        FabManager.chat.setMenu(this, CHAT_HOME_FAM_KEY);
+        FabManager.chat.init(this, View.VISIBLE, CHAT_HOME_FAM_KEY);
+        initAdView(mLayout);
+        mItemListType = DatabaseListManager.ChatListType.group;
+        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), false);
         mUpdateOnResume = true;
         super.onResume();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
@@ -32,6 +32,8 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
+import static com.pajato.android.gamechat.chat.ChatFragment.CHAT_HOME_FAM_KEY;
+
 /**
  * Provide a fragment to handle the display of the groups available to the current user.  This is
  * the top level view in the chat hierarchy.  It shows all the joined groups and allows for drilling
@@ -57,18 +59,6 @@ public class ShowRoomListFragment extends BaseChatFragment {
         setItemState(menu, R.id.search, true);
     }
 
-    /** Handle the setup for the groups panel. */
-    @Override public void onInitialize() {
-        // Inflate the layout for this fragment and initialize by setting the titles, declaring the
-        // use of the options menu, setting up the ad view and initializing the rooms handling.
-        super.onInitialize();
-        setTitles(mItem.groupKey, null);
-        mItemListType = DatabaseListManager.ChatListType.room;
-        initAdView(mLayout);
-        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), false);
-        FabManager.chat.init(this);
-    }
-
     /** Manage the list UI every time a message change occurs. */
     @Subscribe public void onChatListChange(final ChatListChangeEvent event) {
         // Log the event and update the list saving the result for a retry later.
@@ -79,9 +69,14 @@ public class ShowRoomListFragment extends BaseChatFragment {
 
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
     @Override public void onResume() {
-        // Turn on the FAB and force a recycler view  update.
+        // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
+        // the group list display.
+        FabManager.chat.init(this, View.VISIBLE, CHAT_HOME_FAM_KEY);
         setTitles(mItem.groupKey, null);
-        FabManager.chat.setState(this, View.VISIBLE);
+        initAdView(mLayout);
+        mItemListType = DatabaseListManager.ChatListType.room;
+        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), false);
         mUpdateOnResume = true;
         super.onResume();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java
@@ -56,12 +56,12 @@ public class MessageItem {
     // Public constructors.
 
     /** Build an instance for the given group. */
-    public MessageItem(final String groupKey, final String roomKey, final Message message) {
+    public MessageItem(final Message message) {
         // Update the group and room keys, the message text and url fields, and set the count to 0
         // to flag that it is not relevant for a message item.  Set the name field to the poster's
         // display name concatenated with the creation date.
-        this.groupKey = groupKey;
-        this.roomKey = roomKey;
+        groupKey = message.groupKey;
+        roomKey = message.roomKey;
         text = message.text;
         url = message.url;
         DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance();

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -60,7 +60,7 @@ public class Dispatcher<T, O> {
 
     // Public Constructors.
 
-    /** Build an instance given an experience type. */
+    /** Build an instance given a type. */
     public Dispatcher(final T type) {
         this.type = type;
         Room room = DatabaseListManager.instance.getMeRoom();

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -97,6 +97,15 @@ public enum FabManager {
         fab.setVisibility(View.GONE);
     }
 
+    /** Initialize the fab state to show the FAB, hide the FAM and preset the FAM. */
+    public void init(final Fragment fragment, final int visibility, final String key) {
+        // Provide a convenience init function to initialize the FAB state and visibility, and to
+        // attach a particular menu.
+        init(fragment);
+        setState(fragment, visibility);
+        setMenu(fragment, key);
+    }
+
     /** Initialize the fab state. */
     public void init(final Fragment fragment) {
         // Ensure that the layout exists. Abort if it does not.  Set the FAB state to closed if it

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -294,12 +294,9 @@ public enum DatabaseListManager {
     }
 
     /** Return a list of ordered chat items from a map of chronologically ordered messages. */
-    private List<ChatListItem> getItems(final ChatListItem item,
-                                        final Map<DateHeaderType, List<Message>> messageMap) {
+    private List<ChatListItem> getItems(final Map<DateHeaderType, List<Message>> messageMap) {
         // Build the list of display items, in reverse order (oldest to newest).
         List<ChatListItem> result = new ArrayList<>();
-        String groupKey = item.groupKey;
-        String roomKey = item.roomKey;
         DateHeaderType[] types = DateHeaderType.values();
         int size = types.length;
         for (int index = size - 1; index >= 0; index--) {
@@ -309,7 +306,7 @@ public enum DatabaseListManager {
             if (list != null) {
                 result.add(new ChatListItem(new DateHeaderItem(dht)));
                 for (Message message : list) {
-                    result.add(new ChatListItem(new MessageItem(groupKey, roomKey, message)));
+                    result.add(new ChatListItem(new MessageItem(message)));
                 }
             }
         }
@@ -339,7 +336,7 @@ public enum DatabaseListManager {
         // of the messages.
         String groupKey = item.groupKey;
         String roomKey = item.roomKey;
-        return getItems(item, getMessageMap(getGroupMessages(groupKey).get(roomKey)));
+        return getItems(getMessageMap(getGroupMessages(groupKey).get(roomKey)));
     }
 
     /** Return a map of the given messages, sorted into chronological buckets. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -134,7 +134,7 @@ public enum NavigationManager {
     private void loadAccountIcon(final Account account, final View header) {
         // Determine if there is an image to be loaded.
         ImageView icon = (ImageView) header.findViewById(R.id.currentAccountIcon);
-        Uri imageUri = Uri.parse(account.url);
+        Uri imageUri = account.url != null ? Uri.parse(account.url) : null;
         if (imageUri != null) {
             // There is an image to load.  Use Glide to do the heavy lifting.
             icon.setImageURI(imageUri);


### PR DESCRIPTION
<h1>Rationale:</h1>

Making the message list be the default when there was only one message prevented access to the FAB in order to create another room or group, thus causing a real problem for the User.  This commit fixes that problem and addresses a few AS warnings.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): flesh this out for all three chat lists: group, room and message.
- doDispatch(): remove as it has become stale.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- getDispatcher(): make the room list the default when there is only one group.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java

- onInitialize(): use the default (super).
- onResume: canonicalize dealing with the relevant list.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/MessageItem.java

- MessageItem(); remove unused constructor arguments; take the keys from the given message.

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- Dispatcher(): minor comment fix.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- init(): provide a convenience overload to deal with mulitiple initialization concerns.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- getItems(): fix an unused argument AS warning.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- loadAccountIcon(): deal with a null url string.