### PR TITLE
Use readable timestamp in game experience names.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -33,6 +33,8 @@ import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -144,8 +146,10 @@ public class CheckersFragment extends BaseGameExpFragment {
         List<Player> players = getDefaultPlayers(context, playerAccounts);
         String name1 = players.get(0).name;
         String name2 = players.get(1).name;
+
         long tstamp = new Date().getTime();
-        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, tstamp);
+        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2,
+                SimpleDateFormat.getDateTimeInstance().format(tstamp));
 
         // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
         // object on the database.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -37,6 +37,7 @@ import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -147,8 +148,10 @@ public class ChessFragment extends BaseGameExpFragment {
         List<Player> players = getDefaultPlayers(context, playerAccounts);
         String name1 = players.get(0).name;
         String name2 = players.get(1).name;
+
         long tstamp = new Date().getTime();
-        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, tstamp);
+        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2,
+                SimpleDateFormat.getDateTimeInstance().format(tstamp));
 
         // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
         // object on the database.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
@@ -46,6 +46,7 @@ import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -178,8 +179,10 @@ public class TTTFragment extends BaseGameExpFragment implements View.OnClickList
         List<Player> players = getDefaultPlayers(context, playerAccounts);
         String name1 = players.get(0).name;
         String name2 = players.get(1).name;
+
         long tstamp = new Date().getTime();
-        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, tstamp);
+        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2,
+                SimpleDateFormat.getDateTimeInstance().format(tstamp));
 
         // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
         // object on the database.


### PR DESCRIPTION
# Rationale
A human-readable timestamp is nicer than a long int value in the experience name.

# Files Changed

### app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
* createExperience(): format timestamp using SimpleDateFormat.getDateTimeInstance (which makes a local-specific value) and use it in the experience name.

### app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
* createExperience(): format timestamp using SimpleDateFormat.getDateTimeInstance (which makes a local-specific value) and use it in the experience name.

### app/src/main/java/com/pajato/android/gamechat/exp/TTTFragment.java
* createExperience(): format timestamp using SimpleDateFormat.getDateTimeInstance (which makes a local-specific value) and use it in the experience name.