### PR TITLE
Fix some display bugs.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java
@@ -52,12 +52,6 @@ public class ShowGroupListFragment extends BaseChatFragment {
         setItemState(menu, R.id.search, true);
     }
 
-    /** Manage the list UI every time a message change occurs. */
-    @Subscribe public void onChatListChange(final ChatListChangeEvent event) {
-        // Log the event and update the list saving the result for a retry later.
-        logEvent(String.format(Locale.US, "onMessageListChange with event {%s}", event));
-    }
-
     /** Initialize ... */
     @Override public void onInitialize() {
         super.onInitialize();

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -23,8 +23,7 @@ import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
 import com.pajato.android.gamechat.account.Account;
 import com.pajato.android.gamechat.account.AccountManager;
-import com.pajato.android.gamechat.database.DatabaseManager;
-import com.pajato.android.gamechat.exp.model.ExpProfile;
+import com.pajato.android.gamechat.database.DatabaseListManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,7 +48,7 @@ import java.util.Map;
     public long createTime;
 
     /** The list of experience profiles.  One exists for each experience. */
-    @Exclude public List<ExpProfile> expProfileList;
+    //@Exclude public List<ExpProfile> expProfileList;
 
     /** The parent group push key. */
     public String groupKey;
@@ -118,11 +117,12 @@ import java.util.Map;
     // Private instance methods.
 
     /** Return a list of comma separated member names excluding the account holder's name. */
-    private String memberNames(@NonNull final Account member) {
+    private String memberNames(@NonNull final Account account) {
         StringBuilder result = new StringBuilder();
         for (String key : memberIdList) {
             // Determine if this member is the current User, in which case just continue.
-            if (key.equals(member.id)) continue;
+            Account member = DatabaseListManager.instance.getGroupMember(groupKey, key);
+            if (key.equals(account.id) || member == null) continue;
 
             // Add the member's, display name to the list.
             if (result.length() > 0) result.append(", ");

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -61,6 +61,9 @@ public abstract class BaseFragment extends Fragment {
 
     // Protected instance variables.
 
+    /** The fragment active state; set when entering onResume and cleared in onPause. */
+    protected boolean mActive;
+
     /** The persisted layout view for this fragment. */
     protected View mLayout;
 
@@ -146,6 +149,7 @@ public abstract class BaseFragment extends Fragment {
         super.onPause();
         logEvent("onPause");
         AppEventManager.instance.unregister(this);
+        mActive = false;
     }
 
     /** Log the lifecycle event and resume showing ads. */
@@ -155,6 +159,7 @@ public abstract class BaseFragment extends Fragment {
         super.onResume();
         logEvent("onResume");
         AppEventManager.instance.register(this);
+        mActive = true;
     }
 
     /** Provide a means to setup the fragment once it has been created. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java
@@ -73,12 +73,6 @@ public enum DatabaseListManager {
 
     // Public enums.
 
-    /** Return null or the group member account given the group key and member key. */
-    public Account getGroupMember(@NonNull final String groupKey, @NonNull final String memberKey) {
-        Map<String, Account> memberMap = groupMemberMap.get(groupKey);
-        return memberMap.get(memberKey);
-    }
-
     /** The chat list type. */
     public enum ChatListType {
         group, message, room, joinMemberRoom, joinRoom,
@@ -154,6 +148,15 @@ public enum DatabaseListManager {
         Map<String, Account> memberMap = groupMemberMap.get(groupKey);
         if (memberMap == null) return null;
         return memberMap.get(account.id);
+    }
+
+    /** Return null or a group member using the current account holder's id and given group key. */
+    public Account getGroupMember(@NonNull final String groupKey, @NonNull final String memberKey) {
+        // Determine if there is an expected member account in the given group.  Abort if not.
+        // Return the account if so.
+        Map<String, Account> memberMap = groupMemberMap.get(groupKey);
+        if (memberMap == null) return null;
+        return memberMap.get(memberKey);
     }
 
     /** Return a name for the group with the given key, "Anonymous" if a name is not available. */


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit addresses two particular nasty display bugs: 1) overwrites were occurring; 2) page updates due to message list changes were not happening realtime.  Also, the names shown in private rooms were incorrect.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- FORMAT_NO_BUNDLE: rename to LOG_FORMAT for the main log statement.
- FORMAT_WITH_BUNDLE: rename to SUFFIX_FORMAT to address extra information.
- onChatListChange(): make logging more concise; only redisplay when the fragment is a group or room list and is running in the foreground.
- logEvent(): simplify and break up into two lines; show the foreground/background state.
- updateAdapterList(): log the number of items being displayed.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ShowGroupListFragment.java

- onChatListChange(): remove as this is a duplicate.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- expProfileList: comment out to silence an AS warning.
- memberNames(): fix to do what was intended.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- mActive, onPause(), onResume(): capture the foreground/background state.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DatabaseListManager.java

- getGroupMember(): move per RNF; add null detection.