### PR TITLE
Return to the existing fragment view after running intent.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpManager.java
@@ -114,6 +114,14 @@ public enum ExpManager {
         // identifies the group, room and the list of experience profiles.
         String roomKey = roomMap.keySet().iterator().next();
         List<Experience> experienceList = new ArrayList<>(roomMap.get(roomKey).values());
+
+        // If we have a signed in user with multiple experience in a single room and the current
+        // experience is one of the experiences in said room, just stick with it
+        if(experienceList.contains(exp)) {
+            ExpFragmentType type = ExpFragmentType.values()[mCurrentFragment];
+            return new Dispatcher<>(type, exp);
+        }
+
         if (experienceList.size() > 1)
             return new Dispatcher<>(expList, exp.getGroupKey(), roomKey, experienceList);
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpManager.java
@@ -117,7 +117,7 @@ public enum ExpManager {
 
         // If we have a signed in user with multiple experience in a single room and the current
         // experience is one of the experiences in said room, just stick with it
-        if(experienceList.contains(exp)) {
+        if (experienceList.contains(exp)) {
             ExpFragmentType type = ExpFragmentType.values()[mCurrentFragment];
             return new Dispatcher<>(type, exp);
         }


### PR DESCRIPTION
# Rationale
While developing/debugging the sending of invitations, I noticed that when I run the invitation intent from a game, after the intent returns, the screen changes away from the current game to the "no games" view. Instead, we want to preserve the selection of the current game.

## Files Changed
### app/src/main/java/com/pajato/android/gamechat/exp/ExpManager.java
* getDispatcher(): the code already determines that we have a signed in user with multiple experiences in a single room. Add a check to see if the current experience is one of the experiences in the list and if so, return a dispatcher for that fragment/experience, which means the view will not be changed (the user will return to the same view/experience that they left before starting the intent).