### PR TITLE
Fix Chess and Checkers game creation.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -143,14 +143,34 @@ public class CheckersFragment extends BaseGameExpFragment {
         long tstamp = new Date().getTime();
         String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, tstamp);
 
-        // Set up the default group and room keys, the owner id and return the value.
-        String groupKey = GroupManager.instance.getGroupKey();
-        String roomKey = RoomManager.instance.getRoomKey(groupKey);
+        // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
+        // object on the database.
+        String groupKey = AccountManager.instance.getMeGroup();
+        String roomKey = AccountManager.instance.getMeRoom();
         String id = getOwnerId();
         // TODO: DEFINE LEVEL INT ENUM VALUES - this is passing "0" for now
         Checkers model = new Checkers(key, id, 0, name, tstamp, groupKey, roomKey, players);
-        ExperienceManager.instance.createExperience(model);
+        if (groupKey != null && roomKey != null) ExperienceManager.instance.createExperience(model);
+        else reportError(context, R.string.ErrorCheckersCreation, groupKey, roomKey);
     }
+    /** Notify the user about an error and log it. */
+    private void reportError(final Context context, final int messageResId, String... args) {
+        // Let the User know that something is amiss.
+        String message = context.getString(messageResId);
+        NotificationManager.instance.notify(this, message, false);
+
+        // Generate a logcat item casing on the given resource id.
+        String format;
+        switch (messageResId) {
+            case R.string.ErrorCheckersCreation:
+                format = "Failed to create a Checkers experience with group/room keys: {%s/%s}";
+                Log.e(TAG, String.format(Locale.US, format, args[0], args[1]));
+                break;
+            default:
+                break;
+        }
+    }
+
 
     /** Return a possibly null list of player information for a checkers experience (always 2 players) */
     protected List<Account> getPlayers(final Dispatcher<ExpFragmentType, ExpProfile> dispatcher) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -148,13 +148,33 @@ public class ChessFragment extends BaseGameExpFragment {
         long tstamp = new Date().getTime();
         String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, tstamp);
 
-        // Set up the default group and room keys, the owner id and return the value.
-        String groupKey = GroupManager.instance.getGroupKey();
-        String roomKey = RoomManager.instance.getRoomKey(groupKey);
+        // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
+        // object on the database.
+        String groupKey = AccountManager.instance.getMeGroup();
+        String roomKey = AccountManager.instance.getMeRoom();
         String id = getOwnerId();
         // TODO: DEFINE LEVEL INT ENUM VALUES - this is passing "0" for now
         Chess model = new Chess(key, id, 0, name, tstamp, groupKey, roomKey, players);
-        ExperienceManager.instance.createExperience(model);
+        if (groupKey != null && roomKey != null) ExperienceManager.instance.createExperience(model);
+        else reportError(context, R.string.ErrorChessCreation, groupKey, roomKey);
+    }
+
+    /** Notify the user about an error and log it. */
+    private void reportError(final Context context, final int messageResId, String... args) {
+        // Let the User know that something is amiss.
+        String message = context.getString(messageResId);
+        NotificationManager.instance.notify(this, message, false);
+
+        // Generate a logcat item casing on the given resource id.
+        String format;
+        switch (messageResId) {
+            case R.string.ErrorChessCreation:
+                format = "Failed to create a Chess experience with group/room keys: {%s/%s}";
+                Log.e(TAG, String.format(Locale.US, format, args[0], args[1]));
+                break;
+            default:
+                break;
+        }
     }
 
     /** Return a possibly null list of player information for a chess experience (always 2 players) */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -191,7 +191,7 @@ public class TTTFragment extends BaseGameExpFragment implements View.OnClickList
         else reportError(context, R.string.ErrorTTTCreation, groupKey, roomKey);
     }
 
-    /** Notifiy the User about an error and log it. */
+    /** Notify the user about an error and log it. */
     private void reportError(final Context context, final int messageResId, String... args) {
         // Let the User know that something is amiss.
         String message = context.getString(messageResId);

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="CheckersImageDesc">Checkers image.</string>
     <string name="ChessImageDesc">Chess image.</string>
+    <string name="ErrorCheckersCreation">Error: cannot create a Checkers experience</string>
+    <string name="ErrorChessCreation">Error: cannot create a Chess experience</string>
     <string name="ErrorTTTCreation">Error: cannot create a TicTacToe experience</string>
     <string name="FutureSelectModes">Select playing modes</string>
     <string name="FutureSelectRooms">Select rooms</string>


### PR DESCRIPTION
# Rationale
This commit fixes Chess and Checkers creation to use the Me Group and Me Room and provides parity with the TTT behavior. Refer to Pull Request #171 for TTT.

# Files Changed

## Java Files
### app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
* createExperience(): use the default Me group and Me room for the experience
* reportError() plagiarized from TTTFragment
### app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
* createExperience(): use the default Me group and Me room for the experience
* reportError() plagiarized from TTTFragment
### app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
* typo in a comment

## XML files
### app/src/main/res/values/strings_exp.xml
* add ErrorCheckersCreation and ErrorChessCreation
