### PR TITLE
Fix the chat home page detection.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -33,7 +33,6 @@ import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.adapter.ChatListAdapter;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
-import com.pajato.android.gamechat.chat.adapter.GroupItem;
 import com.pajato.android.gamechat.chat.adapter.MessageItem;
 import com.pajato.android.gamechat.chat.adapter.RoomItem;
 import com.pajato.android.gamechat.chat.model.Group;
@@ -219,8 +218,7 @@ public abstract class BaseChatFragment extends BaseFragment {
         ChatFragmentType type = (ChatFragmentType) dispatcher.type;
         switch (type) {
             case groupList:
-                GroupItem groupItem = new GroupItem(dispatcher.groupKey);
-                mItem = new ChatListItem(groupItem);
+                // A group list does not need an item.
                 return true;
             case messageList:
                 Message payload = (Message) dispatcher.payload;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -42,6 +42,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static com.pajato.android.gamechat.chat.ChatFragmentType.showNoJoinedRooms;
 
@@ -139,14 +140,9 @@ public class ChatFragment extends BaseChatFragment {
         FabManager.chat.setMenu(CHAT_HOME_FAM_KEY, getHomeMenu());
     }
 
-    /** Deal with a change in the joined rooms state. */
+    /** Deal with a change in the joined rooms state by logging it. */
     @Subscribe public void onJoinedRoomListChange(@NonNull final JoinedRoomListChangeEvent event) {
-        // Turn off the loading progress dialog and handle a signed in account with some joined
-        // rooms by rendering the list.
-        if (event.joinedRoomList.size() == 0) {
-            // Handle the case where there are no joined rooms by enabling the no rooms message.
-            ChatManager.instance.replaceFragment(showNoJoinedRooms, this.getActivity());
-        }
+        logEvent(String.format(Locale.US, "onJoinedRoomListChange with event: {%s}", event));
     }
 
     /** Dispatch to a more suitable fragment. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -68,7 +68,7 @@ public class ShowGroupListFragment extends BaseChatFragment {
         FabManager.chat.init(this, View.VISIBLE, CHAT_HOME_FAM_KEY);
         initAdView(mLayout);
         mItemListType = DatabaseListManager.ChatListType.group;
-        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, mItem), false);
+        initList(mLayout, DatabaseListManager.instance.getList(mItemListType, null), false);
         mUpdateOnResume = true;
         super.onResume();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -119,7 +119,7 @@ public enum DatabaseListManager {
     }
 
     /** Get the profile for a given group, queueing it up to be loaded if necessary. */
-    public Group getGroupProfile(final String groupKey) {
+    public Group getGroupProfile(@NonNull final String groupKey) {
         // Return the group if it has been loaded.
         Group result = groupMap.get(groupKey);
         if (result != null) return result;
@@ -141,8 +141,7 @@ public enum DatabaseListManager {
     }
 
     /** Get the list data given a list type. */
-    public List<ChatListItem> getList(@NonNull final ChatListType type,
-                                      @NonNull final ChatListItem item) {
+    public List<ChatListItem> getList(@NonNull final ChatListType type, final ChatListItem item) {
         switch (type) {
             case group:
                 return getGroupListData();

--- a/app/src/main/java/com/pajato/android/gamechat/event/JoinedRoomListChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/JoinedRoomListChangeEvent.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.event;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -37,4 +38,8 @@ public class JoinedRoomListChangeEvent {
         joinedRoomList = list;
     }
 
+    /** Return the joined room list as an array of String objecs. */
+    @Override public String toString() {
+        return Arrays.toString(joinedRoomList.toArray());
+    }
 }


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a problem in the detection of the group vs room list chat home page.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): do not set mItem on a group list.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- onJoinedRoomsListChange(): for now, just log the event.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- mFragmentMap: change to a Map to allow the use of enums as the key.  Much more sane.
- replaceFragment(): remove as this is now stale.
- getFragment(), getFragmentInstance(), startNextFragment(), fragmentExists(): use the dispatcher type directly, not the ordinal value to key the fragment from the map.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java

- onResume(): use a null argument value for the getList() call.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- getGroupProfile(), getList(): signal the intent for null arguments.

modified:   app/src/main/java/com/pajato/android/gamechat/event/JoinedRoomListChangeEvent.java

- toString(): provide support for debugging.