### PR TITLE
Updating How Fragments Are Initialized

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -116,8 +116,8 @@ public abstract class BaseChatFragment extends BaseFragment {
     }
 
     /** Initialize chat list fragments by dealing with ads. */
-    @Override public void onInitialize() {
-        super.onInitialize();
+    @Override public void onStart() {
+        super.onStart();
         initAdView(mLayout);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.chat;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -53,8 +54,10 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Establish the layout file to show that the app is offline due to network loss. */
-    @Override public int getLayout() {return R.layout.fragment_chat_create;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_create);
+    }
 
     /** Provide a click event handler. */
     @Subscribe public void onClick(final ClickEvent event) {
@@ -95,8 +98,8 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
     }
 
     /** Initialize the create type. */
-    @Override public void onInitialize() {
-        super.onInitialize();
+    @Override public void onStart() {
+        super.onStart();
         EditText text = (EditText) mLayout.findViewById(R.id.NameText);
         TextView button = (TextView) mLayout.findViewById(R.id.SaveButton);
         text.addTextChangedListener(new TextChangeHandler(getContext(), text, button));

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -54,6 +54,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
     // Public instance methods.
 
+    /** Establish the layout file to show that the app is offline due to network loss. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_create);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -52,14 +53,16 @@ public class ChatFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Set the layout file, which specifies the chat FAB and the basic options menu. */
-    @Override public int getLayout() {return R.layout.fragment_chat;}
-
     /** Handle a authentication change event by dealing with the fragment to display. */
     @Subscribe public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         // Simply start the next logical fragment.
         logEvent(String.format("onAccountStateChange: with event {%s};", event));
         ChatManager.instance.startNextFragment(getActivity());
+    }
+
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat);
     }
 
     /** Process a given button click event looking for the chat FAB. */
@@ -100,9 +103,9 @@ public class ChatFragment extends BaseChatFragment {
     }
 
     /** Create the view to do essentially nothing. Things will happen in the onStart() method. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Declare the use of the options menu and intialize the FAB and it's menu.
-        super.onInitialize();
+        super.onStart();
         FabManager.chat.setTag(this.getTag());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
@@ -60,6 +60,7 @@ public class ChatFragment extends BaseChatFragment {
         ChatManager.instance.startNextFragment(getActivity());
     }
 
+    /** Set the layout file, which specifies the chat FAB and the basic options menu. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -49,10 +49,10 @@ public class CreateGroupFragment extends BaseCreateFragment {
     // Public instance methods.
 
     /** Establish the create time state. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Establish the create type, the list type, setup the toolbar and turn off the access
         // control.
-        super.onInitialize();
+        super.onStart();
         mCreateType = CreateType.group;
         mItemListType = DBUtils.ChatListType.addGroup;
         initToolbar();

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -53,9 +53,9 @@ public class CreateRoomFragment extends BaseCreateFragment {
     // Public instance methods.
 
     /** Establish the create time state. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Ensure that there is a group to use in creating the new room.
-        super.onInitialize();
+        super.onStart();
         mGroup = GroupManager.instance.getGroupProfile(mItem.groupKey);
         Account account = AccountManager.instance.getCurrentAccount();
         mMember = MemberManager.instance.getMember(mGroup.key, account.id);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -65,8 +66,10 @@ public class JoinRoomsFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Establish the layout file to show that the app is offline due to network loss. */
-    @Override public int getLayout() {return R.layout.fragment_chat_join_rooms;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_join_rooms);
+    }
 
     /** Provide a placeholder subscriber to satisfy the event bus contract. */
     @Subscribe public void onClick(final ClickEvent event) {
@@ -119,9 +122,9 @@ public class JoinRoomsFragment extends BaseChatFragment {
     }
 
     /** Establish the create time state. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Establish the list type and setup the toolbar.
-        super.onInitialize();
+        super.onStart();
         mItemListType = DBUtils.ChatListType.joinRoom;
         initToolbar();
         FabManager.chat.setMenu(CHAT_SELECTION_FAM_KEY, getSelectionMenu());

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -66,6 +66,7 @@ public class JoinRoomsFragment extends BaseChatFragment {
 
     // Public instance methods.
 
+    /** Establish the layout file to show that the app is offline due to network loss. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_join_rooms);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
@@ -52,9 +53,10 @@ public class ShowGroupListFragment extends BaseChatFragment {
     public static final String CHAT_GROUP_FAM_KEY = "chatGroupFamKey";
 
     // Public instance methods.
-
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_chat_list;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_list);
+    }
 
     /** Process a menu click event ... */
     @Subscribe public void onClick(final TagClickEvent event) {
@@ -84,8 +86,8 @@ public class ShowGroupListFragment extends BaseChatFragment {
     }
 
     /** Initialize ... */
-    @Override public void onInitialize() {
-        super.onInitialize();
+    @Override public void onStart() {
+        super.onStart();
         mItemListType = DBUtils.ChatListType.group;
         initToolbar();
         FabManager.chat.setMenu(CHAT_GROUP_FAM_KEY, getGroupMenu());

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
@@ -53,6 +53,8 @@ public class ShowGroupListFragment extends BaseChatFragment {
     public static final String CHAT_GROUP_FAM_KEY = "chatGroupFamKey";
 
     // Public instance methods.
+
+    /** Set the layout to a shared layout file for showing a list (of groups, in this case). */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_list);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessageListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessageListFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -82,8 +83,10 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
         }
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_chat_messages;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_messages);
+    }
 
     /** Handle a button click on the FAB button by posting a new message. */
     @Override public void onClick(final View view) {
@@ -106,8 +109,9 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
     }
 
     /** Establish the create time state. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Establish the list type and setup the toolbar.
+        super.onStart();
         mItemListType = DBUtils.ChatListType.message;
         initToolbar();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessageListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessageListFragment.java
@@ -83,6 +83,7 @@ public class ShowMessageListFragment extends BaseChatFragment implements View.On
         }
     }
 
+    /** Setup a layout akin to the other "show list" fragments, but with the input section. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_messages);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoJoinedRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoJoinedRoomsFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 
@@ -29,7 +31,9 @@ public class ShowNoJoinedRoomsFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_chat_no_joined_rooms;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_no_joined_rooms);
+    }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoJoinedRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoJoinedRoomsFragment.java
@@ -31,6 +31,7 @@ public class ShowNoJoinedRoomsFragment extends BaseChatFragment {
 
     // Public instance methods.
 
+    /** Establish the layout file to indicate that no room are available. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_no_joined_rooms);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.chat.ChatManager;
@@ -31,8 +33,10 @@ public class ShowNoMessagesFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Establish the layout file to indicate that no experiences are available. */
-    @Override public int getLayout() {return R.layout.fragment_chat_no_messages;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_no_messages);
+    }
 
     /** Handle a message list change event by starting the next fragment, as necessary. */
     @Subscribe public void onMessageListChange(MessageChangeEvent event) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
@@ -33,6 +33,7 @@ public class ShowNoMessagesFragment extends BaseChatFragment {
 
     // Public instance methods.
 
+    /** Establish the layout file to indicate that no experiences are available. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_no_messages);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowOfflineFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -34,6 +36,8 @@ public class ShowOfflineFragment extends BaseChatFragment {
         logEvent("onClick (showOffline)");
     }
 
-    /** Establish the layout file to show that the app is offline due to network loss. */
-    @Override public int getLayout() {return R.layout.fragment_chat_offline;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_offline);
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowOfflineFragment.java
@@ -36,6 +36,7 @@ public class ShowOfflineFragment extends BaseChatFragment {
         logEvent("onClick (showOffline)");
     }
 
+    /** Establish the layout file to show that the app is offline due to network loss. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_offline);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
@@ -55,6 +55,7 @@ public class ShowRoomListFragment extends BaseChatFragment {
 
     // Public instance methods.
 
+    /** Set the layout to a shared layout file for showing a list (of rooms, in this case). */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_list);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
@@ -54,8 +55,10 @@ public class ShowRoomListFragment extends BaseChatFragment {
 
     // Public instance methods.
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_chat_list;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_list);
+    }
 
     /** Process a menu click event ... */
     @Subscribe public void onClick(final TagClickEvent event) {
@@ -88,8 +91,8 @@ public class ShowRoomListFragment extends BaseChatFragment {
     }
 
     /** Initialize ... */
-    @Override public void onInitialize() {
-        super.onInitialize();
+    @Override public void onStart() {
+        super.onStart();
         mItemListType = DBUtils.ChatListType.room;
         initToolbar();
         FabManager.chat.setMenu(CHAT_ROOM_FAM_KEY, getRoomMenu());

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.common.FabManager;
@@ -75,14 +77,16 @@ public class ShowSignedOutFragment extends BaseChatFragment {
         }
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_chat_signed_out;}
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_chat_signed_out);
+    }
 
     /** Handle the setup for the groups panel. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
         // view and the listeners for backend data changes.
-        super.onInitialize();
+        super.onStart();
         FabManager.chat.init(this);
         FabManager.chat.setMenu(SIGN_IN_FAM_KEY, getSignInMenu());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
@@ -77,6 +77,7 @@ public class ShowSignedOutFragment extends BaseChatFragment {
         }
     }
 
+    /** Establish the layout file to show that the user is signed out and cannot chat. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_signed_out);

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -64,6 +64,8 @@ public abstract class BaseFragment extends Fragment {
 
     /** The persisted layout view for this fragment. */
     protected View mLayout;
+    /** The persistent layout's corresponding resource ID. */
+    protected int mLayoutId;
 
     // Public constructors.
 
@@ -95,8 +97,9 @@ public abstract class BaseFragment extends Fragment {
         if (mLayout != null) return mLayout;
 
         // The layout does not exist.  Create and persist it, and initialize the fragment layout.
-        mLayout = inflater.inflate(getLayout(), container, false);
-        onInitialize();
+        mLayout = inflater.inflate(mLayoutId, container, false);
+        // All chat and game fragments will use the options menu.
+        setHasOptionsMenu(true);
         return mLayout;
     }
 
@@ -114,12 +117,6 @@ public abstract class BaseFragment extends Fragment {
     @Override public void onDetach() {
         super.onDetach();
         logEvent("onDetach");
-    }
-
-    /** Initialize the fragment. */
-    public void onInitialize() {
-        // All chat and game fragments will use the options menu.
-        setHasOptionsMenu(true);
     }
 
     /** Handle an options menu choice. */
@@ -188,9 +185,6 @@ public abstract class BaseFragment extends Fragment {
 
     // Protected instance methods.
 
-    /** Obtain a layout file from the subclass. */
-    protected abstract int getLayout();
-
     /** Return a menu entry for a given title and icon id, and a given fragment type. */
     protected MenuEntry getEntry(final int titleId, final int iconId, final ExpFragmentType type) {
         final int itemType = MENU_ITEM_NO_TINT_TYPE;
@@ -222,6 +216,11 @@ public abstract class BaseFragment extends Fragment {
     protected void setItemState(final Menu menu, final int itemId, final boolean state) {
         MenuItem item = menu.findItem(itemId);
         if (item != null) item.setVisible(state);
+    }
+
+    /** Set the Layout ID. Should be called by child classes in their onCreate methods. */
+    protected void setLayoutId(int id) {
+        this.mLayoutId = id;
     }
 
     /** Set the title in the toolbar based on the list type. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -45,6 +45,7 @@ public class CheckersFragment extends BaseGameFragment {
     /** Handle button clicks ... placeholder. */
     @Subscribe public void onClick(final ClickEvent event) {}
 
+    /** Setup the Player Controls. The Board setup will be done later, in onNewGame. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_checkers);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -1,6 +1,7 @@
 package com.pajato.android.gamechat.exp;
 
 import android.graphics.PorterDuff;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.SparseIntArray;
 import android.view.Gravity;
@@ -41,14 +42,16 @@ public class CheckersFragment extends BaseGameFragment {
 
     // Public instance methods.
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_checkers;}
-
     /** Handle button clicks ... placeholder. */
     @Subscribe public void onClick(final ClickEvent event) {}
 
-    @Override public void onInitialize() {
-        super.onInitialize();
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_checkers);
+    }
+
+    @Override public void onStart() {
+        super.onStart();
         mBoard = (GridLayout) mLayout.findViewById(R.id.board);
         mTurn = true;
         onNewGame();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -49,6 +49,7 @@ public class ChessFragment extends BaseGameFragment {
     /** Handle button clicks ... placeholder. */
     @Subscribe public void onClick(final ClickEvent event) {}
 
+    /** Setup the Player Controls. The Board setup will be done later, in onNewGame. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_checkers);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -1,6 +1,7 @@
 package com.pajato.android.gamechat.exp;
 
 import android.graphics.PorterDuff;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.util.SparseArray;
@@ -45,15 +46,17 @@ public class ChessFragment extends BaseGameFragment {
 
     // Public instance methods.
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_checkers;}
-
     /** Handle button clicks ... placeholder. */
     @Subscribe public void onClick(final ClickEvent event) {}
 
-    @Override public void onInitialize() {
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_checkers);
+    }
+
+    @Override public void onStart() {
         // Setup the board and start a new game to create the board.
-        super.onInitialize();
+        super.onStart();
         mBoard = (GridLayout) mLayout.findViewById(R.id.board);
         mTurn = false;
         onNewGame();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/GameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/GameFragment.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -54,9 +55,6 @@ public class GameFragment extends BaseGameFragment {
     public static final String GAME_HOME_FAM_KEY = "gameHomeFamKey";
 
     // Public instance methods.
-
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game;}
 
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
@@ -120,10 +118,16 @@ public class GameFragment extends BaseGameFragment {
         menuInflater.inflate(R.menu.game_menu, menu);
     }
 
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game);
+    }
+
     /** Intialize the game fragment envelope. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Inflate the layout, and initialize the various managers.
-        super.onInitialize();
+        super.onStart();
         FabManager.game.setTag(this.getTag());
         FabManager.game.setMenu(GAME_HOME_FAM_KEY, getHomeMenu());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpGroupListFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -32,14 +34,18 @@ public class ShowExpGroupListFragment extends BaseGameFragment {
         logEvent("onClick (showExpGroupList)");
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_no_games);
+    }
+
     /** Initialize the fragment by setting in the FAB. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
+        super.onStart();
         FabManager.game.init(this);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -32,14 +34,18 @@ public class ShowExpListFragment extends BaseGameFragment {
         logEvent("onClick (showExp)");
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_no_games);
+    }
+
     /** Initialize the fragment by setting in the FAB. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
+        super.onStart();
         FabManager.game.init(this);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
@@ -37,9 +37,10 @@ public class ShowExpListFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
-    @Override
-    public void onCreate(Bundle bundle) {
+    /** Set the layout file. */
+    @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
+        //TODO: Establish better layout for the list of games. Potentially like fragment_chat_list?
         super.setLayoutId(R.layout.fragment_game_no_games);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -32,14 +34,18 @@ public class ShowExpRoomListFragment extends BaseGameFragment {
         logEvent("onClick (showExpRoomList)");
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_no_games);
+    }
+
     /** Initialize the fragment by setting in the FAB. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
+        super.onStart();
         FabManager.game.init(this);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
@@ -37,9 +37,10 @@ public class ShowExpRoomListFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
-    @Override
-    public void onCreate(Bundle bundle) {
+    /** Set the layout file. */
+    @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
+        //TODO: Establish better layout for the list of games. Potentially like fragment_chat_list?
         super.setLayoutId(R.layout.fragment_game_no_games);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpTypeListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpTypeListFragment.java
@@ -29,6 +29,7 @@ public class ShowExpTypeListFragment extends BaseGameFragment {
 
     }
 
+    /** Set the layout file. */
     @Override public void onCreate(Bundle bundle) {
         // TODO: Add a real layout for this class.
         super.onCreate(bundle);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpTypeListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpTypeListFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 /**
  * Show a list of experiences of a particular type.
  *
@@ -27,8 +29,8 @@ public class ShowExpTypeListFragment extends BaseGameFragment {
 
     }
 
-    @Override protected int getLayout() {
+    @Override public void onCreate(Bundle bundle) {
         // TODO: Add a real layout for this class.
-        return 0;
+        super.onCreate(bundle);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ExpProfileListChangeEvent;
@@ -31,11 +33,14 @@ public class ShowNoExperiencesFragment extends BaseGameFragment {
 
     // Public instance methods.
 
-    /** Establish the layout file to indicate that no experiences are available. */
-    @Override public int getLayout() {return R.layout.fragment_game_no_games;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
+
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_no_games);
+    }
 
     /** Handle an experience profile list change event. */
     @Subscribe public void onExpProfileListChangeEvent(ExpProfileListChangeEvent event) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
@@ -36,8 +36,8 @@ public class ShowNoExperiencesFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
-    @Override
-    public void onCreate(Bundle bundle) {
+    /** Establish the layout file to indicate that no experiences are available. */
+    @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_game_no_games);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -35,11 +37,14 @@ public class ShowOfflineFragment extends BaseGameFragment {
         logEvent("onClick (showOffline)");
     }
 
-    /** Establish the layout file to show that the app is offline due to network loss. */
-    @Override public int getLayout() {return R.layout.fragment_game_offline;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
+
+    @Override
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_offline);
+    }
 
     /** Reset the FAM to use the game home menu. */
     @Override public void onResume() {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
@@ -40,8 +40,8 @@ public class ShowOfflineFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
-    @Override
-    public void onCreate(Bundle bundle) {
+    /** Establish the layout file to show that the app is offline due to network loss. */
+    @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_game_offline);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
@@ -37,6 +37,7 @@ public class ShowSignedOutFragment extends BaseGameFragment {
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    /** Establish the layout file to show that the user is signed out and cannot chat. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_exp_signed_out);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.exp;
 
+import android.os.Bundle;
+
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -32,14 +34,17 @@ public class ShowSignedOutFragment extends BaseGameFragment {
         logEvent("onClick (showSignedOut)");
     }
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_exp_signed_out;}
-
     /** Satisfy the base game fragment contract with a nop message handler. */
     @Override public void messageHandler(final String message) {}
 
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_exp_signed_out);
+    }
+
     /** Initialize the fragment by setting in the FAB. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
+        super.onStart();
         // Set up the FAB.
         FabManager.game.init(this);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -97,6 +97,7 @@ public class TTTFragment extends BaseGameFragment implements View.OnClickListene
     /** Placeholder while message handler stays relevant for chess and checkers. */
     @Override public void messageHandler(final String msg) {}
 
+    /** Setup the Player Controls and empty board. */
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_game_ttt);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.exp;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
@@ -93,11 +94,13 @@ public class TTTFragment extends BaseGameFragment implements View.OnClickListene
 
     // Public instance methods.
 
-    /** Set the layout file. */
-    @Override public int getLayout() {return R.layout.fragment_game_ttt;}
-
     /** Placeholder while message handler stays relevant for chess and checkers. */
     @Override public void messageHandler(final String msg) {}
+
+    @Override public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        super.setLayoutId(R.layout.fragment_game_ttt);
+    }
 
     /** Handle a FAM or Snackbar TicTacToe click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
@@ -133,9 +136,9 @@ public class TTTFragment extends BaseGameFragment implements View.OnClickListene
     }
 
     /** Initialie by setting up tile click handlers on the board. */
-    @Override public void onInitialize() {
+    @Override public void onStart() {
         // Place an click listener on all nine buttons by iterating over all nine buttons.
-        super.onInitialize();
+        super.onStart();
         FabManager.game.setMenu(TIC_TAC_TOE_FAM_KEY, getTTTMenu());
         final String format = "Invalid tag found on button with tag {%s}";
         for (int i = 0; i < 3; i++) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 04 08:56:25 EDT 2016
+#Wed Dec 28 16:27:20 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip


### PR DESCRIPTION
After some peer programming, we identified that there was some extraneous code in the initialization of fragments. I am removing the onInitialize and getLayout methods from all fragments and instead we can use the onStart fragment method (as supplied by the base android code) and we simply set the layout using a new method in BaseFragment, called setLayoutId. This is now being called in the onCreate of BaseFragment subclasses, and should be how we set the layout of all future fragments.

# Changed Files

## Java Files

### chat.fragment.ChatFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### chat.fragment.CreateGroupFragment
* onInitialize functionality moved to onStart

### chat.fragment.CreateRoomFragment
* onInitialize functionality moved to onStart

### chat.fragment.JoinRoomsFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### chat.fragment.ShowGroupListFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### chat.fragment.ShowMessageListFragment
* onCreate added to set the method
* getLayout removed
* added call to the super method in onInitialize
* onInitialize functionality moved to onStart

### chat.fragment.ShowNoJoinedRoomsFragment
* onCreate added to set the method
* getLayout removed

### chat.fragment.ShowNoMessagesFragment
* onCreate added to set the method
* getLayout removed

### chat.fragment.ShowOfflineFragment
* onCreate added to set the method
* getLayout removed

### chat.fragment.ShowRoomListFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### chat.fragment.ShowSignedOutFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### chat.BaseChatFragment
* onInitialize functionality moved to onStart

### chat.fragment.BaseCreateFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### common.BaseFragment
* mLayoutId field added
** can be set by setLayoutId
** is used in the onCreateView method

### exp.CheckersFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### exp.ChessFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### exp.GameFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

### exp.ShowExpGroupListFragment
* onCreate added to set the method
* getLayout removed
* added call to the super method in onInitialize
* onInitialize functionality moved to onStart

### exp.ShowExpListFragment
* onCreate added to set the method
* getLayout removed
* added call to the super method in onInitialize
* onInitialize functionality moved to onStart

### exp.ShowExpRoomListFragment
* onCreate added to set the method
* getLayout removed
* added call to the super method in onInitialize
* onInitialize functionality moved to onStart

### exp.ShowExpTypeListFragment
* onCreate added to set the method
* getLayout removed

### exp.ShowNoExperiencesFragment
* onCreate added to set the method
* getLayout removed

### exp.ShowOfflineFragment
* onCreate added to set the method
* getLayout removed

### exp.ShowSignedOutFragment
* onCreate added to set the method
* getLayout removed
* added call to the super method in onInitialize
* onInitialize functionality moved to onStart

### exp.TTTFragment
* onCreate added to set the method
* getLayout removed
* onInitialize functionality moved to onStart

## Gradle Files

### gradle/wrapper/gradle-wrapper.properties
* updated automatically by Android Studio's canary channel.

### build.gradle
* updated automatically by Android Studio's canary channel.