### PR TITLE
Fix a tablet NPE bug.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -80,8 +80,8 @@ public enum PaneManager {
         // The app is running on a tablet. Add the fragments to their containers and force
         // orientation to landscape.
         context.getSupportFragmentManager().beginTransaction()
-                .add(R.id.chat_container, fragmentList.get(CHAT_INDEX))
-                .add(R.id.game_container, fragmentList.get(GAME_INDEX))
+                .add(R.id.chat_container, fragmentList.get(CHAT_INDEX), "chat")
+                .add(R.id.game_container, fragmentList.get(GAME_INDEX), "game")
                 .commit();
         context.invalidateOptionsMenu();
         context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a tablet bug whereby the game and chat fragment tag value is null causing the FAB manager to generate a series of NPEs.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- init(): ensure that a tag value is assigned when the fragment add transaction is executed.