### PR TITLE
Provide first pass at adding game modes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
+apply plugin: 'project-report'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -35,6 +36,7 @@ android {
 
     lintOptions {
         disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'GradleDependency'
+        warning 'RestrictedApi', 'GradleCompatible'
         abortOnError true
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -52,7 +52,7 @@ import static com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment.Select
 
 public class JoinRoomsFragment extends BaseChatFragment {
 
-    public enum SelectionType {all, members, rooms}
+    enum SelectionType {all, members, rooms}
 
     // Public constants.
 
@@ -137,7 +137,6 @@ public class JoinRoomsFragment extends BaseChatFragment {
         FabManager.chat.setImage(R.drawable.ic_check_white_24dp);
         FabManager.chat.init(this);
         FabManager.chat.setVisibility(this, View.VISIBLE);
-        FabManager.chat.setMenu(this, CHAT_SELECTION_FAM_KEY);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
@@ -104,7 +104,6 @@ public class ShowGroupListFragment extends BaseChatFragment {
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this);
         FabManager.chat.setVisibility(this, View.VISIBLE);
-        FabManager.chat.setMenu(this, CHAT_GROUP_FAM_KEY);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java
@@ -108,7 +108,6 @@ public class ShowRoomListFragment extends BaseChatFragment {
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this);
         FabManager.chat.setVisibility(this, View.VISIBLE);
-        FabManager.chat.setMenu(this, CHAT_ROOM_FAM_KEY);
     }
 
     /** Return the home FAM used in the top level show games and show no games fragments. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
@@ -92,13 +92,6 @@ public class ShowSignedOutFragment extends BaseChatFragment {
         FabManager.chat.setMenu(SIGN_IN_FAM_KEY, getSignInMenu());
     }
 
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        // TODO: Change the FAB button menu to show "Sign In", "Add Account" or "Switch Account".
-        super.onResume();
-        FabManager.chat.setMenu(this, SIGN_IN_FAM_KEY);
-    }
-
     // Private instance methods.
 
     /** Return the home FAM used in the top level show games and show no games fragments. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -56,6 +56,9 @@ public enum FabManager {
 
     // Private instance variables.
 
+    /** The name of the default menu. */
+    private String mDefaultMenuName;
+
     /** The fab resource identifier. */
     private int mFabId;
 
@@ -86,6 +89,12 @@ public enum FabManager {
 
     // Public instance methods
 
+    /** Add the named floating action menu (FAM) to the cache. */
+    public void addMenu(@NonNull final String name, @NonNull final List<MenuEntry> menu) {
+        // Cache the menu, if one is provided.
+        if (name.length() != 0) mMenuMap.put(name, menu);
+    }
+
     /** Dismiss the menu associated with the given FAB button. */
     public void dismissMenu(@NonNull final Fragment fragment) {
         // Determine if the chat fragment is accessible.  If not, abort.
@@ -103,41 +112,45 @@ public enum FabManager {
 
     /** Initialize the fab state. */
     public void init(final Fragment fragment) {
-        // Ensure that the layout exists. Abort if it does not.  Set the FAB state to closed if it
-        // does.
+        // Ensure that the layout and the recycler views exist. Abort quietly if they do not.
         View layout = getFragmentLayout(fragment);
-        if (layout == null) return;
+        RecyclerView recyclerView;
+        recyclerView = layout != null ? (RecyclerView) layout.findViewById(R.id.MenuList) : null;
+        if (layout == null || recyclerView == null) return;
+
+        // Set up the recycler view by establishing a layout manager, item animator and adapter.
+        Context context = fragment.getContext();
+        recyclerView.setLayoutManager(new LinearLayoutManager(context, VERTICAL, false));
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
+        recyclerView.setAdapter(new MenuAdapter());
+
+        // Set the FAB state to closed by assuming an open FAM and dismissing it.
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
         dismissMenu(layout);
     }
 
-    /** Set the floating action menu (FAM) with a given name and menu. */
-    public void setMenu(final String name, final List<MenuEntry> menu) {
-        // Cache the menu, if one is provided.
-        if (menu != null && name != null) mMenuMap.put(name, menu);
+    /** Set the named floating action menu (FAM) making it the default. */
+    public void setMenu(@NonNull final String name, @NonNull final List<MenuEntry> menu) {
+        // Test for a reasonable (non-empty) name.  Abort if not.
+        if (name.length() == 0) return;
+
+        // Cache the menu and make it the default.
+        mMenuMap.put(name, menu);
+        mDefaultMenuName = name;
     }
 
     /** Set the current FAM using the cached item with the given name. */
-    public void setMenu(final Fragment fragment, final String name) {
-        // Ensure that the game fragment layout is accessible.  Abort if not (error is logged).
+    private void setMenu(final Fragment fragment, final String name) {
+        // Ensure that the game fragment layout is accessible and that there is an adapter on the
+        // recycler view.  Abort quietly if not.
         View layout = getFragmentLayout(fragment);
-        if (layout == null) return;
+        RecyclerView recyclerView;
+        recyclerView = layout != null ? (RecyclerView) layout.findViewById(R.id.MenuList) : null;
+        MenuAdapter adapter = recyclerView != null ? (MenuAdapter) recyclerView.getAdapter() : null;
+        if (layout == null || recyclerView == null || adapter == null) return;
 
-        // Add the menu to initialize the recycler view.
-        Context context = fragment.getContext();
-        LinearLayoutManager layoutManager = new LinearLayoutManager(context, VERTICAL, false);
-        RecyclerView recyclerView = (RecyclerView) layout.findViewById(R.id.MenuList);
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setItemAnimator(new DefaultItemAnimator());
-
-        // Ensure that the recycler view has an adapter installed.  Install one if not.  Set up the
-        // adapter on the recycler view with the given menu.
-        MenuAdapter adapter = (MenuAdapter) recyclerView.getAdapter();
-        if (adapter == null) {
-            adapter = new MenuAdapter();
-            recyclerView.setAdapter(adapter);
-        }
+        // Add the menu to initialize the recycler view's data items.
         adapter.clearEntries();
         adapter.addEntries(mMenuMap.get(name));
     }
@@ -173,8 +186,18 @@ public enum FabManager {
         fab.setVisibility(View.VISIBLE);
     }
 
-    /** Toggle the state of the FAB button using a given fragment to obtain the layout view. */
+    /** Toggle the state of the FAB button for the given fragment, use the given menu once. */
     public void toggle(@NonNull final Fragment fragment) {
+        toggle(fragment, mDefaultMenuName, false);
+    }
+
+    /** Toggle the state of the FAB/FAM for the given fragment using the given menu once. */
+    public void toggle(@NonNull final Fragment fragment, @NonNull final String name) {
+        toggle(fragment, name, true);
+    }
+
+    /** Toggle the state of the FAB button using a given fragment to obtain the layout view. */
+    public void toggle(@NonNull final Fragment fragment, final String name, final boolean restore) {
         // Determine if the fragment layout exists.  Continue if it does.  Return if it does not.
         // An error message with stack trace will have been generated if the view cannot be
         // accessed.
@@ -195,11 +218,13 @@ public enum FabManager {
                     // The FAB is showing 'X' and it's menu is visible.  Set the icon to '+', close
                     // the menu and undim the frame.
                     dismissMenu(layout);
+                    if (restore) setMenu(fragment, mDefaultMenuName);
                     dimmerView.setVisibility(View.GONE);
                     break;
                 case closed:
                     // The FAB is showing '+' and the menu is not visible.  Set the icon to X and
-                    // open the menu.
+                    // open the named menu (if name is set) or the last one used.
+                    if (name != null) setMenu(fragment, name);
                     fab.setImageResource(R.drawable.ic_clear_white_24dp);
                     fab.setTag(R.integer.fabStateKey, opened);
                     dimmerView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseGameFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseGameFragment.java
@@ -26,12 +26,18 @@ import android.util.Log;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.Dispatcher;
+import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.RoomManager;
+import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.exp.model.ExpProfile;
 
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -41,6 +47,11 @@ import java.util.Locale;
  * @author Paul Michael Reilly
  */
 public abstract class BaseGameFragment extends BaseFragment {
+
+    // Public class constants.
+
+    /** The mode floating action menu key. */
+    public static final String EXP_MODE_FAM_KEY = "expModeFamKey";
 
     // Private class constants.
 
@@ -79,6 +90,27 @@ public abstract class BaseGameFragment extends BaseFragment {
     /** Remove this after dealing with the chess and checkers fragments. */
     abstract public void messageHandler(final String message);
 
+    /** Handle the player 2 control click. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        logEvent("Got a player 2 control click event.");
+        switch (event.view.getId()) {
+            case R.id.player2Name:
+                // Simulate a click on the exp FAB.
+                FabManager.game.toggle(this, EXP_MODE_FAM_KEY);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** Handle the setup for the mode control. */
+    @Override public void onStart() {
+        // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
+        // view and the listeners for backend data changes.
+        super.onStart();
+        FabManager.game.addMenu(EXP_MODE_FAM_KEY, getExpModeFam());
+    }
+
     // Protected instance methods.
 
     /** Create a new experience to be displayed in this fragment. */
@@ -97,15 +129,13 @@ public abstract class BaseGameFragment extends BaseFragment {
     /** Log a lifecycle event that has no bundle. */
     @Override protected void logEvent(final String event) {
         String manager = getFragmentManager().toString();
-        String format = FORMAT_NO_BUNDLE;
-        Log.v(TAG, String.format(Locale.US, format, event, this, manager));
+        Log.v(TAG, String.format(Locale.US, FORMAT_NO_BUNDLE, event, this, manager));
     }
 
     /** Log a lifecycle event that has a bundle. */
     @Override protected void logEvent(final String event, final Bundle bundle) {
         String manager = getFragmentManager().toString();
-        String format = FORMAT_WITH_BUNDLE;
-        Log.v(TAG, String.format(Locale.US, format, event, this, manager, bundle));
+        Log.v(TAG, String.format(Locale.US, FORMAT_WITH_BUNDLE, event, this, manager, bundle));
     }
 
     /** Process the dispatcher to set up the experience fragment. */
@@ -127,7 +157,8 @@ public abstract class BaseGameFragment extends BaseFragment {
     }
 
     /** Provide a default implementation for setting up an experience. */
-    protected void setupExperience(final Context context, final Dispatcher<ExpFragmentType, ExpProfile> dispatcher) {
+    protected void setupExperience(final Context context,
+                                   final Dispatcher<ExpFragmentType, ExpProfile> dispatcher) {
         // Ensure that the dispatcher is valid.  Abort if not.
         // TODO: might be better to show a toast or snackbar on error.
         if (dispatcher == null || dispatcher.type == null) return;
@@ -148,4 +179,16 @@ public abstract class BaseGameFragment extends BaseFragment {
             // Create a new experience.
             createExperience(context, dispatcher);
     }
+
+    // Private instance methods.
+
+    /** Return the experience mode control FAM. */
+    private List<MenuEntry> getExpModeFam() {
+        final List<MenuEntry> menu = new ArrayList<>();
+        menu.add(getTintEntry(R.string.PlayModeLocalMenuTitle, R.drawable.ic_local_play_black_24px));
+        menu.add(getTintEntry(R.string.PlayModeComputerMenuTitle, R.drawable.ic_smartphone_black_24px));
+        menu.add(getTintEntry(R.string.PlayModeUserMenuTitle, R.drawable.ic_person_black_24px));
+        return menu;
+    }
+
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpGroupListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpGroupListFragment.java
@@ -25,8 +25,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
-
 public class ShowExpGroupListFragment extends BaseGameFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
@@ -47,11 +45,5 @@ public class ShowExpGroupListFragment extends BaseGameFragment {
     @Override public void onStart() {
         super.onStart();
         FabManager.game.init(this);
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
@@ -25,8 +25,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
-
 public class ShowExpListFragment extends BaseGameFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
@@ -48,11 +46,5 @@ public class ShowExpListFragment extends BaseGameFragment {
     @Override public void onStart() {
         super.onStart();
         FabManager.game.init(this);
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
@@ -25,8 +25,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
-
 public class ShowExpRoomListFragment extends BaseGameFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
@@ -48,11 +46,5 @@ public class ShowExpRoomListFragment extends BaseGameFragment {
     @Override public void onStart() {
         super.onStart();
         FabManager.game.init(this);
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
@@ -20,14 +20,12 @@ package com.pajato.android.gamechat.exp;
 import android.os.Bundle;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ExpProfileListChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
 
 public class ShowNoExperiencesFragment extends BaseGameFragment {
 
@@ -52,11 +50,5 @@ public class ShowNoExperiencesFragment extends BaseGameFragment {
             default:
                 break;
         }
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
@@ -20,12 +20,9 @@ package com.pajato.android.gamechat.exp;
 import android.os.Bundle;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
-
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
 
 public class ShowOfflineFragment extends BaseGameFragment {
 
@@ -44,11 +41,5 @@ public class ShowOfflineFragment extends BaseGameFragment {
     @Override public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_game_offline);
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java
@@ -25,8 +25,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.exp.GameFragment.GAME_HOME_FAM_KEY;
-
 public class ShowSignedOutFragment extends BaseGameFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
@@ -43,16 +41,10 @@ public class ShowSignedOutFragment extends BaseGameFragment {
         super.setLayoutId(R.layout.fragment_exp_signed_out);
     }
 
-    /** Initialize the fragment by setting in the FAB. */
+    /** Initialize the fragment by setting up the FAB/FAM. */
     @Override public void onStart() {
-        super.onStart();
         // Set up the FAB.
+        super.onStart();
         FabManager.game.init(this);
-    }
-
-    /** Reset the FAM to use the game home menu. */
-    @Override public void onResume() {
-        super.onResume();
-        FabManager.game.setMenu(this, GAME_HOME_FAM_KEY);
     }
 }

--- a/app/src/main/res/drawable/ic_arrow_drop_down_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M7,10l5,5 5,-5z"
+        android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_local_play_black_24px.xml
+++ b/app/src/main/res/drawable/ic_local_play_black_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M20,12c0,-1.1 0.9,-2 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2v4c1.1,0 1.99,0.9 1.99,2s-0.89,2 -2,2v4c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2v-4c-1.1,0 -2,-0.9 -2,-2zM15.58,16.8L12,14.5l-3.58,2.3 1.08,-4.12 -3.29,-2.69 4.24,-0.25L12,5.8l1.54,3.95 4.24,0.25 -3.29,2.69 1.09,4.11z"
+        android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_person_black_24px.xml
+++ b/app/src/main/res/drawable/ic_person_black_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"
+        android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_smartphone_black_24px.xml
+++ b/app/src/main/res/drawable/ic_smartphone_black_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M17,1.01L7,1c-1.1,0 -2,0.9 -2,2v18c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3c0,-1.1 -0.9,-1.99 -2,-1.99zM17,19H7V5h10v14z"
+        android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_game_ttt.xml
+++ b/app/src/main/res/layout/fragment_game_ttt.xml
@@ -36,11 +36,10 @@ http://www.gnu.org/licenses
         app:layout_constraintLeft_toRightOf="parent"
         tools:text="vs" />
 
-    <TextView
+    <TextView android:id="@+id/player1Name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="24dp"
-        android:id="@+id/player1Name"
         android:text="@string/me"
         android:textAlignment="center"
         android:textStyle="bold"
@@ -49,18 +48,27 @@ http://www.gnu.org/licenses
         app:layout_constraintRight_toLeftOf="@+id/vs"
         tools:text="theShovel" />
 
-    <TextView
+    <TextView android:id="@+id/player2Name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:id="@+id/player2Name"
         android:text="@string/friend"
         android:textAlignment="center"
         android:textStyle="bold"
         android:textSize="20sp"
+        android:drawableEnd="@drawable/ic_arrow_drop_down_black_24dp"
+        android:onClick="onClick"
         app:layout_constraintCenterY_toCenterY="@id/vs"
         app:layout_constraintLeft_toRightOf="@+id/vs"
-        tools:text="Friend" />
+        tools:text="Friend"/>
+
+    <android.support.v7.widget.RecyclerView android:id="@+id/player2Menu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/player2Name"
+        app:layout_constraintStart_toStartOf="@+id/player2Name"
+        tools:visibility="visible" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -84,7 +92,8 @@ http://www.gnu.org/licenses
         android:id="@+id/player1WinCount"
         app:layout_constraintCenterY_toCenterY="@id/wins"
         app:layout_constraintRight_toLeftOf="@+id/wins"
-        tools:text="0" />
+        tools:text="0"
+        tools:layout_editor_absoluteY="108dp" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -95,7 +104,8 @@ http://www.gnu.org/licenses
         android:textSize="20sp"
         app:layout_constraintCenterY_toCenterY="@id/wins"
         app:layout_constraintLeft_toRightOf="@+id/wins"
-        tools:text="0" />
+        tools:text="0"
+        tools:layout_editor_absoluteY="108dp" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -119,7 +129,8 @@ http://www.gnu.org/licenses
         android:id="@+id/player1Symbol"
         android:textColor="@color/colorAccent"
         app:layout_constraintCenterY_toCenterY="@id/turn"
-        app:layout_constraintRight_toLeftOf="@+id/turn" />
+        app:layout_constraintRight_toLeftOf="@+id/turn"
+        tools:layout_editor_absoluteY="129dp" />
 
     <TextView
         android:layout_width="wrap_content"
@@ -154,7 +165,8 @@ http://www.gnu.org/licenses
         android:id="@+id/player2Symbol"
         android:textColor="@color/colorPrimaryDark"
         app:layout_constraintCenterY_toCenterY="@+id/turn"
-        app:layout_constraintLeft_toRightOf="@+id/turn" />
+        app:layout_constraintLeft_toRightOf="@+id/turn"
+        tools:layout_editor_absoluteY="138dp" />
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="CheckersImageDesc">Checkers image.</string>
     <string name="ChessImageDesc">Chess image.</string>
+    <string name="FutureSelectModes">Select playing modes</string>
     <string name="FutureSelectRooms">Select rooms</string>
     <string name="InvalidButton">You must click on an empty button!  Try again.</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
@@ -10,6 +11,9 @@
     <string name="PlayAgain">Play again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
+    <string name="PlayModeComputerMenuTitle">Play the computer</string>
+    <string name="PlayModeLocalMenuTitle">Play a friend</string>
+    <string name="PlayModeUserMenuTitle">Play a User</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
     <string name="SignIn">Sign In</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ ext {
 
     // App dependencies
     espressoVersion = '2.2.2'
+    facebookSdkVersion = '4.18.0'
     gmsVersion = '10.0.1'
     hamcrestVersion = '1.3'
     junitVersion = '4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Wed Dec 28 16:27:20 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/libraries/intro/build.gradle
+++ b/libraries/intro/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'project-report'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -35,6 +36,7 @@ android {
 
     lintOptions {
         disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'GradleDependency'
+        warning 'RestrictedApi', 'GradleCompatible'
         abortOnError true
     }
 }

--- a/libraries/intro/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/libraries/intro/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -60,11 +60,6 @@ public class IntroActivity extends AppCompatActivity {
         invokeSignIn("signin");
     }
 
-    /** Handle registering a new account by invoking the signin activity. */
-    public void doRegister(final View view) {
-        invokeSignIn("register");
-    }
-
     // Protected instance methods.
 
     /** Handle the sign in activity result, if any. */
@@ -118,7 +113,7 @@ public class IntroActivity extends AppCompatActivity {
                           final float... heights) {
         // Animate the Z property on the given view over the given heights for 200 milliseconds.
         final int DURATION = 200;
-        final String PROP = "animationZ";
+        final String PROP = "z";
         int [] viewState = viewStateId != -1 ? new int[] {viewStateId} : new int[] {};
         ObjectAnimator viewAnimator = ObjectAnimator.ofFloat(view, PROP, heights);
         animator.addState(viewState, viewAnimator.setDuration(DURATION));

--- a/libraries/signin/build.gradle
+++ b/libraries/signin/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'project-report'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -34,6 +35,7 @@ android {
 
     lintOptions {
         disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'GradleDependency'
+        warning 'RestrictedApi', 'GradleCompatible'
         abortOnError true
     }
 }
@@ -46,8 +48,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.facebook.android:facebook-android-sdk:4.11.0'
-
+    compile "com.facebook.android:facebook-android-sdk:$rootProject.ext.facebookSdkVersion"
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.google.android.gms:play-services-auth:$rootProject.ext.gmsVersion"
     compile "com.google.firebase:firebase-auth:$rootProject.ext.gmsVersion"


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit brings a FAM menu that presents modes to play games.  In subsequent commits these modes will be enhanced to provide more functional mode support.  In addition, this commit upgrades to the next Gradle and Android Studio toolset including the next generation lint support.

<h1>File changes:</h1>

modified:   app/build.gradle
modified:   libraries/intro/build.gradle
modified:   libraries/signin/build.gradle

- Summary: add support for a comprehensive but unobtrusive project report, the most important aspect of which is a dependency version report; add lint warning categories for a couple of new checks.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java

- SelectionType: make the access qualifier package protected to silence an AS warning.
- onResume(): remove the setMenu() call as it is now stale.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowGroupListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowRoomListFragment.java

- onResume(): remove the setMenu() call as it is now stale.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowExpGroupListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowExpListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowExpRoomListFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowNoExperiencesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowOfflineFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ShowSignedOutFragment.java

- onResume(): remove entirely as all it was doing was the now stale setMenu().

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- Summary: overhaul to make it more optimal and shareable.
- addMenu(): provide a new interface to simply add a menu to the menu cache.
- init(): move the recycler view (FAM) setup here as it is more optimal.
- setMenu(): add the notion of making the cached menu the default, which will get restored as needed; enhance the error checking in the fragment overload.
- toggle(): add overloads to allow for a temporary menu override such that the default is automatically restored.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseGameFragment.java

- Summary: add the infrastructure to handle experience modes on a player 2 tap/click, simulating a spinner.
- onStart(): setup the mode control menu.
- logEvent(): simplify per AS advice.
- getExpModeFam(): new mode setting menu.

modified:
app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java

- onClick(): update the comment; handle the mode click/selection.
- onClick(): conciseify.
- onResume(): lose the stale setMenu() call.
- handleTileClick(): rename to allow for more conciseness.

new file:   app/src/main/res/drawable/ic_arrow_drop_down_black_24dp.xml
new file:   app/src/main/res/drawable/ic_local_play_black_24px.xml
new file:   app/src/main/res/drawable/ic_person_black_24px.xml
new file:   app/src/main/res/drawable/ic_smartphone_black_24px.xml

- Add new vector graphic icons supporting game mode selection.

modified:   app/src/main/res/layout/fragment_game_ttt.xml
modified:   app/src/main/res/values/strings_exp.xml

- Summary: add support for game mode selection.

modified:   build.gradle

- Summary: add a version constant for the Facebook Android SDK.

modified:   gradle/wrapper/gradle-wrapper.properties

- Summary: upgrade to the latest Android Studio version.

modified:   libraries/intro/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java

- Summary: remove doRegister() as it is not used and fix a constant error caught by the new AS lint support.