### PR TITLE
Add the basic join room presentation, including members.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@ http://www.gnu.org/licenses
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
         <activity
             android:name=".chat.AddGroupActivity"
-            android:label="@string/AddGroupTitle"
+            android:label="@string/CreateGroupTitle"
             android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
         <service

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -57,6 +57,7 @@ import static com.pajato.android.gamechat.chat.ChatFragmentType.messageList;
 import static com.pajato.android.gamechat.chat.ChatFragmentType.roomList;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.GROUP_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.ROOM_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.RoomItem.TextType.countList;
 import static com.pajato.android.gamechat.database.DatabaseListManager.ChatListType.message;
 
 /**
@@ -196,7 +197,7 @@ public abstract class BaseChatFragment extends BaseFragment {
                 return true;
             case roomList:
                 String roomKey = dispatcher.roomMap.keySet().iterator().next().toString();
-                RoomItem roomItem = new RoomItem(dispatcher.groupKey, roomKey);
+                RoomItem roomItem = new RoomItem(dispatcher.groupKey, roomKey, countList);
                 mItem = new ChatListItem(roomItem);
                 return true;
             default:
@@ -239,21 +240,23 @@ public abstract class BaseChatFragment extends BaseFragment {
 
         // Walk the list of developer groups to ensure that all are joined.
         List<String> groupList = new ArrayList<>();
-        groupList.add("-KUpGKrumJPeBi8-dTqH");      // Paul Reilly Group
-        groupList.add("-KUpHCHRnXW0IvIDe4hd");      // GameChat Group
-        groupList.add("-KUpHLkxb9c1nM2O8Ocs");      // Pajato Technologies LLC
-        groupList.add("-KUpHWgtdLSnFwMiMp0k");      // Pajato Support Group
+        groupList.add("-KXvxnOUoXFZr91D3aMR");      // Paul Reilly Group
+        groupList.add("-KXyXYn6WocFLa5F6HmC");      // Heather Music
+        groupList.add("-KXyiDyFqQkDDgTgd4yD");      // Hawthorn
+        groupList.add("-KXyfV6sX5FSkGki5LgK");      // GameChat Group
+        groupList.add("-KXw5ly2OPhgXuVtbNCw");      // Pajato Technologies
+        groupList.add("-KXw5aX1iqSnt3NChdya");      // Pajato Support Group
         for (String groupKey : groupList) {
             // Extend an invitation to the group and verify that this group has been joined.
             InvitationManager.instance.extendGroupInvite(account, groupKey);
-            if (!account.groupIdList.contains(groupKey)) {
+            if (!account.joinList.contains(groupKey)) {
                 // Join the group now if it has been loaded.  It will be queued for joining later if
                 // necessary.
                 Group group = DatabaseListManager.instance.getGroupProfile(groupKey);
                 if (group != null)
                     // The group is available.  Accept any open invitations. There should be at
                     // least one!
-                    InvitationManager.instance.acceptGroupInvite(account, group, groupKey);
+                    InvitationManager.instance.acceptGroupInvite(account, groupKey);
             }
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java
@@ -32,9 +32,9 @@ import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
-import com.pajato.android.gamechat.event.AccountStateChangeEvent;
+import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.JoinedRoomListChangeEvent;
+import com.pajato.android.gamechat.event.MemberChangeEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.chat.ChatFragmentType.joinRoom;
-import static com.pajato.android.gamechat.chat.ChatFragmentType.showNoJoinedRooms;
 
 /**
  * Provide a fragment class that decides which alternative chat fragment to show to the User.
@@ -65,8 +64,9 @@ public class ChatFragment extends BaseChatFragment {
     @Override public int getLayout() {return R.layout.fragment_chat;}
 
     /** Handle a authentication change event by dealing with the fragment to display. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeEvent event) {
+    @Subscribe public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         // Simply start the next logical fragment.
+        logEvent(String.format("onAccountStateChange: with event {%s};", event));
         ChatManager.instance.startNextFragment(this.getActivity());
     }
 
@@ -97,7 +97,7 @@ public class ChatFragment extends BaseChatFragment {
         FabManager.chat.dismissMenu(this);
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
-            case R.string.AddGroupMenuTitle:
+            case R.string.CreateGroupMenuTitle:
                 // Dismiss the FAB menu, and start up the add group activity.
                 Intent intent = new Intent(this.getActivity(), AddGroupActivity.class);
                 startActivity(intent);
@@ -131,7 +131,7 @@ public class ChatFragment extends BaseChatFragment {
         Group group = event.group;
         if (groupKey != null && group != null)
             // The group and key are available.  Accept any open invitations.
-            InvitationManager.instance.acceptGroupInvite(account, group, groupKey);
+            InvitationManager.instance.acceptGroupInvite(account, groupKey);
     }
 
     /** Create the view to do essentially nothing. Things will happen in the onStart() method. */
@@ -143,8 +143,8 @@ public class ChatFragment extends BaseChatFragment {
     }
 
     /** Deal with a change in the joined rooms state by logging it. */
-    @Subscribe public void onJoinedRoomListChange(@NonNull final JoinedRoomListChangeEvent event) {
-        logEvent(String.format(Locale.US, "onJoinedRoomListChange with event: {%s}", event));
+    @Subscribe public void onMemberChange(@NonNull final MemberChangeEvent event) {
+        logEvent(String.format(Locale.US, "onGroupMemberChange with event: {%s}", event));
     }
 
     /** Dispatch to a more suitable fragment. */
@@ -166,7 +166,7 @@ public class ChatFragment extends BaseChatFragment {
         final List<MenuEntry> menu = new ArrayList<>();
         menu.add(getTintEntry(R.string.JoinRoomsMenuTitle, R.drawable.vd_casino_black_24px));
         menu.add(getTintEntry(R.string.CreateRoomMenuTitle, R.drawable.vd_casino_black_24px));
-        menu.add(getTintEntry(R.string.AddGroupMenuTitle, R.drawable.ic_group_add_black_24dp));
+        menu.add(getTintEntry(R.string.CreateGroupMenuTitle, R.drawable.ic_group_add_black_24dp));
         return menu;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -46,7 +46,7 @@ import static com.pajato.android.gamechat.chat.ChatFragmentType.signedOut;
  *
  * @author Paul Michael Reilly
  */
-enum ChatManager {
+public enum ChatManager {
     instance;
 
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java
@@ -24,8 +24,6 @@ import android.view.View;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.database.DatabaseListManager;
-import com.pajato.android.gamechat.event.AppEventManager;
-import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -35,9 +33,9 @@ import java.util.Locale;
 import static com.pajato.android.gamechat.chat.ChatFragment.CHAT_HOME_FAM_KEY;
 
 /**
- * Provide a fragment to handle the display of the groups available to the current user.  This is
- * the top level view in the chat hierarchy.  It shows all the joined groups and allows for drilling
- * into rooms and chats within those rooms.
+ * Provide a fragment to handle the display of the rooms available to the current user.  This is the
+ * penultimate view in the chat hierarchy when there is more than one group.  It shows all the
+ * joined rooms and allows for drilling into chats within those rooms.
  *
  * @author Paul Michael Reilly
  */
@@ -47,11 +45,6 @@ public class ShowRoomListFragment extends BaseChatFragment {
 
     /** Set the layout file. */
     @Override public int getLayout() {return R.layout.fragment_chat_rooms;}
-
-    /** Provide a general button click handler to post the click for general consumption. */
-    public void onClick(final View view) {
-        AppEventManager.instance.post(new ClickEvent(view));
-    }
 
     /** Deal with the options menu creation by making the search item visible. */
     @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
@@ -71,8 +64,8 @@ public class ShowRoomListFragment extends BaseChatFragment {
         // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
         // the group list display.
         super.onResume();
-        FabManager.chat.init(this, View.VISIBLE, CHAT_HOME_FAM_KEY);
         setTitles(mItem.groupKey, null);
+        FabManager.chat.init(this, View.VISIBLE, CHAT_HOME_FAM_KEY);
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
@@ -47,7 +47,6 @@ import static com.pajato.android.gamechat.chat.adapter.ChatListItem.MEMBER_ITEM_
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.MESSAGE_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.ROOMS_HEADER_ITEM_TYPE;
 import static com.pajato.android.gamechat.chat.adapter.ChatListItem.ROOM_ITEM_TYPE;
-import static com.pajato.android.gamechat.chat.adapter.ChatListItem.SELECTION_ITEM_TYPE;
 
 /**
  * Provide a recycler view adapter to handle showing a list of rooms with messages to view based on
@@ -99,10 +98,8 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
             case ROOMS_HEADER_ITEM_TYPE:
                 return new HeaderViewHolder(getView(parent, R.layout.item_header));
             case MEMBER_ITEM_TYPE:
-                return new ChatListViewHolder(getView(parent, R.layout.item_message));
+                return new ChatListViewHolder(getView(parent, R.layout.item_room));
             case MESSAGE_ITEM_TYPE:
-                return new ChatListViewHolder(getView(parent, R.layout.item_message));
-            case SELECTION_ITEM_TYPE:
                 return new ChatListViewHolder(getView(parent, R.layout.item_message));
             default:
                 Log.d(TAG, String.format(Locale.US, UNHANDLED_FORMAT, entryType));
@@ -128,7 +125,6 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
                 case MEMBER_ITEM_TYPE:
                 case MESSAGE_ITEM_TYPE:
                 case ROOM_ITEM_TYPE:
-                case SELECTION_ITEM_TYPE:
                     // The group item has to update the group title, the number of new messages,
                     // and the list of rooms with messages (possibly old).
                     updateChatHolder((ChatListViewHolder) holder, item);
@@ -267,21 +263,4 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         }
     }
 
-    /** Provide a class to include a contact view in the list. */
-    private class SelectionViewHolder extends RecyclerView.ViewHolder {
-
-        // Private instance variables.
-
-        TextView name;
-        //TextView discriminant;
-        ImageView icon;
-
-        /** Build a selection item holder for the given item. */
-        SelectionViewHolder(View itemView) {
-            super(itemView);
-            name = (TextView) itemView.findViewById(R.id.contactName);
-            //discriminant = (TextView) itemView.findViewById(???);
-            icon = (ImageView) itemView.findViewById(R.id.contactIcon);
-        }
-    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
@@ -97,14 +97,11 @@ public class ChatListItem {
         desc = String.format(Locale.US, format, name, email, phone, url);
     }
 
-    /** Build an instance for a given contact list item. */
-    public ChatListItem(final MemberItem item) {
-        type = MEMBER_ITEM_TYPE;
-        name = item.name;
-        email = item.email;
-        url = item.url;
-        String format = "Member item with name {%s}, email: {%s}, and url {%s}.";
-        desc = String.format(Locale.US, format, name, email, url);
+    /** Build an instance for a given date header item. */
+    public ChatListItem(final DateHeaderItem item) {
+        type = DATE_ITEM_TYPE;
+        nameResourceId = item.getNameResourceId();
+        desc = String.format(Locale.US, "Contact header with id: {%d}.", nameResourceId);
     }
 
     /** Build an instance for a given group list item. */
@@ -118,11 +115,15 @@ public class ChatListItem {
         desc = String.format(Locale.US, format, name, key, count, text);
     }
 
-    /** Build an instance for a given date header item. */
-    public ChatListItem(final DateHeaderItem item) {
-        type = DATE_ITEM_TYPE;
-        nameResourceId = item.getNameResourceId();
-        desc = String.format(Locale.US, "Contact header with id: {%d}.", nameResourceId);
+    /** Build an instance for a given contact list item. */
+    public ChatListItem(final MemberItem item) {
+        type = MEMBER_ITEM_TYPE;
+        groupKey = item.groupKey;
+        name = item.name;
+        text = item.text;
+        url = item.url;
+        String format = "Member item with name {%s}, email: {%s}, and url {%s}.";
+        desc = String.format(Locale.US, format, name, email, url);
     }
 
     /** Build an instance for a given room list item. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MemberItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/MemberItem.java
@@ -18,6 +18,8 @@
 package com.pajato.android.gamechat.chat.adapter;
 
 import com.pajato.android.gamechat.account.Account;
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.database.DatabaseListManager;
 
 /**
  * Provide a POJO to encapsulate a member item to be added to a list view.
@@ -28,26 +30,26 @@ public class MemberItem {
 
     // Public instance variables.
 
-    /** The email address, possibly null. */
-    public String email;
-
     /** The group key. */
-    public String groupName;
-
-    /** The member's icon URL, possibly null. */
-    public String url;
+    public String groupKey;
 
     /** The member's display name. */
     public String name;
 
+    /** The member's nickname. */
+    public String text;
+
+    /** The member's icon URL, possibly null. */
+    public String url;
+
     // Public constructors.
 
     /** Build an instance using the given group name and account. */
-    public MemberItem(final String groupName, final Account account) {
-        this.groupName = groupName;
-        this.name = account.displayName;
-        this.email = account.email;
-        this.url = account.url;
+    public MemberItem(final String groupKey, final Account member) {
+        this.groupKey = groupKey;
+        this.name = member.getNickName("Anonymous");
+        Group group = DatabaseListManager.instance.getGroupProfile(groupKey);
+        text = group.name;
+        this.url = member.url;
     }
-
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.chat.adapter;
 
 import com.pajato.android.gamechat.account.AccountManager;
+import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.DatabaseListManager;
@@ -32,6 +33,8 @@ import java.util.Map;
  * @author Paul Michael Reilly
  */
 public class RoomItem {
+
+    public enum TextType {countList, groupName}
 
     // Public instance variables.
 
@@ -53,17 +56,34 @@ public class RoomItem {
     // Public constructors.
 
     /** Build an instance for the given group. */
-    public RoomItem(final String groupKey, final String roomKey) {
-        // Use the group key to unpack a group's messages by walking the set of messages in
-        // each room in the group.
+    public RoomItem(final String groupKey, final String roomKey, TextType type) {
+        // Generate the name value (the room name.
         this.groupKey = groupKey;
         this.roomKey = roomKey;
+        Room room = DatabaseListManager.instance.getRoomProfile(roomKey);
+        name = room.name;
+
+        // Generate the text value based on the type.
+        switch (type) {
+            case countList:
+                generateCountList();
+                break;
+            case groupName:
+                Group group = DatabaseListManager.instance.getGroupProfile(groupKey);
+                text = group.name;
+                break;
+            default:
+                text = null;
+                break;
+        }
+    }
+
+    /** Build a comma separated list of message counts by poster name. */
+    private void generateCountList() {
         count = 0;
         String accountId = AccountManager.instance.getCurrentAccountId();
         StringBuilder textBuilder = new StringBuilder();
         Map<String, Boolean> memberNameMap = new HashMap<>();
-        Room room = DatabaseListManager.instance.getRoomProfile(roomKey);
-        name = room.name;
         Map<String, Map<String, Message>> rooms;
         rooms = DatabaseListManager.instance.messageMap.get(groupKey);
         for (Message message : rooms.get(roomKey).values()) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -20,10 +20,11 @@ package com.pajato.android.gamechat.chat.fragment;
 import android.content.res.Resources;
 import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v7.widget.Toolbar;
+import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
-import com.pajato.android.gamechat.chat.ContactManager;
+import com.pajato.android.gamechat.chat.ChatManager;
 import com.pajato.android.gamechat.database.DatabaseListManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 
@@ -31,9 +32,14 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-public class JoinRoomsFragment extends BaseChatFragment {
+public class JoinRoomsFragment extends BaseChatFragment implements View.OnClickListener {
 
     // Public instance methods.
+
+    /** Provide a click handler for aborting the fragment. */
+    @Override public void onClick(final View view) {
+        ChatManager.instance.startNextFragment(getActivity());
+    }
 
     /** Provide a placeholder subscriber to satisfy the event bus contract. */
     @Subscribe public void onClick(final ClickEvent event) {
@@ -52,6 +58,7 @@ public class JoinRoomsFragment extends BaseChatFragment {
         Toolbar toolbar = (Toolbar) mLayout.findViewById(R.id.toolbar);
         toolbar.setTitle(getActivity().getString(R.string.JoinRoomsMenuTitle));
         toolbar.setNavigationIcon(R.drawable.vd_arrow_back_black_24px);
+        toolbar.setNavigationOnClickListener(this);
         toolbar.inflateMenu(R.menu.add_group_menu);
         Resources resources = getResources();
         int id = R.drawable.vd_more_vert_black_24px;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java
@@ -36,8 +36,8 @@ import java.util.Map;
     /** The group name. */
     public String name;
 
-    /** The group member account identifiers. */
-    public List<String> memberIdList;
+    /** The map associating a member name with the a push key. */
+    public Map<String, String> memberMap;
 
     /** The last modification timestamp. */
     public long modTime;
@@ -53,14 +53,14 @@ import java.util.Map;
 
     /** Build a default Group. */
     public Group(final String key, final String owner, final String name, final long createTime,
-                 final long modTime, final List<String> members, final Map<String, String> map) {
+                 final Map<String, String> members, final Map<String, String> rooms) {
         this.createTime = createTime;
         this.key = key;
         this.name = name;
-        this.modTime = modTime;
+        memberMap = members;
+        modTime = 0;
         this.owner = owner;
-        memberIdList = members;
-        roomMap = map;
+        roomMap = rooms;
     }
 
     /** Provide a default map for a Firebase create/update. */
@@ -69,11 +69,10 @@ import java.util.Map;
         result.put("createTime", createTime);
         result.put("key", key);
         result.put("name", name);
-        result.put("memberIdList", memberIdList);
+        result.put("memberMap", memberMap);
         result.put("modTime", modTime);
         result.put("owner", owner);
         result.put("roomMap", roomMap);
-
         return result;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -34,14 +34,11 @@ import java.util.Map;
     /** A room no one can join. */
     public final static int ME = 0;
 
-    /** A room in which only invited members may join. */
+    /** A room for two or more members by implicit or explicit invitation. */
     public final static int PRIVATE = 1;
 
     /** A room in which any User can join. */
     public final static int PUBLIC = 2;
-
-    /** A room in which only two members can exist (a direct room in Slack). */
-    public final static int MEMBER = 3;
 
     /** The creation timestamp. */
     public long createTime;
@@ -52,7 +49,7 @@ import java.util.Map;
     /** The room push key. */
     public String key;
 
-    /** The room member account identifiers. These are the people currently in the room. */
+    /** The room member identifiers. These are the Users joined to the room. */
     public List<String> memberIdList = new ArrayList<>();
 
     /** The last modification timestamp. */
@@ -75,8 +72,7 @@ import java.util.Map;
 
     /** Build a default room. */
     public Room(final String key, final String owner, final String name, final String groupKey,
-                final long createTime, final long modTime, final int type,
-                final List<String> members) {
+                final long createTime, final long modTime, final int type) {
         this.createTime = createTime;
         this.groupKey = groupKey;
         this.key = key;
@@ -84,7 +80,6 @@ import java.util.Map;
         this.name = name;
         this.owner = owner;
         this.type = type;
-        memberIdList = members;
     }
 
     /** Provide a default map for a Firebase create/update. */
@@ -95,10 +90,9 @@ import java.util.Map;
         result.put("key", key);
         result.put("name", name);
         result.put("owner", owner);
+        result.put("memberIdList", memberIdList);
         result.put("modTime", modTime);
         result.put("type", type);
-        result.put("memberIdList", memberIdList);
-
         return result;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java
@@ -26,20 +26,15 @@ import com.pajato.android.gamechat.account.Account;
  */
 public class AccountChangeEvent {
 
-    // Public instance variables
-
-    /** The group push key associated with the account. */
-    public String groupKey;
-
-    /** The account push key (User id) */
-    public String key;
+    // Public instance variable.
 
     /** The changed, non-null acount. */
     public Account account;
 
+    // Public constructor.
+
     /** Build the instance with the given account; null indicates a sign out occurred. */
-    public AccountChangeEvent(final String key, final String groupKey, final Account account) {
-        this.key = key;
+    public AccountChangeEvent(final Account account) {
         this.account = account;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeEvent.java
@@ -20,13 +20,13 @@ package com.pajato.android.gamechat.event;
 import com.pajato.android.gamechat.account.Account;
 
 /**
- * Provides an event type indicating that an account state change has just finished being handled.
+ * Provides an account state change data model class.
  *
  * @author Paul Michael Reilly
  */
-public class AccountStateChangeHandled {
+public class AuthenticationChangeEvent {
 
-    // Public instance variables.
+    // Public instance variables
 
     /** The changed account: if null the User signed out, if non-null the User signed in. */
     public Account account;
@@ -34,7 +34,14 @@ public class AccountStateChangeHandled {
     // Public constructor.
 
     /** Build the instance with the given account; null indicates a sign out occurred. */
-    public AccountStateChangeHandled(final Account account) {
+    public AuthenticationChangeEvent(final Account account) {
         this.account = account;
+    }
+
+    // Public instance methods.
+
+    /** Provide debug support. */
+    @Override public String toString() {
+        return account != null ? account.toMap().toString() : "(null)";
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeHandled.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeHandled.java
@@ -20,19 +20,21 @@ package com.pajato.android.gamechat.event;
 import com.pajato.android.gamechat.account.Account;
 
 /**
- * Provides an account state change data model class.
+ * Provides an event type indicating that an account state change has just finished being handled.
  *
  * @author Paul Michael Reilly
  */
-public class AccountStateChangeEvent {
+public class AuthenticationChangeHandled {
 
-    // Public instance variables
+    // Public instance variables.
 
     /** The changed account: if null the User signed out, if non-null the User signed in. */
     public Account account;
 
+    // Public constructor.
+
     /** Build the instance with the given account; null indicates a sign out occurred. */
-    public AccountStateChangeEvent(final Account account) {
+    public AuthenticationChangeHandled(final Account account) {
         this.account = account;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java
@@ -17,8 +17,9 @@
 
 package com.pajato.android.gamechat.event;
 
-import java.util.Arrays;
-import java.util.List;
+import com.pajato.android.gamechat.account.Account;
+
+import java.util.Locale;
 
 /**
  * Provides a model class to encapsulate the list of joined rooms to be displayed on the main rooms
@@ -26,20 +27,27 @@ import java.util.List;
  *
  * @author Paul Michael Reilly
  */
-public class JoinedRoomListChangeEvent {
+public class MemberChangeEvent {
 
-    // Private instance variables
+    /** The group push key associated with the account. */
+    public String groupKey;
 
-    /** The list of joined rooms by push key. */
-    public List<String> joinedRoomList;
+    /** The account push key (User id) */
+    public String key;
 
-    /** Build the event with the given list. */
-    public JoinedRoomListChangeEvent(final List<String> list) {
-        joinedRoomList = list;
+    /** The changed, non-null acount. */
+    public Account member;
+
+    /** Build the instance with the given account; null indicates a sign out occurred. */
+    public MemberChangeEvent(final String key, final String groupKey, final Account member) {
+        this.key = key;
+        this.groupKey = groupKey;
+        this.member = member;
     }
 
-    /** Return the joined room list as an array of String objecs. */
-    @Override public String toString() {
-        return Arrays.toString(joinedRoomList.toArray());
+    /** Return the description of the instance. */
+    public String toString() {
+        String format = "Member id: {%s}, group id: {%s}, member: {%s}";
+        return String.format(Locale.US, format, key, groupKey, member.toMap());
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/GameFragment.java
@@ -26,7 +26,7 @@ import android.view.View;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
-import com.pajato.android.gamechat.event.AccountStateChangeHandled;
+import com.pajato.android.gamechat.event.AuthenticationChangeHandled;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.main.PaneManager;
@@ -62,7 +62,7 @@ public class GameFragment extends BaseGameFragment {
     @Override public void messageHandler(final String message) {}
 
     /** There has been a handled authentication change event.  Deal with the fragment to display. */
-    @Subscribe public void onAccountStateChange(final AccountStateChangeHandled event) {
+    @Subscribe public void onAuthenticationChange(final AuthenticationChangeHandled event) {
         // Simply start the next logical fragment.
         GameManager.instance.startNextFragment(this.getActivity());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -284,7 +284,7 @@ public class TTTFragment extends BaseGameFragment implements View.OnClickListene
         if (player == null) return defaultName;
 
         // There is an account.  Use the first name for the game.
-        return player.getFirstName(defaultName);
+        return player.getNickName(defaultName);
     }
 
     /** Return the game state after applying the given button move to the data model. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -37,7 +37,7 @@ import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.account.AccountManager;
 import com.pajato.android.gamechat.chat.ChatFragment;
 import com.pajato.android.gamechat.database.DatabaseManager;
-import com.pajato.android.gamechat.event.AccountStateChangeEvent;
+import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.BackPressEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -88,7 +88,7 @@ public class MainActivity extends BaseActivity
     // Public instance methods
 
     /** Handle an account state change by updating the navigation drawer header. */
-    @Subscribe public void accountStateChanged(final AccountStateChangeEvent event) {
+    @Subscribe public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         // Due to a "bug" in Android, using XML to configure the navigation header current profile
         // click handler does not work.  Instead we do it here programmatically.
         Account account = event != null ? event.account : null;

--- a/app/src/main/res/layout/activity_group_add.xml
+++ b/app/src/main/res/layout/activity_group_add.xml
@@ -65,7 +65,7 @@ http://www.gnu.org/licenses
             android:textSize="18sp"
             android:textStyle="normal"
             android:textColorHint="@color/white"
-            android:hint="@string/AddGroupNameHint"
+            android:hint="@string/CreateGroupNameHint"
             tools:text="Paul Michael Reilly Group"/>
         <ImageButton
             android:layout_width="48dp"

--- a/app/src/main/res/layout/fragment_chat_create_room.xml
+++ b/app/src/main/res/layout/fragment_chat_create_room.xml
@@ -63,7 +63,7 @@ http://www.gnu.org/licenses
             android:textSize="18sp"
             android:textStyle="normal"
             android:textColorHint="@color/white"
-            android:hint="@string/AddGroupNameHint"
+            android:hint="@string/CreateGroupNameHint"
             tools:text="Paul Michael Reilly Group"/>
         <ImageButton
             android:layout_width="48dp"

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -1,9 +1,9 @@
 <resources>
-    <string name="AddGroupDesc">Add Group menu button</string>
+    <string name="AddGroupDesc">Create Group menu button</string>
     <string name="AddGroupMembers">Invite group members</string>
-    <string name="AddGroupMenuTitle">Add Group</string>
-    <string name="AddGroupNameHint">Type group name</string>Title">
-    <string name="AddGroupTitle">Add Group</string>
+    <string name="CreateGroupMenuTitle">Create Group</string>
+    <string name="CreateGroupNameHint">Type group name</string>Title">
+    <string name="CreateGroupTitle">Create Group</string>
     <string name="ChatSignedOutMessageText">GameChat is much more fun when you can chat with your family and friends.</string>
     <string name="ChatTitle">Chat</string>
     <string name="CreateRoomDesc">Create Room menu button</string>
@@ -25,14 +25,14 @@
     <string name="JoinRoomsMenuTitle">Join Rooms</string>
     <string name="JoinRoomsEditTextDefault">Select rooms or members</string>
     <string name="LearnMoreFeature">Providing context help</string>
-    <string name="MembersAvailableHeader">Available Members</string>
-    <string name="MembersNotAvailableHeader">No Members Available</string>
+    <string name="MembersAvailableHeaderText">Members</string>
+    <string name="MembersNotAvailableHeaderText">No Available Members</string>
+    <string name="NoJoinableRoomsHeaderText">No Available Rooms or Members</string>
     <string name="NoMessagesText">There are no messages to show in this room. That\'s weird.</string>
     <string name="NoRoomsMessageText">You must join a room to see messages.</string>
     <string name="RoomListIcon">The room list icon.</string>
-    <string name="RoomsAvailableHeader">Available Rooms</string>
-    <string name="RoomsNotAvailableHeader">No Rooms Available</string>
-    <string name="SetAddGroupIconFeature">Setting the add group icon</string>
+    <string name="RoomsAvailableHeaderText">Rooms</string>
+    <string name="SetCreateGroupIconFeature">Setting the create group icon</string>
     <string name="SetGroupIconDesc">Set the group icon</string>
     <string name="SetRoomIconDesc">Set the room icon</string>
     <string name="SignInLastAccountMenuTitle">Use Current Account</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit is the second in a series of commits providing the join rooms feature.  In this one, all available rooms and members are presented for selection.  Susequent commits will provide slight improvements to the presentation (providing User icons for example) and will implement selection behaviors.

It is worth noting that this commit includes a significant database change that essentially duplicates an account profile for all members of a group.

<h1>File changes:</h1>

modified:   app/src/main/AndroidManifest.xml

- Summary: rename AddGroupTitle to CreateGroupTitle.

modified:   app/src/main/java/com/pajato/android/gamechat/account/Account.java

- Account, STANDARD, PROTECTED: enhance or introduce doc comments.
- groupIdList: rename to joinList to reflect the field being used to track tracking joined groups (for a top level account) and joined rooms (for a group member account).
- groupKey: provide a convenience field for group member accounts.
- nickname: introduce this important concept and start fleshing it out.
- token: remove as Firebase preserves this on the device under the hood.
- Account(): add default and copy constructors.
- getDisplayName, getNickName(), getPrefix(): enhance or create to provide a more robust experience for the User.

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- getJoinedRoomEntry(), getPhotoUrl(): moved to account change handler.
- onAccountChange(): provide a handler to deal with account changes.
- onAuthStateChanged(): change name accordingly; use the canonical form of handler registration.
- AccountChangeHandler: move to it's own file.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/AddGroupActivity.java

- onClick(): move the View on click listener to a separate class to avoid interference with XML onClick references.
- onClick(): use the renamed resource R.string.SetCreateGroupIconFeature.
- init(): change the initial Group object setup.
- initToolbar(): use a private on navigation click listener.
- processGroup(): remove code made stale by introducing the group member feature; use the modified Room constructor; update the join list on the account; update the group profile with a new member map entry; update the group member entry; do not call the now stale database manager appendDefaultJoinedRoomEntry() method.
- NavigationExitHandler: new class to handle aborting.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): use the modified RoomEntry constructor.
- joinDeveloperGroups(): update with new group keys; use the renamed account joinList field.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatFragment.java

- onAccountStateChange(): rename to onAuthenticationChange(); add a log statement.
- onClick(): rename AddGroupMenuTitle to CreateGroupMenuTitle.
- onGroupProfileChange(): use the modified acceptGroupInvide() interface.
- onJoinedRoomListChange(): remove.
- onMemberChange(): new handler for dealing with changes to member accounts.
- getHomeMenu(): use the renamed resource R.string.CreateGroupMenuTitle.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- ChatManager: make public access.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowRoomListFragment.java

- ShowRoomListFragment: enhance doc comment.
- onClick(): remove.
- onResume(): move FAB init to last (can't remember why).

modified:
app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

- onCreateViewHolder(): use a room model, not a message model; lose the SELECTION_ITEM_TYPE artifacts.
- SelectionViewHolder: remove.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java

- Summary: move methods to achieve RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/MemberItem.java

- Summary: use a more canonical model structure.
- email, groupName: lose these fields.
- groupKey, text, url: add these canonical fields.
- MemberItem(): adjust constructors accordingly.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java

- Summary: adapt to work with members as well.
- TextType: use a type field to discriminate between a room and member.
- RoomItem(): modify constructer to be used for members as well as rooms.
- generateCountList(): new method to handle count setup.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java

- onClick(): connect up the abort code.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Group.java

- memberIdList: change to use a memberMap associating the member name and the account push key.
- Group(): remove the mod time argument and add a member map argument.
- toMap(): change memberIdList to memberMap.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- MEMBER: remove this type constant as it is redundant with private. (the ME type might be also)
- Room(): lose the mod time and members arguments.

modified:   app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java

- acceptGroupInvite(): lose the group key argument; use the account joinList field; update to reflect group member changes.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- ACCOUNT_CHANGE_HANDLER: rename to GROUP_MEMBER_CHANGE_HANDLER.
- GROUP_PROFILE_LIST_CHANGE_HANDLER: rename to GROUP_PROFILE_CHANGE_HANDLER:
- ROOM_PROFILE_LIST_CHANGE_HANDLER: rename to ROOM_PROFILE_CHANGE_HANDLER:
- accountMap: rename to groupMemberMap.
- getList(): use the modified getRoomListData() interface; use getJoinableRoomsListData() instead of the now stale getJoinRoomsListData();
- onAccountStateChange(): rename to onAuthenticationChange() and simplify dramatically.
- onAccountChange(): rename to onMemberChange() and simplify.
- onGroupProfileChange(): set a group member watcher rather than an account watcher.
- onJoinedRoomsChange(), addAll(), getAvailable(), getAvailableMemberRooms(), getGroupMemberListData(), pruneJoinedRooms(), getJoinRoomsListData(): lose them as they are now stale.
- getAvailableMembers(), getAvailableRooms(): simplify based on db changes.
- getGroups(), getJoinableRoomsListData(), getJoinableRooms(), getJoinedRooms(), getRoomList(): new support methods (procedural abstractions.)
- setAccountWatcher(): rename to setMemberWatcher().

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseManager.java

- appendDefaultJoinedRoomEntry(): remove.
- createAccount(): overhaul for new db changes.
- getJoinedRoomListPath(): rename to getGroupMembersPath().
- updateGroup(): remove.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java

- AccountChangeHandler(): simplify constructor by only dealing with a top level account.
- onDataChange(): similarly, simplify.
- getAccount(), getPhotoUrl(): new home (from AccountManager).

renamed:    app/src/main/java/com/pajato/android/gamechat/database/handler/JoinedRoomListChangeHandler.java -> app/src/main/java/com/pajato/android/gamechat/database/handler/MemberChangeHandler.java

modified:   app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java

- AccountChangeEvent(): simplify.

renamed:    app/src/main/java/com/pajato/android/gamechat/event/AccountStateChangeEvent.java -> app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeEvent.java
renamed:    app/src/main/java/com/pajato/android/gamechat/event/AccountStateChangeHandled.java -> app/src/main/java/com/pajato/android/gamechat/event/AuthenticationChangeHandled.java
renamed:    app/src/main/java/com/pajato/android/gamechat/event/JoinedRoomListChangeEvent.java -> app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java

modified:   app/src/main/java/com/pajato/android/gamechat/exp/GameFragment.java

- onAccountStateChange(): rename to onAuthenticationChange().

modified:   app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java

- getPlayerName(): use nickname rather than first name.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- accountStateChanged(): rename to onAuthenticationChange().

modified:   app/src/main/res/layout/activity_group_add.xml:
modified:   app/src/main/res/layout/fragment_chat_create_room.xml

- rename AddGroupNameHint to CreateGroupNameHint.

modified:   app/src/main/res/values/strings_chat.xml

- Summary: use "Create" rather than "Add" prefix; provide join rooms localized strings.