### PR TITLE
Fix TTT game creation.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -169,14 +169,26 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     }
 
     /** Return the current account id, null if there is no curent signed in User. */
-    public String getCurrentAccountId() {
-        return mCurrentAccountKey;
+    public String getCurrentAccountId() { return mCurrentAccountKey; }
+
+    /** Return null or the push key for the "me group" associated with the current account. */
+    public String getMeGroup() { return hasAccount() ? mCurrentAccount.groupKey : null; }
+
+    /** Return null or the push key for the "me room" associated with the current account. */
+    public String getMeRoom() {
+        if (!hasAccount()) return null;
+
+        // There is an account. Ensure that there is one and only one room, the "me room" in the
+        // group.  Abort if not.
+        Group group = GroupManager.instance.getGroupProfile(mCurrentAccount.groupKey);
+        if (group == null || group.roomList == null || group.roomList.size() != 1) return null;
+
+        // The me room is valid.
+        return group.roomList.get(0);
     }
 
     /** Return TRUE iff there is a signed in User. */
-    public boolean hasAccount() {
-        return mCurrentAccount != null;
-    }
+    public boolean hasAccount() { return mCurrentAccount != null; }
 
     /** Handle initialization by setting up the Firebase required list of registered classes. */
     public void init(final List<String> classNameList) {

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -153,6 +153,7 @@ public enum GroupManager {
         // message list for the logged out User.
         if (event.account != null) {
             // Set up watchers on the group profile this User has access to.
+            if (event.account.groupKey != null) setGroupProfileWatcher(event.account.groupKey);
             for (String groupKey : event.account.joinList) setGroupProfileWatcher(groupKey);
             return;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -24,18 +24,17 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
+import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.exp.model.ExpProfile;
-import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.NetworkManager;
 
 import org.greenrobot.eventbus.Subscribe;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseGameExpFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseGameExpFragment.java
@@ -11,6 +11,8 @@ import com.pajato.android.gamechat.exp.model.Player;
 import java.util.List;
 
 /**
+ * Provides a base class for experience objects that are also games.
+ *
  * Created by sscott on 12/31/16.
  */
 public abstract class BaseGameExpFragment extends BaseExperienceFragment {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
@@ -17,12 +17,11 @@
 
 package com.pajato.android.gamechat.exp;
 
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.common.Dispatcher;
+import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.exp.model.ExpProfile;
 import com.pajato.android.gamechat.main.NetworkManager;
@@ -60,22 +59,11 @@ public enum GameManager {
     /** The current fragment. */
     private int mCurrentFragment;
 
-    /** The current group key as determined the last selected group. */
-    //public String currentGroupKey;
-
-    /** The current room key as determined by the last selected room. */
-    //public String currentRoomKey;
-
     // Public instance methods.
 
     /** Return the current fragment's index value. */
     public int getCurrent() {
         return mCurrentFragment;
-    }
-
-    /** Return the current fragment being shown in the experience panel. */
-    public BaseExperienceFragment getFragment(final int index) {
-        return mFragmentList[index];
     }
 
     /** Initialize the game manager's current fragment. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
@@ -31,10 +31,10 @@ import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.TagClickEvent;
 
 /**
- * Manages the game related aspects of the GameChat application. These include the creation of new
- * game instances, notifications, and game settings.
+ * Manages the presentation of UI messages, mainly error messsages.
  *
  * @author Bryan Scott
+ * @author Paul Michael Reilly
  */
 enum NotificationManager {
     instance;

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="CheckersImageDesc">Checkers image.</string>
     <string name="ChessImageDesc">Chess image.</string>
+    <string name="ErrorTTTCreation">Error: cannot create a TicTacToe experience</string>
     <string name="FutureSelectModes">Select playing modes</string>
     <string name="FutureSelectRooms">Select rooms</string>
     <string name="InvalidButton">You must click on an empty button!  Try again.</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes TTT creation to use the Me Group and Me Room.  This room acts as a sort of staging area for new experiences.  Upon selecting a User, the experience will be relocated to the Group of the given User and a room selected along with the User (default is the private room for two Users.)

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- getCurrentAccountId(), hasAccount(): make these single line methods.
- getMeGroup(), getMeRoom(): new methods providing access via the Account object.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- onAuthenticationChange(): set up a watcher on the "me group".

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseGameExpFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java

- Summary: fix some AS warnings.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java

- Summary: enhance the class doc comment.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java

- createExperience(): make this work using the "me group" and "me room".
- reportError(): provide a first stab at a generic error handler.

modified:   app/src/main/res/values/strings_exp.xml

- ErrorTTTCreation: new localized create experience error message.