### PR TITLE
Removing Extra Items in Overflow Menu

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -182,6 +182,7 @@ public abstract class BaseChatFragment extends BaseFragment {
 
         // Setup the overflow menu on all pages but the group (home) page.
         int id = mItemListType.overflowMenuIconResourceId;
+        toolbar.getMenu().clear();
         toolbar.inflateMenu(mItemListType.overflowMenuResourceId);
         toolbar.setOverflowIcon(VectorDrawableCompat.create(getResources(), id, null));
         toolbar.setNavigationIcon(mItemListType.navigationIconResourceId);


### PR DESCRIPTION
Resolving issue #162

# Changed Files

### BaseChatFragment
* In *initToolbar()*, which is used by five subclasses of **BaseChatFragment**, we now clear the toolbar's menu before inflating the new menu in it. This should clear up the problems we were having with the overflow options menu in these chat fragments, as detailed in issue #162 