### PR TITLE
Fix default account creation and display.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -206,13 +206,11 @@ public abstract class BaseChatFragment extends BaseFragment {
                 // A group list does not need an item.
                 return true;
             case messageList:
-                Message payload = (Message) dispatcher.payload;
-                MessageItem messageItem = new MessageItem(payload);
+                MessageItem messageItem = new MessageItem((Message) dispatcher.payload);
                 mItem = new ChatListItem(messageItem);
                 return true;
             case roomList:
-                String roomKey = dispatcher.roomMap.keySet().iterator().next().toString();
-                RoomItem roomItem = new RoomItem(dispatcher.groupKey, roomKey);
+                RoomItem roomItem = new RoomItem(dispatcher.groupKey, dispatcher.roomKey);
                 mItem = new ChatListItem(roomItem);
                 return true;
             default:
@@ -380,7 +378,7 @@ public abstract class BaseChatFragment extends BaseFragment {
     // Protected inner classes.
 
     /** Provide a handler that will generate a backpress event. */
-    protected class UpHandler implements View.OnClickListener {
+    private class UpHandler implements View.OnClickListener {
         /** Handle a click on the back arrow button by generating a back press. */
         public void onClick(final View view) {
             getActivity().onBackPressed();

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java
@@ -56,7 +56,7 @@ public class ChatFragment extends BaseChatFragment {
     /** Handle a authentication change event by dealing with the fragment to display. */
     @Subscribe public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         // Simply start the next logical fragment.
-        logEvent(String.format("onAccountStateChange: with event {%s};", event));
+        logEvent(String.format("onAuthenticationChange: with event {%s};", event));
         ChatManager.instance.startNextFragment(getActivity());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -187,20 +187,18 @@ public abstract class BaseFragment extends Fragment {
 
     /** Return a menu entry for a given title and icon id, and a given fragment type. */
     protected MenuEntry getEntry(final int titleId, final int iconId, final ExpFragmentType type) {
-        final int itemType = MENU_ITEM_NO_TINT_TYPE;
-        return new MenuEntry(new MenuItemEntry(itemType, titleId, iconId, type.ordinal()));
+        int ordinal = type.ordinal();
+        return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId, ordinal));
     }
 
     /** Return a menu entry for with given title and icon resource items. */
     protected MenuEntry getNoTintEntry(final int titleId, final int iconId) {
-        final int type = MENU_ITEM_NO_TINT_TYPE;
-        return new MenuEntry(new MenuItemEntry(type, titleId, iconId));
+        return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId));
     }
 
     /** Return a menu entry for with given title and icon resource items. */
     protected MenuEntry getTintEntry(final int titleId, final int iconId) {
-        final int type = MENU_ITEM_TINT_TYPE;
-        return new MenuEntry(new MenuItemEntry(type, titleId, iconId));
+        return new MenuEntry(new MenuItemEntry(MENU_ITEM_TINT_TYPE, titleId, iconId));
     }
 
     /** Provide a logger to show the given message and the given bundle. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.common;
 
 import com.pajato.android.gamechat.chat.model.Room;
-import com.pajato.android.gamechat.database.RoomManager;
 
 import java.util.List;
 import java.util.Map;
@@ -43,9 +42,6 @@ public class Dispatcher<T, O> {
     /** A list of messages or experience profiles. */
     public List<O> list;
 
-    /** Associates groups, rooms and either messages or experience profiles. */
-    public Map<String, Map<String, Map<String, O>>> groupMap;
-
     /** The group key. */
     public String groupKey;
 
@@ -63,17 +59,15 @@ public class Dispatcher<T, O> {
     /** Build an instance given a type. */
     public Dispatcher(final T type) {
         this.type = type;
-        Room room = RoomManager.instance.getMeRoom();
+    }
+
+    /** Build an instance given a type and a room. */
+    public Dispatcher(final T type, final Room room) {
         if (room != null) {
+            this.type = type;
             groupKey = room.groupKey;
             roomKey = room.key;
         }
-    }
-
-    /** Build an instance given a type and an experience map. */
-    public Dispatcher(final T type, final Map<String, Map<String, Map<String, O>>> groupMap) {
-        this.type = type;
-        this.groupMap = groupMap;
     }
 
     /** Build an instance given a group key and room map. */
@@ -83,7 +77,7 @@ public class Dispatcher<T, O> {
         this.roomMap = roomMap;
     }
 
-    /** Build an instance given a group key, room key, and an experience list. */
+    /** Build an instance given a group key, room key, and an experience or message list. */
     public Dispatcher(final T type, final String gKey, final String rKey, final List<O> list) {
         this.type = type;
         this.groupKey = gKey;
@@ -103,5 +97,12 @@ public class Dispatcher<T, O> {
     public Dispatcher(final T type, O payload) {
         this.type = type;
         this.payload = payload;
+    }
+
+    /** Build an instance given a fragment type, group key and room key. */
+    public Dispatcher(final T type, String groupKey, String roomKey) {
+        this.type = type;
+        this.groupKey = groupKey;
+        this.roomKey = roomKey;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -86,8 +86,8 @@ public enum DBUtils {
 
     // Lookup keys.
     public static final String DEFAULT_ROOM_NAME_KEY = "defaultRoomNameKey";
-    public static final String ME_GROUP_KEY = "meGroupKey";
     public static final String SYSTEM_NAME_KEY = "systemNameKey";
+    public static final String WELCOME_MESSAGE_KEY = "welcomeMessageKey";
 
     // Public instance variables.
 
@@ -127,9 +127,9 @@ public enum DBUtils {
     /** Intialize the database manager by setting up localized resources. */
     public void init(final Context context) {
         mResourceMap.clear();
-        mResourceMap.put(ME_GROUP_KEY, context.getString(R.string.DefaultPrivateGroupName));
-        mResourceMap.put(SYSTEM_NAME_KEY, context.getString(R.string.app_name));
         mResourceMap.put(DEFAULT_ROOM_NAME_KEY, context.getString(R.string.DefaultRoomName));
+        mResourceMap.put(SYSTEM_NAME_KEY, context.getString(R.string.app_name));
+        mResourceMap.put(WELCOME_MESSAGE_KEY, context.getString(R.string.WelcomeMessageText));
     }
 
     /** Store an object on the database using a given path, pushKey, and properties. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -164,7 +164,7 @@ public enum GroupManager {
         mGroupToLastNewMessageMap.clear();
     }
 
-    /** Handle a room profile change by updating the map. */
+    /** Handle a group profile change by updating the map. */
     @Subscribe public void onGroupProfileChange(@NonNull final ProfileGroupChangeEvent event) {
         // Ensure that the group profile is cached and set up watchers for each member and room in
         // the group.

--- a/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
@@ -119,6 +119,17 @@ public enum MessageManager {
         return messageMap.get(groupKey);
     }
 
+    /** Return a possibly empty list of messages for a given group and room. */
+    public List<Message> getMessageList(final String groupKey, final String roomKey) {
+        // Ensure there are some messages to be had in the group.  Return the empty list if none
+        // are found, otherwise return all messages in that room.
+        List<Message> result = new ArrayList<>();
+        Map<String, Map<String, Message>> roomMap = getGroupMessages(groupKey);
+        if (roomMap == null) return result;
+        result.addAll(roomMap.get(roomKey).values());
+        return result;
+    }
+
     /** Return a list of messages, an empty list if there are none to be had, for a given item. */
     public List<ChatListItem> getMessageListData(@NonNull final ChatListItem item) {
         // Generate a map of date header types to a list of messages, i.e. a chronological ordering

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -78,11 +78,9 @@ public enum RoomManager {
 
     /** Return the "Me" room or null if there is no such room for one reason or another. */
     public Room getMeRoom() {
-        // Ensure that a search is viable.  Return null if not, otherwise walk the list of rooms to
-        // find one (and only one) with a "Me" room.
-        if (roomMap == null || roomMap.size() == 0) return null;
-        for (Room room : roomMap.values()) if (room.type == Room.ME) return room;
-        return null;
+        // Find the me room via the current account.
+        String roomKey = AccountManager.instance.getMeRoom();
+        return roomKey != null ? roomMap.get(roomKey) : null;
     }
 
     /** Return a room push key to use with a subsequent room object persistence. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java
@@ -25,6 +25,7 @@ import com.google.firebase.database.DatabaseError;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.database.MessageManager;
 import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.MessageChangeEvent;
 
 import java.util.HashMap;
@@ -159,5 +160,6 @@ public class MessageListChangeHandler extends DatabaseEventHandler implements Ch
                 break;
         }
         AppEventManager.instance.post(new MessageChangeEvent(message, type));
+        AppEventManager.instance.post(new ChatListChangeEvent());
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ProfileRoomChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ProfileRoomChangeHandler.java
@@ -25,6 +25,7 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.ValueEventListener;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.ProfileRoomChangeEvent;
 
 /**

--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -228,9 +228,6 @@ public class CheckersFragment extends BaseGameExpFragment {
         if (getModel() == null) {
             // Disable the layout and startup the spinner.
             mLayout.setVisibility(View.GONE);
-            String title = "Checkers";
-            String message = "Waiting for the database to provide the game...";
-            ProgressManager.instance.show(getContext(), title, message);
         } else {
             // Start the game and update the views using the current state of the experience.
             mLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -310,9 +310,6 @@ public class ChessFragment extends BaseGameExpFragment implements View.OnClickLi
         if (mExperience == null) {
             // Disable the layout and startup the spinner.
             mLayout.setVisibility(View.GONE);
-            String title = "Chess";
-            String message = "Waiting for the database to provide the game...";
-            ProgressManager.instance.show(getContext(), title, message);
         } else {
             // Start the game and update the views using the current state of the experience.
             mLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java
@@ -104,7 +104,7 @@ public enum GameManager {
 
         // Deal with a signed in User with multiple experiences across more than one group.  Return
         // a dispatcher with a map of experience keys.
-        if (expProfileMap.size() > 1) return new Dispatcher<>(groupList, expProfileMap);
+        if (expProfileMap.size() > 1) return new Dispatcher<>(groupList);
 
         // A signed in user with experiences in more than one room but only one group. Return a
         // dispatcher identifying the group and room map.
@@ -171,7 +171,8 @@ public enum GameManager {
     }
 
     /** Return true iff a fragment for the given experience is started. */
-    private boolean startNextFragment(final FragmentActivity context, final Dispatcher<ExpFragmentType, ExpProfile> dispatcher) {
+    private boolean startNextFragment(final FragmentActivity context,
+                                      final Dispatcher<ExpFragmentType, ExpProfile> dispatcher) {
         // Ensure that the fragment exists, creating it as necessary.  Abort if the fragment cannot
         // be created.
         if (!fragmentExists(dispatcher)) return false;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -107,10 +107,13 @@ public class TTTFragment extends BaseGameExpFragment implements View.OnClickList
         switch (titleResId) {
             case R.string.PlayModeLocalMenuTitle:
             case R.string.PlayModeComputerMenuTitle:
-            case R.string.PlayModeUserMenuTitle:
                 // Handle selecting a friend by deferring for now and restoring the default menu.
                 showFutureFeatureMessage(R.string.FutureSelectModes);
-                FabManager.game.toggle(this, EXP_MODE_FAM_KEY);
+                FabManager.game.dismissMenu(this);
+                break;
+            case R.string.PlayModeUserMenuTitle:
+                // Handle selecting another User.
+                //selectModeUser();
                 break;
             default:
                 break;
@@ -400,9 +403,6 @@ public class TTTFragment extends BaseGameExpFragment implements View.OnClickList
         if (mExperience == null) {
             // Disable the layout and startup the spinner.
             mLayout.setVisibility(View.GONE);
-            String title = "TicTacToe";
-            String message = "Waiting for the database to provide the game...";
-            ProgressManager.instance.show(getContext(), title, message);
         } else {
             // Start the game and update the views using the current state of the experience.
             mLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/res/layout/fragment_checkers.xml
+++ b/app/src/main/res/layout/fragment_checkers.xml
@@ -47,7 +47,6 @@ http://www.gnu.org/licenses
         android:textStyle="bold"
         app:layout_constraintCenterY_toCenterY="@id/vs"
         app:layout_constraintRight_toLeftOf="@+id/vs"
-        tools:layout_editor_absoluteY="0dp"
         tools:text="theShovel" />
 
     <TextView
@@ -61,7 +60,6 @@ http://www.gnu.org/licenses
         android:textStyle="bold"
         app:layout_constraintCenterY_toCenterY="@id/vs"
         app:layout_constraintLeft_toRightOf="@+id/vs"
-        tools:layout_editor_absoluteY="0dp"
         tools:text="Friend" />
 
     <TextView

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -25,7 +25,6 @@
     <string name="InstallDebugUsers">Install developer users</string>
     <string name="InviteMembersFeature">Inviting group or room members</string>
     <string name="JoinRoomsMenuTitle">Join Rooms</string>
-    <!-- <string name="JoinRoomsFilterTextDefault">Tyoe to filter rooms or members</string> -->
     <string name="LearnMoreFeature">Providing context help</string>
     <string name="MembersAvailableHeaderText">Members</string>
     <string name="MembersNotAvailableHeaderText">No Available Members</string>
@@ -39,6 +38,8 @@
     <string name="SelectRoomsMenuTitle">Select All Rooms</string>
     <string name="SetCreateIconFeature">Setting the create group or room icon</string>
     <string name="SetCreateIconDesc">Set the group or room icon</string>
+    <string name="SignInDialogTitleText">Attempting to sign in …</string>
+    <string name="SignInDialogMessageText">Hold on a few moments while we sign you in …</string>
     <string name="SignInLastAccountMenuTitle">Use Current Account</string>
     <string name="SwitchAccountDesc">Switch account menu item.</string>
     <string name="SwitchAccountMenuTitle">Switch Account</string>
@@ -46,6 +47,7 @@
     <string name="TakePictureDesc">Take a camera picture image button.</string>
     <string name="TakeVideo">Inserting a video from your camera</string>
     <string name="TakeVideoDesc">Take a video image button.</string>
+    <string name="WelcomeMessageText">Welcome to your private messages. Use this space to take notes and stash files. Enjoy!</string>
     <string name="contacts">Contacts</string>
     <string name="editMessageHint">Type a message</string>
     <string name="frequent">Frequent</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

When a new account is created, the app should show a default message in the account holder's private room.  The toolbar title should be the display name for the account holder and no group should be displayed.  This commit makes that happen correctly. It is part of the task of making sure that the "me group" is not exposed to the User.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): make the code a little more concise.
- UpHandler: make AS happy by making this private.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/ChatManager.java

- startNextFragment(): remove the "type" overload.
- getDispatcher(): complete rewrite along with two overloads.
- getFragment(), setItem(): make concise.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatFragment.java

- onAuthenticationChange(): fix a logging comment.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowSignedOutFragment.java

- Summary: add a timed progress spinner at startup.
- mTimer: new variable to handle shutting down the timer.
- onChatListChange(): use this to shut off the progress spinner and switch to a more appropriate fragment.
- onCreate(): set up the timer with an anonymous class to hadle it.
- onStart(): start the timer and show the sign in progress spinner.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- getEntry(), getNoTintEntry(), getTintEntry(): fix some AS warnings that make the code more concise.

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- groupMap: remove per AS suggestions.
- Dispatcher(): do not try to establish a room on the fragment type overload.
- Dispatcher(): remove the groupMap overload.
- Dispatcher(): add a group and room key overload.

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- createAccount(): do not name the default private group (aka me group); name the default private room using the account holder's display name; use a localized string for the welcome message.
- getMeRoom(): obtain the group from the instance map.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java

- ME_GROUP_KEY: lose this.
- WELCOME_MESSAGE_KEY: new key for the localized me group welcome message text.
- init(): manage a welcome message and do not manage the me group name.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- onGroupProfileChange(): fix a comment.

modified:   app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java

- getMessageList(): new method to obtain the messages for a given group and room.

modified:   app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java

- getMeRoom(): use the account manager to obtain the me room.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java

- process(): post an app chat list change event as well as a message change event.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/ProfileRoomChangeHandler.java

- Summary: fix an AS unused import complaint.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/GameManager.java

- getDispatcher(): do not pass in an expProfileMap.
- startNextFragment(): deal with a long line.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java

- onResume(): do not deal with a progress spinner (let Chat do that).

modified:   app/src/main/res/layout/fragment_checkers.xml

- Summary: lose some AS contraint layout generated detritus.

modified:   app/src/main/res/values/strings_chat.xml

- Summary: add some localized string resources.