### PR TITLE
Use Unicode chess characters on pawn promotion dialog.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.exp;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -40,8 +39,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static android.R.color.white;
+import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static android.util.TypedValue.COMPLEX_UNIT_SP;
 import static com.pajato.android.gamechat.R.id.board;
+import static com.pajato.android.gamechat.R.color.colorAccent;
+import static com.pajato.android.gamechat.R.color.colorPrimary;
+import static com.pajato.android.gamechat.R.color.colorLightGray;
 import static com.pajato.android.gamechat.R.id.player_1_icon;
 import static com.pajato.android.gamechat.exp.ExpFragmentType.chess;
 import static com.pajato.android.gamechat.exp.ExpFragmentType.tictactoe;
@@ -55,8 +59,7 @@ import static com.pajato.android.gamechat.exp.model.Checkers.SECONDARY_WINS;
  * @author Bryan Scott
  */
 public class CheckersFragment extends BaseExperienceFragment {
-    // We refer to the two sides as primary and secondary to differentiate between the two players.
-    // (Primary pieces belong to player1, secondary belong to player 2).
+
     public static final String PRIMARY_PIECE = "pp";
     public static final String PRIMARY_KING = "pk";
     public static final String SECONDARY_PIECE = "sp";
@@ -120,12 +123,10 @@ public class CheckersFragment extends BaseExperienceFragment {
 
         // Color the player icons.
         ImageView playerOneIcon = (ImageView) mLayout.findViewById(player_1_icon);
-        playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorPrimary),
-                PorterDuff.Mode.SRC_ATOP);
+        playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
 
         ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
-        playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorAccent),
-                PorterDuff.Mode.SRC_ATOP);
+        playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
     }
 
     /** Handle taking the foreground by updating the UI based on the current experience. */
@@ -407,7 +408,8 @@ public class CheckersFragment extends BaseExperienceFragment {
     }
 
     // Set up an image button which will be a cell in the game board
-    private TextView makeBoardButton(int index, int sideSize, Map<String, String> board, String pieceType) {
+    private TextView makeBoardButton(final int index, final int sideSize,
+                                     final Map<String, String> board, final String pieceType) {
         TextView currentTile = new TextView(getContext());
 
         // Set up the gridlayout params, so that each cell is functionally identical.
@@ -429,20 +431,19 @@ public class CheckersFragment extends BaseExperienceFragment {
         currentTile.setTypeface(null, Typeface.BOLD);
         currentTile.setGravity(Gravity.CENTER);
 
-        // Handle the checkerboard positions.
-        boolean isEven = index % 2 == 0;
-
         // Create the checkerboard pattern on the button backgrounds.
+        boolean isEven = index % 2 == 0;
         if (isEvenEvenOrOddOdd(index, isEven)) {
-            currentTile.setBackgroundColor(ContextCompat.getColor(getContext(), android.R.color.white));
+            currentTile.setBackgroundColor(ContextCompat.getColor(getContext(), white));
             currentTile.setText(" ");
         } else {
-            currentTile.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.colorLightGray));
+            currentTile.setBackgroundColor(ContextCompat.getColor(getContext(), colorLightGray));
             currentTile.setText(" ");
         }
 
         // If the tile is meant to contain a board piece at the start of play, give it a piece.
-        if (containsSecondaryPiece(index, isEven) || (pieceType.equals(SECONDARY_PIECE) || pieceType.equals(SECONDARY_KING))) {
+        if (containsSecondaryPiece(index, isEven) ||
+                (pieceType.equals(SECONDARY_PIECE) || pieceType.equals(SECONDARY_KING))) {
             if (pieceType.equals(SECONDARY_KING)) {
                 currentTile.setText(KING_UNICODE);
             } else {
@@ -454,7 +455,8 @@ public class CheckersFragment extends BaseExperienceFragment {
             } else {
                 board.put(buttonTag, SECONDARY_PIECE);
             }
-        } else if (containsPrimaryPiece(index, isEven) || (pieceType.equals(PRIMARY_PIECE) || pieceType.equals(PRIMARY_KING))) {
+        } else if (containsPrimaryPiece(index, isEven) ||
+                (pieceType.equals(PRIMARY_PIECE) || pieceType.equals(PRIMARY_KING))) {
             if (pieceType.equals(PRIMARY_KING)) {
                 currentTile.setText(KING_UNICODE);
             } else {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessFragment.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.exp;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
@@ -42,8 +41,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static android.util.TypedValue.COMPLEX_UNIT_SP;
 import static com.pajato.android.gamechat.R.id.board;
+import static com.pajato.android.gamechat.R.color.colorAccent;
+import static com.pajato.android.gamechat.R.color.colorPrimary;
 import static com.pajato.android.gamechat.exp.ChessPiece.ChessTeam.PRIMARY;
 import static com.pajato.android.gamechat.exp.ChessPiece.ChessTeam.SECONDARY;
 import static com.pajato.android.gamechat.exp.ChessPiece.PieceType.BISHOP;
@@ -121,12 +123,10 @@ public class ChessFragment extends BaseExperienceFragment {
 
         // Color the Player Icons.
         ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player_1_icon);
-        playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorPrimary),
-                PorterDuff.Mode.SRC_ATOP);
+        playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
 
         ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
-        playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.colorAccent),
-                PorterDuff.Mode.SRC_ATOP);
+        playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
     }
 
     /** Handle taking the foreground by updating the UI based on the current experience. */
@@ -380,7 +380,7 @@ public class ChessFragment extends BaseExperienceFragment {
      * @param sideSize size to use for width and height of the new item to add to the board
      * @param board a ChessBoard object representing the game board (0->63) the piece type at that location.
      */
-    private TextView makeBoardButton(int index, int sideSize, ChessBoard board) {
+    private TextView makeBoardButton(final int index, final int sideSize, final ChessBoard board) {
         TextView currentTile = new TextView(getContext());
 
         // Set up the gridlayout params, so that each cell is functionally identical.
@@ -800,38 +800,42 @@ public class ChessFragment extends BaseExperienceFragment {
         int alertIconId = getActivity().getResources().getIdentifier("android:id/icon", null, null);
         ImageView alertIcon = (ImageView) pawnChooser.findViewById(alertIconId);
         if(alertIcon != null) {
-            alertIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            alertIcon.setColorFilter(color, SRC_ATOP);
         }
         // Setup the Queen Listeners and change color appropriate to the team.
-        ImageView queenIcon = (ImageView) pawnChooser.findViewById(R.id.queen_icon);
+        TextView queenIcon = (TextView) pawnChooser.findViewById(R.id.queen_icon);
         TextView queenText = (TextView) pawnChooser.findViewById(R.id.queen_text);
         if(queenIcon != null && queenText != null) {
-            queenIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            queenIcon.setText(ChessPiece.UC_QUEEN);
+            queenIcon.setTextColor(color);
             queenIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
             queenText.setOnClickListener(new Promoter(position, team, pawnChooser));
         }
         // Do the same for bishop.
-        ImageView bishopIcon = (ImageView) pawnChooser.findViewById(R.id.bishop_icon);
+        TextView bishopIcon = (TextView) pawnChooser.findViewById(R.id.bishop_icon);
         TextView bishopText = (TextView) pawnChooser.findViewById(R.id.bishop_text);
         if(bishopIcon != null && bishopText != null) {
-            bishopIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            bishopIcon.setText(ChessPiece.UC_BISHOP);
+            bishopIcon.setTextColor(color);
             bishopIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
             bishopText.setOnClickListener(new Promoter(position, team, pawnChooser));
         }
         // And the same for knight.
-        ImageView knightIcon = (ImageView) pawnChooser.findViewById(R.id.knight_icon);
+        TextView knightIcon = (TextView) pawnChooser.findViewById(R.id.knight_icon);
         TextView knightText = (TextView) pawnChooser.findViewById(R.id.knight_text);
         if(knightIcon != null && knightText != null) {
-            knightIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+            knightIcon.setText(ChessPiece.UC_KNIGHT);
+            knightIcon.setTextColor(color);
             knightIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
             knightText.setOnClickListener(new Promoter(position, team, pawnChooser));
         }
         // And finally, the same for rook.
-        ImageView rookIcon = (ImageView) pawnChooser.findViewById(R.id.rook_icon);
+        TextView rookIcon = (TextView) pawnChooser.findViewById(R.id.rook_icon);
         TextView rookText = (TextView) pawnChooser.findViewById(R.id.rook_text);
         if(rookIcon != null && rookText != null) {
+            rookIcon.setText(ChessPiece.UC_ROOK);
+            rookIcon.setTextColor(color);
             rookIcon.setOnClickListener(new Promoter(position, team, pawnChooser));
-            rookIcon.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
             rookText.setOnClickListener(new Promoter(position, team, pawnChooser));
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ChessPiece.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ChessPiece.java
@@ -2,12 +2,9 @@ package com.pajato.android.gamechat.exp;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
-import com.pajato.android.gamechat.R;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static android.R.attr.name;
 
 /**
  * A simple P.O.J.O. class that keeps track of a chess pieces type and the team it is on.
@@ -27,16 +24,16 @@ public class ChessPiece {
     private static final String UC_KING = "\u2654";
 
     // Unicode value for queen
-    private static final String UC_QUEEN = "\u2655";
+    static final String UC_QUEEN = "\u2655";
 
     // Unicode value for bishop
-    private static final String UC_BISHOP = "\u2657";
+    static final String UC_BISHOP = "\u2657";
 
     // Unicode value for knight
-    private static final String UC_KNIGHT = "\u2658";
+    static final String UC_KNIGHT = "\u2658";
 
     // Unicode value for rook
-    private static final String UC_ROOK = "\u2656";
+    static final String UC_ROOK = "\u2656";
 
     // Unicode value for pawn
     private static final String UC_PAWN = "\u2659";

--- a/app/src/main/res/layout/pawn_dialog.xml
+++ b/app/src/main/res/layout/pawn_dialog.xml
@@ -28,14 +28,13 @@
         app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"
         app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"/>
 
-    <ImageView
+    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_games_white"
         android:id="@+id/queen_icon"
+        android:textSize="20sp"
         android:contentDescription="@string/chess_promotion_queen"
         android:layout_marginEnd="16dp"
-
         app:layout_constraintRight_toLeftOf="@id/queen_text"
         app:layout_constraintTop_toTopOf="@id/queen_text"
         app:layout_constraintBottom_toBottomOf="@id/queen_text"/>
@@ -45,13 +44,11 @@
         android:layout_height="1dp"
         android:background="@android:color/darker_gray"
         android:id="@+id/dividing_line_1"
-
         android:layout_marginTop="8dp"
         android:layout_marginEnd="30dp"
         app:layout_constraintTop_toBottomOf="@id/queen_text"
         app:layout_constraintLeft_toLeftOf="@id/pawn_promotion_window"
         app:layout_constraintRight_toRightOf="@id/pawn_promotion_window"/>
-
 
     <TextView
         android:layout_width="wrap_content"
@@ -59,19 +56,17 @@
         android:id="@+id/bishop_text"
         android:text="@string/chess_promotion_bishop"
         android:textSize="20sp"
-
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/dividing_line_1"
         app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
 
-    <ImageView
+    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:srcCompat="@drawable/ic_info_black_24dp"
         android:id="@+id/bishop_icon"
+        android:textSize="20sp"
         android:contentDescription="@string/chess_promotion_bishop"
         android:layout_marginEnd="16dp"
-
         app:layout_constraintTop_toTopOf="@id/bishop_text"
         app:layout_constraintBottom_toBottomOf="@id/bishop_text"
         app:layout_constraintRight_toLeftOf="@id/bishop_text"/>
@@ -81,7 +76,6 @@
         android:layout_height="1dp"
         android:background="@android:color/darker_gray"
         android:id="@+id/dividing_line_2"
-
         android:layout_marginTop="8dp"
         android:layout_marginEnd="30dp"
         app:layout_constraintTop_toBottomOf="@id/bishop_text"
@@ -94,18 +88,17 @@
         android:id="@+id/knight_text"
         android:text="@string/chess_promotion_knight"
         android:textSize="20sp"
-
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/dividing_line_2"
         app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
 
-    <ImageView
+    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/knight_icon"
+        android:textSize="20sp"
         android:contentDescription="@string/chess_promotion_knight"
         android:layout_marginEnd="16dp"
-        app:srcCompat="@drawable/vd_help_black_24px"
         app:layout_constraintRight_toLeftOf="@id/knight_text"
         app:layout_constraintTop_toTopOf="@id/knight_text"
         app:layout_constraintBottom_toBottomOf="@id/knight_text"/>
@@ -128,18 +121,17 @@
         android:id="@+id/rook_text"
         android:text="@string/chess_promotion_rook"
         android:textSize="20sp"
-
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/dividing_line_3"
         app:layout_constraintLeft_toLeftOf="@id/queen_text"/>
 
-    <ImageView
+    <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/rook_icon"
+        android:textSize="20sp"
         android:contentDescription="@string/chess_promotion_rook"
         android:layout_marginEnd="16dp"
-        app:srcCompat="@drawable/vd_settings_black_24px"
         app:layout_constraintTop_toTopOf="@id/rook_text"
         app:layout_constraintBottom_toBottomOf="@id/rook_text"
         app:layout_constraintRight_toLeftOf="@id/rook_text"/>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -18,12 +18,13 @@
     <string name="PlayModeLocalMenuTitle">Play a friend</string>
     <string name="PlayModeUserMenuTitle">Play a User</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
+    <string name="PromotePawnMsg">Promote Your Pawn:</string>
     <string name="SignIn">Sign In</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>
+    <string name="StalemateMessage">Stalemate!</string>
     <string name="StartNewGame">Starting a new game.  Enjoy!</string>
     <string name="TicTacToeImageDesc">TicTacToe image.</string>
     <string name="TieMessage">Tie game!</string>
-    <string name="StalemateMessage">Stalemate!</string>
     <string name="TieMessageNotification">Well done players</string>
     <string name="WinMessageFormat">%1$s Wins!</string>
     <string name="WinMessageNotificationFormat">Congratulations %s, you win</string>
@@ -38,11 +39,10 @@
     <string name="oValue">O</string>
     <string name="player1">Player 1</string>
     <string name="player2">Player 2</string>
+    <string name="primaryTeam">primary</string>
+    <string name="secondaryTeam">secondary</string>
     <string name="turn">turn</string>
     <string name="vs">vs</string>
     <string name="wins">wins</string>
     <string name="xValue">X</string>
-    <string name="primaryTeam">primary</string>
-    <string name="secondaryTeam">secondary</string>
-    <string name="PromotePawnMsg">Promote Your Pawn:</string>
 </resources>


### PR DESCRIPTION
# Rationale
We changed the Chess board to use Unicode text rather than icons for the chess pieces. However, the "promote pawn" dialog was missed. This commit fixes it. And also cleans up a few nitty things.

## Files Changed

### app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
* Use some static imports to shorten some text lines (this is nit stuff).
* makeBoardButton(): change params to final

### app/src/main/java/com/pajato/android/gamechat/exp/CheckersFragment.java
* Use some static imports to shorten some text lines (this is nit stuff).
* makeBoardButton(): change params to final
* promotePawn(): use unicode characters in TextViews rather than icons in ImageViews for queen, bishop, rook and knight

### app/src/main/java/com/pajato/android/gamechat/exp/ChessPiece.java
* remove some unused imports
* make various Unicode values package public so they can be used by the promote-pawn dialog

### app/src/main/res/values/strings_exp.xml
* change ImageView objects to be TextView for each of the four options (queen, bishop, knight, rook)

### app/src/main/res/values/strings_exp.xml
* reorder entries to be alphabetical (NIT!!)
