### PR TITLE
Fix a experience bug.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
@@ -133,7 +133,7 @@ public enum GameManager {
         Map<String, Map<String, Map<String, ExpProfile>>> expProfileMap =
                 ExperienceManager.instance.expProfileMap;
         if (!NetworkManager.instance.isConnected()) return new Dispatcher<>(offline);
-        if (AccountManager.instance.hasAccount()) return new Dispatcher<>(signedOut);
+        if (!AccountManager.instance.hasAccount()) return new Dispatcher<>(signedOut);
         if (expProfileMap.size() == 0) return new Dispatcher<>(noExp);
 
         // Deal with a signed in User with multiple experiences across more than one group.  Return

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -74,16 +74,17 @@ public enum PaneManager {
             viewPager.setAdapter(new GameChatPagerAdapter(context.getSupportFragmentManager(),
                     (ViewGroup) context.findViewById(R.id.page_monitor)));
             context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        } else {
-            // The app is running on a tablet. Add the fragments to their containers and force
-            // orientation to landscape.
-            context.getSupportFragmentManager().beginTransaction()
-                    .add(R.id.chat_container, fragmentList.get(CHAT_INDEX))
-                    .add(R.id.game_container, fragmentList.get(GAME_INDEX))
-                    .commit();
-            context.invalidateOptionsMenu();
-            context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            return;
         }
+
+        // The app is running on a tablet. Add the fragments to their containers and force
+        // orientation to landscape.
+        context.getSupportFragmentManager().beginTransaction()
+                .add(R.id.chat_container, fragmentList.get(CHAT_INDEX))
+                .add(R.id.game_container, fragmentList.get(GAME_INDEX))
+                .commit();
+        context.invalidateOptionsMenu();
+        context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     }
 
     // Nested classes

--- a/app/src/main/res/layout-w820dp/activity_fragments.xml
+++ b/app/src/main/res/layout-w820dp/activity_fragments.xml
@@ -11,13 +11,13 @@
     tools:ignore="InconsistentLayout">
 
     <FrameLayout
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         android:id="@+id/chat_container"
         android:layout_weight="1"/>
 
     <FrameLayout
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         android:id="@+id/game_container"
         android:layout_weight="1"/>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes an experience bug where startup incorrectly detected a signed out experience.  It should have reported no experiences detected.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java

- getDispatcher(): reverse the sense of the "has account" test.

modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- init(): modify to be consistent with the preferred if-then-return hacking style, just because.

modified:   app/src/main/res/layout-w820dp/activity_fragments.xml

- Summary: change the layout width attributes on the fragments to be 0dp to follow the conventions when using layout weights.