### PR TITLE
Apply some review observations on the recent FAB/FAM changes.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -97,9 +97,9 @@ public enum FabManager {
 
     /** Dismiss the menu associated with the given FAB button. */
     public void dismissMenu(@NonNull final Fragment fragment) {
-        // Determine if the chat fragment is accessible.  If not, abort.
+        // Determine if the chat fragment is accessible.  If so, dismiss the FAM.
         View layout = getFragmentLayout(fragment);
-        if (layout != null) dismissMenu(layout);
+        if (layout != null) dismissMenu(fragment, layout);
     }
 
     /** Ensure that the FAb is not being shown. */
@@ -127,7 +127,7 @@ public enum FabManager {
         // Set the FAB state to closed by assuming an open FAM and dismissing it.
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
-        dismissMenu(layout);
+        dismissMenu(fragment, layout);
     }
 
     /** Set the named floating action menu (FAM) making it the default. */
@@ -188,16 +188,11 @@ public enum FabManager {
 
     /** Toggle the state of the FAB button for the given fragment, use the given menu once. */
     public void toggle(@NonNull final Fragment fragment) {
-        toggle(fragment, mDefaultMenuName, false);
+        toggle(fragment, mDefaultMenuName);
     }
 
-    /** Toggle the state of the FAB/FAM for the given fragment using the given menu once. */
+    /** Toggle the state of the FAB/FAM for the given fragment using the given menu. */
     public void toggle(@NonNull final Fragment fragment, @NonNull final String name) {
-        toggle(fragment, name, true);
-    }
-
-    /** Toggle the state of the FAB button using a given fragment to obtain the layout view. */
-    public void toggle(@NonNull final Fragment fragment, final String name, final boolean restore) {
         // Determine if the fragment layout exists.  Continue if it does.  Return if it does not.
         // An error message with stack trace will have been generated if the view cannot be
         // accessed.
@@ -217,9 +212,7 @@ public enum FabManager {
                 case opened:
                     // The FAB is showing 'X' and it's menu is visible.  Set the icon to '+', close
                     // the menu and undim the frame.
-                    dismissMenu(layout);
-                    if (restore) setMenu(fragment, mDefaultMenuName);
-                    dimmerView.setVisibility(View.GONE);
+                    dismissMenu(fragment, layout);
                     break;
                 case closed:
                     // The FAB is showing '+' and the menu is not visible.  Set the icon to X and
@@ -238,14 +231,17 @@ public enum FabManager {
     // Private instance methods.
 
     /** Dismiss the menu associated with the given layout view. */
-    private void dismissMenu(@NonNull final View layout) {
-        // The fragment is accessible and the layout has been established.  Dismiss the FAM.
-        View dimmerView = layout.findViewById(mFabDimmerId);
+    private void dismissMenu(@NonNull final Fragment fragment, @NonNull final View layout) {
+        // Dismiss the FAM and ensure that the default menu has been setup.
+        View menu = layout.findViewById(mFabMenuId);
+        menu.setVisibility(View.GONE);
+        if (mDefaultMenuName != null) setMenu(fragment, mDefaultMenuName);
+
+        // Restore the FAB to the closed state and dismiss the dimmer view.
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, State.closed);
         fab.setImageResource(mImageResourceId);
-        View menu = layout.findViewById(mFabMenuId);
-        menu.setVisibility(View.GONE);
+        View dimmerView = layout.findViewById(mFabDimmerId);
         dimmerView.setVisibility(View.GONE);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -102,24 +102,22 @@ public class TTTFragment extends BaseGameFragment implements View.OnClickListene
         // Determine if this event is for this fragment.  Abort if not.
         if (GameManager.instance.getCurrent() != tictactoe.ordinal()) return;
 
-        // The event is either a snackbar action (start a new game) or a menu (FAM or Player2)
-        // entry.  Detect and handle a snackbar action first.
+        // The event has been initiated by a FAM menu item.  It is either a snackbar action (start a
+        // new game) or a menu (FAM or Player2) entry.  Detect and handle a snackbar action first.
         Object tag = event.view.getTag();
-        if (isPlayAgain(tag, TAG)) {
-            // Dismiss the FAB (assuming it was the source of the click --- being wrong is ok, and
-            // setup a new game.
-            FabManager.game.dismissMenu(this);
-            handleNewGame();
-            return;
-        }
+        FabManager.game.dismissMenu(this);
+        if (isPlayAgain(tag, TAG)) handleNewGame();
+        else handleMode(tag instanceof MenuEntry ? ((MenuEntry) tag).titleResId : -1);
+    }
 
+    /** Handle a possible game mode selection by ... */
+    private void handleMode(final int titleResId) {
         // Case on the title resource id to handle a mode selection.
-        int titleResId = tag instanceof MenuEntry ? ((MenuEntry) tag).titleResId : -1;
         switch (titleResId) {
             case R.string.PlayModeLocalMenuTitle:
             case R.string.PlayModeComputerMenuTitle:
             case R.string.PlayModeUserMenuTitle:
-                // Handle selecting a friend by deferring for now.
+                // Handle selecting a friend by deferring for now and restoring the default menu.
                 showFutureFeatureMessage(R.string.FutureSelectModes);
                 FabManager.game.toggle(this, EXP_MODE_FAM_KEY);
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -33,13 +33,6 @@ import static com.pajato.android.gamechat.exp.ExpType.ttt;
 
     // Public class constants.
 
-    /** The level types. */
-    //public final static int EASY = 0;
-    //public final static int INTERMEDIATE = 1;
-    //public final static int IMPOSSIBLE = 2;
-
-    // The game state values.
-
     /** The game is still active. */
     public final static int ACTIVE = 0;
 
@@ -68,9 +61,6 @@ import static com.pajato.android.gamechat.exp.ExpType.ttt;
 
     /** The group push key. */
     public String groupKey;
-
-    /** The game level. */
-    //public int level;
 
     /** The last modification timestamp. */
     private long modTime;


### PR DESCRIPTION
<h1>Rationale:</h1>

While working on the changes to support User experience mode, it was clear that the recent changes to make the FAM more general could and should be enhanced.  This commit applies those enhancements.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- dismissMenu(), init(): add a fragment to the overloaded, private dismissMenu().
- toggle(): lose the restore flag argument, lose the overload that uses it, and remove it from the main overload.
- dismissMenu(): enhance to restore the default menu to the adapter.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java

- onClick(): simplify by using a procedural abstraction to handle player mode selection.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java

- Summary: apply suggested AS changes to eliminate a few warnings.