### PR TITLE
Preserve create time and mod time in game models.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -28,7 +28,7 @@ public class Checkers implements Experience {
     public Map<String, String> board;
 
     /** The creation timestamp. */
-    private long createTime;
+    public long createTime;
 
     /** The group push key. */
     public String groupKey;
@@ -40,7 +40,7 @@ public class Checkers implements Experience {
     public int level;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The experience display name. */
     public String name;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
@@ -28,7 +28,7 @@ public class Chess implements Experience {
     public ChessBoard board;
 
     /** The creation timestamp. */
-    private long createTime;
+    public long createTime;
 
     /** The group push key. */
     public String groupKey;
@@ -40,7 +40,7 @@ public class Chess implements Experience {
     public int level;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The experience display name. */
     public String name;
@@ -70,14 +70,19 @@ public class Chess implements Experience {
 
     /** Remember that the primary team queen side rook has moved */
     public boolean primaryQueenSideRookHasMoved;
+
     /** Remember that the primary team king side rook has moved */
     public boolean primaryKingSideRookHasMoved;
+
     /** Remember that the primary team king has moved */
     public boolean primaryKingHasMoved;
+
     /** Remember that the secondary team queen side rook has moved */
     public boolean secondaryQueenSideRookHasMoved;
+
     /** Remember that the secondary team king side rook has moved */
     public boolean secondaryKingSideRookHasMoved;
+
     /** Remember that the secondary team king has moved */
     public boolean secondaryKingHasMoved;
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -54,7 +54,7 @@ import static com.pajato.android.gamechat.exp.ExpType.ttt;
     public TTTBoard board;
 
     /** The creation timestamp. */
-    private long createTime;
+    public long createTime;
 
     /** The experience push key. */
     public String key;
@@ -63,7 +63,7 @@ import static com.pajato.android.gamechat.exp.ExpType.ttt;
     public String groupKey;
 
     /** The last modification timestamp. */
-    private long modTime;
+    public long modTime;
 
     /** The experience display name. */
     public String name;


### PR DESCRIPTION
# Rationale
Make createTime and modTime public in Checkers, Chess and TicTacToe models so that Firebase can access and doesn't overwrite with zero value.

# Files Changed

### app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
Change access level of createTime and modTime member variables from private to public.

### app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
Change access level of createTime and modTime member variables from private to public.

### app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
Change access level of createTime and modTime member variables from private to public.
