### PR TITLE
Make all chat lists use a similar appearance.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
@@ -98,7 +98,7 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
             case ROOMS_HEADER_ITEM_TYPE:
                 return new HeaderViewHolder(getView(parent, R.layout.item_header));
             case MEMBER_ITEM_TYPE:
-                return new ChatListViewHolder(getView(parent, R.layout.item_room));
+                return new ChatListViewHolder(getView(parent, R.layout.item_member));
             case MESSAGE_ITEM_TYPE:
                 return new ChatListViewHolder(getView(parent, R.layout.item_message));
             default:
@@ -170,6 +170,7 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         // The icon and url both exist.  Case on the item type.
         Context context = holder.icon.getContext();
         switch (item.type) {
+            case MEMBER_ITEM_TYPE:
             case MESSAGE_ITEM_TYPE:
                 // For a message, load the icon, if there is one.
                 Uri imageUri = Uri.parse(item.url);
@@ -230,21 +231,6 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         }
     }
 
-    /** Provide a class to include a header in the list. */
-    private class HeaderViewHolder extends RecyclerView.ViewHolder {
-
-        // Private instance variables.
-
-        /** The text view showing the date or contact header. */
-        TextView title;
-
-        /** ... */
-        HeaderViewHolder(View itemView) {
-            super(itemView);
-            title = (TextView) itemView.findViewById(R.id.header);
-        }
-    }
-
     /** Provide a class to include a contact view in the list. */
     private class ContactViewHolder extends RecyclerView.ViewHolder {
 
@@ -260,6 +246,21 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
             name = (TextView) itemView.findViewById(R.id.contactName);
             email = (TextView) itemView.findViewById(R.id.contactEmail);
             icon = (ImageView) itemView.findViewById(R.id.contactIcon);
+        }
+    }
+
+    /** Provide a class to include a header in the list. */
+    private class HeaderViewHolder extends RecyclerView.ViewHolder {
+
+        // Private instance variables.
+
+        /** The text view showing the date or contact header. */
+        TextView title;
+
+        /** ... */
+        HeaderViewHolder(View itemView) {
+            super(itemView);
+            title = (TextView) itemView.findViewById(R.id.header);
         }
     }
 

--- a/app/src/main/res/layout/item_group.xml
+++ b/app/src/main/res/layout/item_group.xml
@@ -24,6 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:gravity="center_vertical"
             android:orientation="vertical">
             <LinearLayout
                 android:layout_width="match_parent"
@@ -33,12 +34,9 @@
                     android:id="@+id/chatName"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceListItem"
                     android:textColor="@color/colorPrimaryDark"
-                    tools:text="Paul &amp; Sandy"/>
+                    tools:text="Paul &amp; Sandy Group"/>
                 <TextView
                     android:id="@+id/newCount"
                     android:layout_width="wrap_content"
@@ -46,8 +44,7 @@
                     android:layout_gravity="center"
                     android:layout_marginStart="8dp"
                     android:background="@color/colorLightGray"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="@color/colorPrimary"
                     android:paddingStart="4dp"
                     android:paddingEnd="4dp"
@@ -57,6 +54,7 @@
                 android:id="@+id/chatText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
                 tools:text="group, Sandy Scott, PT General"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_member.xml
+++ b/app/src/main/res/layout/item_member.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/chatListItem"
+        android:orientation="horizontal">
+        <de.hdodenhof.circleimageview.CircleImageView
+            android:id="@+id/chatIcon"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginStart="16dp"
+            android:layout_gravity="center" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/chatName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                tools:text="Fred C. Jones"/>
+            <TextView
+                android:id="@+id/chatText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:text="The Jones Boys Group" />
+        </LinearLayout>
+    </LinearLayout>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:background="@android:color/darker_gray"/>
+</LinearLayout>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -8,7 +8,6 @@
     android:layout_marginTop="1dp"
     android:layout_marginBottom="1dp"
     android:orientation="horizontal">
-
     <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/chatIcon"
         android:layout_width="36dp"
@@ -16,26 +15,22 @@
         android:layout_marginStart="4dp"
         android:layout_gravity="center"
         android:src="@drawable/ic_account_circle_black_36dp"/>
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
         android:gravity="center_vertical"
         android:orientation="vertical">
-
         <TextView
             android:id="@+id/chatText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceListItem"
             tools:text="A simple sample message that extends over two lines..."/>
-
         <TextView
             android:id="@+id/chatName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceSmall"/>
-
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_room.xml
+++ b/app/src/main/res/layout/item_room.xml
@@ -24,6 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:gravity="center_vertical"
             android:orientation="vertical">
             <LinearLayout
                 android:layout_width="match_parent"
@@ -33,10 +34,7 @@
                     android:id="@+id/chatName"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceListItem"
                     android:textColor="@color/colorPrimaryDark"
                     tools:text="General"/>
                 <TextView
@@ -46,8 +44,7 @@
                     android:layout_gravity="center"
                     android:layout_marginStart="8dp"
                     android:background="@color/colorLightGray"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="@color/colorPrimary"
                     android:paddingStart="4dp"
                     android:paddingEnd="4dp"
@@ -57,7 +54,8 @@
                 android:id="@+id/chatText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="TheShovel, ConorTheWhiz, GrandPop"/>
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:text="TheShovel, ConorTheWhiz, GrandPop" />
         </LinearLayout>
     </LinearLayout>
     <View


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit ensures that the join rooms feature provides lists that have consistency with other chat lists.  The commit also fixes a sign in bug.

<h1>Files changed:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/account/AccountManager.java

- mAccountMap: remove as it's raison d'etre is questionable.
- mCurrentAccount: add a field to store the current account.
- getCurrentAccount(): obtain the account from the new field.
- onAccountChange(): detect an authentication change correctly; update the fields on an authentication change.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

- onCreateViewHolder(): layout a member item using it's own layout spec.
- setChatIcon(): ensure that a member icon is processed the same as a message icon.
- HeaderViewHolder: move per RNF.

modified:   app/src/main/res/layout/item_group.xml
new file:   app/src/main/res/layout/item_member.xml
modified:   app/src/main/res/layout/item_message.xml
modified:   app/src/main/res/layout/item_room.xml

- Summary: ensure that all layouts use a similar style.