### PR TITLE
Normalize the database room manager and deal with a lint error.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,18 +14,13 @@ android {
         versionName "1.0-alpha"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled true
     }
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
-            // Run code coverage reports by default on debug builds.
-            minifyEnabled true
-            useProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testCoverageEnabled = true
         }
     }
@@ -39,10 +34,14 @@ android {
 
     lintOptions {
         disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'GradleDependency'
-        warning 'RestrictedApi', 'GradleCompatible'
+
+        warning 'RestrictedApi', 'GradleCompatible', 'InvalidPackage'
         abortOnError true
     }
 
+    dexOptions {
+        javaMaxHeapSize "4g"
+    }
 }
 
 gradle.projectsEvaluated {
@@ -56,6 +55,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha6'
+    compile 'com.android.support:multidex:1.0.1'
 
     // Google
     compile "com.google.android.gms:play-services-ads:$rootProject.ext.gmsVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@ http://www.gnu.org/licenses
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:name="android.support.multidex.MultiDexApplication">
         <provider
             android:authorities="com.pajato.fileprovider"
             android:name="android.support.v4.content.FileProvider"

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -50,7 +50,11 @@ public enum RoomManager {
     // Public class constants.
 
     // Database paths, often used as format strings.
+
+    /** The Firebase database path to the room objects. */
     public static final String ROOMS_PATH = GroupManager.GROUPS_PATH + "%s/rooms/";
+
+    /** The Firebase database path to the room profile object. */
     public static final String ROOM_PROFILE_PATH = ROOMS_PATH + "%s/profile/";
 
     // Private class constants.
@@ -67,13 +71,13 @@ public enum RoomManager {
 
     /** Return a room push key resulting from persisting the given room on the database. */
     public void createRoomProfile(final Room room) {
-        // Ensure that a valid group key exists.  Abort quietly (for now) if not.
-        // TODO: do something about a null group key.
+        // Ensure that the room is valid.  Abort if not, otherwise persist the room and set a
+        // watcher on it.
         if (room.groupKey == null || room.key == null) return;
-        setRoomProfileWatcher(room.groupKey, room.key);
         String profilePath = String.format(Locale.US, ROOM_PROFILE_PATH, room.groupKey, room.key);
         room.createTime = new Date().getTime();
         DBUtils.instance.updateChildren(profilePath, room.toMap());
+        setWatcher(room.groupKey, room.key);
     }
 
     /** Return the "Me" room or null if there is no such room for one reason or another. */
@@ -141,7 +145,7 @@ public enum RoomManager {
     }
 
     /** Setup database listeners for the room profile and the experience profiles in the room. */
-    public void setRoomProfileWatcher(final String groupKey, final String roomKey) {
+    public void setWatcher(final String groupKey, final String roomKey) {
         // Determine if the room has a profile change watcher.  If so, abort, if not, then set one.
         String path = RoomManager.instance.getRoomProfilePath(groupKey, roomKey);
         String name = DBUtils.instance.getHandlerName(ROOM_PROFILE_LIST_CHANGE_HANDLER, roomKey);


### PR DESCRIPTION
<h1>Rationale:</h1>

In purging ExpProfile, the room manager set*Watcher() was not renamed to setWatcher() to match the other database managers.  This commit corrects that.  Also, multidex support has been added and a lint error dealt with.

<h1>File changes:</h1>

modified:   app/build.gradle

- Summary: enable multidex support and remove (minify) proguard support.

modified:   app/src/main/AndroidManifest.xml

- Summary: enable multidex support.

modified:   app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java

- setRoomProfileWatcher(): rename to setWatcher to be consistent with other database managers.