### PR TITLE
Fix bugs with group and room creation.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
@@ -10,7 +10,6 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 /**
  * All tests are based on the the following documentation:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -26,9 +26,8 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.BaseChatFragment;
-import com.pajato.android.gamechat.chat.ChatManager;
 import com.pajato.android.gamechat.chat.model.Account;
+import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -49,6 +48,9 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
     /** The current create type. */
     protected CreateType mCreateType;
 
+    /** Set the room or group type. */
+    protected abstract void setType(final int type);
+
     // Public instance methods.
 
     /** Establish the layout file to show that the app is offline due to network loss. */
@@ -62,7 +64,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
         // The event appears to be expected.  Confirm by finding the selector check view.
         switch (event.view.getId()) {
-            case R.id.saveButton:
+            case R.id.SaveButton:
                 // Process the group (validate and persist it) and be done with the activity.
                 Account account = AccountManager.instance.getCurrentAccount();
                 if (account != null) save(account);
@@ -74,11 +76,17 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
                 EditText editText = (EditText) mLayout.findViewById(R.id.NameText);
                 if (editText != null) editText.setText("");
                 break;
-            case R.id.addMembers:
+            case R.id.AddMembers:
                 showFutureFeatureMessage(R.string.InviteMembersFeature);
                 break;
             case R.id.SettableIconButton:
                 showFutureFeatureMessage(R.string.SetCreateIconFeature);
+                break;
+            case R.id.PublicButton:
+                setType(Room.PUBLIC);
+                break;
+            case R.id.PrivateButton:
+                setType(Room.PRIVATE);
                 break;
             default:
                 // Ignore everything else.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java
@@ -87,7 +87,7 @@ public enum ChatManager {
         Map<String, Map<String, Map<String, Message>>> messageMap;
         messageMap = MessageManager.instance.messageMap;
         if (!NetworkManager.instance.isConnected()) return new Dispatcher<>(offline);
-        if (AccountManager.instance.hasAccount()) return new Dispatcher<>(signedOut);
+        if (!AccountManager.instance.hasAccount()) return new Dispatcher<>(signedOut);
         if (messageMap.size() == 0) return new Dispatcher<>(noMessages);
 
         // Deal with a signed in User with multiple messages across more than one group.  Return

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -94,10 +94,9 @@ public class CreateGroupFragment extends BaseCreateFragment {
         mGroup.memberList.add(account.id);
         GroupManager.instance.createGroupProfile(mGroup);
 
-        // Create and persist the default (common) room, update the group's room list, add the group
-        // key to the account's group id list, and update the member in the group.
+        // Create and persist the default (common) room.
         Room room = new Room(roomKey, mGroup.owner, "Common", groupKey, 0, 0, PUBLIC);
-        account.joinList.add(groupKey);
+        room.memberIdList.add(account.id);
         RoomManager.instance.createRoomProfile(room);
 
         // Create and persist a member object to the database joined to the default room.
@@ -117,4 +116,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
 
     /** Set the name of the managed object conditionally to the given value. */
     @Override protected void setName(final String value) {if (mGroup != null) mGroup.name = value;}
+
+    /** Implement the set type as a nop. */
+    @Override protected void setType(final int type) {}
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.annotation.NonNull;
 
-import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Account;
 import com.pajato.android.gamechat.chat.model.Group;
@@ -30,15 +29,8 @@ import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.MemberManager;
 import com.pajato.android.gamechat.database.MessageManager;
 import com.pajato.android.gamechat.database.RoomManager;
-import com.pajato.android.gamechat.event.ClickEvent;
-
-import org.greenrobot.eventbus.Subscribe;
-
-import java.util.Locale;
 
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
-import static com.pajato.android.gamechat.chat.model.Room.PRIVATE;
-import static com.pajato.android.gamechat.chat.model.Room.PUBLIC;
 
 /**
  * Create a room ...
@@ -59,26 +51,6 @@ public class CreateRoomFragment extends BaseCreateFragment {
     private Room mRoom;
 
     // Public instance methods.
-
-    /** Provide a click event handler. */
-    @Subscribe public void onClick(final ClickEvent event) {
-        // Log the event and determine if the event looks right.  Abort if it doesn't.
-        logEvent(String.format(Locale.US, "onClick (create room) event: {%s}.", event));
-        if (event == null || event.view == null) return;
-
-        // The event appears to be ok.  Update the room type.
-        switch (event.view.getId()) {
-            case R.id.PublicButton:
-                mRoom.type = PUBLIC;
-                break;
-            case R.id.PrivateButton:
-                mRoom.type = PRIVATE;
-                break;
-            default:
-                // Ignore everything else.
-                break;
-        }
-    }
 
     /** Establish the create time state. */
     @Override public void onInitialize() {
@@ -105,6 +77,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
         mRoom.name = getDefaultName();
         mRoom.groupKey = mGroup.key;
         mRoom.owner = mMember.id;
+        mRoom.type = Room.PUBLIC;
     }
 
     // Protected instance methods.
@@ -113,6 +86,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
     @Override protected void save(@NonNull Account account) {
         // Persist the configured room.
         mRoom.key = RoomManager.instance.getRoomKey(mGroup.key);
+        mRoom.memberIdList.add(account.id);
         RoomManager.instance.createRoomProfile(mRoom);
 
         // Update and persist the group adding the new room to it's room list.
@@ -130,4 +104,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
 
     /** Set the room name conditionally to the given value. */
     @Override protected void setName(final String value) {if (mRoom != null) mRoom.name = value;}
+
+    /** Implement the set type. */
+    @Override protected void setType(final int type) {mRoom.type = type;}
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -195,8 +195,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         String id = event.account != null ? event.account.id : null;
         String cid = mCurrentAccountKey;
         if ((cid == null && id != null) || (cid != null && id == null)) {
-            // An authentication change has taken place.  Let the app know and finish by kicking off
-            // watchers on group the group profiles this account is privy to.
+            // An authentication change has taken place.  Let the app know.
             mCurrentAccountKey = id;
             mCurrentAccount = event.account;
             AppEventManager.instance.post(new AuthenticationChangeEvent(event.account));

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -88,6 +88,7 @@ public enum GroupManager {
         String profilePath = String.format(Locale.US, GROUP_PROFILE_PATH, group.key);
         group.createTime = new Date().getTime();
         DBUtils.instance.updateChildren(profilePath, group.toMap());
+        setGroupProfileWatcher(group.key);
     }
 
     /** Return a room push key to use with a subsequent room object persistence. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -70,6 +70,7 @@ public enum RoomManager {
         // Ensure that a valid group key exists.  Abort quietly (for now) if not.
         // TODO: do something about a null group key.
         if (room.groupKey == null || room.key == null) return;
+        setRoomProfileWatcher(room.groupKey, room.key);
         String profilePath = String.format(Locale.US, ROOM_PROFILE_PATH, room.groupKey, room.key);
         room.createTime = new Date().getTime();
         DBUtils.instance.updateChildren(profilePath, room.toMap());

--- a/app/src/main/res/layout/fragment_chat_create.xml
+++ b/app/src/main/res/layout/fragment_chat_create.xml
@@ -94,7 +94,7 @@ http://www.gnu.org/licenses
             android:onClick="onClick" />
     </RadioGroup>
     <TextView
-        android:id="@+id/AddRoomMembers"
+        android:id="@+id/AddMembers"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="36dp"


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a few bugs found during manual testing of the group and room create fragments.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java

- Summary: remove an unused import.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java

- setType(): provide a new abstract method to handle setting the new room type.
- onClick(): fix the spelling of the save button and the add members view id names; add cases for handling the public/private radio buttons.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- getDisatcher(): fix the sense on the has account test.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java

- save(): enhance the comments; update the room member id list, not the account join list; provide a nop implmentation for the setType() method.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java

- onClick(): remove since there is already one in the base class (Green Robot's EventBus does not handle super class subscriptions); initialize the default room type to public; update the room member id list.
- setType(): provide an implementation.

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- onAuthStateChanged(): enhance the comments.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- createGroupProfile(): set the group profile watcher.

modified:   app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java

- createRoomProfile(): set the room profile watcher.

modified:   app/src/main/res/layout/fragment_chat_create.xml

- Summary: fix the spelling of the member invite text.