### PR TITLE
Fix startup behavior so we get to a chat screen.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -173,7 +173,9 @@ public enum GroupManager {
         String groupKey = event.key;
         if (groupKey == null || event.group == null) return;
         groupMap.put(event.key, event.group);
-        for (String key : event.group.memberList) MemberManager.instance.setWatcher(groupKey, key);
+        for (String key : event.group.memberList) {
+            MemberManager.instance.setWatcher(groupKey, key);
+        }
     }
 
     /** Return a list of joined group push keys based on the given item. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
@@ -114,6 +114,7 @@ public enum MemberManager {
         // experience watcher on the joined rooms.
         if (event.member.id.equals(AccountManager.instance.getCurrentAccountId()))
             for (String roomKey : event.member.joinList) {
+                RoomManager.instance.setRoomProfileWatcher(event.member.groupKey, roomKey);
                 MessageManager.instance.setWatcher(event.member.groupKey, roomKey);
                 ExperienceManager.instance.setWatcher(event.member.groupKey, roomKey);
             }

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
@@ -43,8 +43,7 @@ import static com.pajato.android.gamechat.event.MessageChangeEvent.REMOVED;
  *
  * @author Paul Michael Reilly
  */
-public class ExperiencesChangeHandler extends DatabaseEventHandler
-        implements ChildEventListener {
+public class ExperiencesChangeHandler extends DatabaseEventHandler implements ChildEventListener {
 
     // Public constants.
 


### PR DESCRIPTION
# Rationale
Fix start up behavior so that we get to a chat screen. This broke recently.

## Files Changed
### app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
* getGroupProfilePath(): minor formatting change to enable better breakpoint setting

### app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
* getMembersPath(): call RoomManger to set database watcher for the room profile and the experience profiles in the room

### app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
* minor formatting change
