### PR TITLE
Fix commit errors in the previous commit that break chat page chaining.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -73,10 +73,10 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(createGroup, getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), createGroup, null);
                 break;
             case R.string.JoinRoomsMenuTitle:
-                DispatchManager.instance.chainFragment(joinRoom, getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);
                 break;
             default:
                 // ...

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -71,13 +71,13 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(createGroup, getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), createGroup, null);
                 break;
             case R.string.CreateRoomMenuTitle:
-                DispatchManager.instance.chainFragment(createRoom, getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), createRoom, null);
                 break;
             case R.string.JoinRoomsMenuTitle:
-                DispatchManager.instance.chainFragment(joinRoom, getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);
                 break;
             default:
                 // ...

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.common;
 
+import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.database.MessageManager;
@@ -95,11 +96,21 @@ public class Dispatcher {
             case messageList:
                 List<Message> list = MessageManager.instance.getMessageList(groupKey, roomKey);
                 messagePayload = list.size() > 0 ? list.get(0) : null;
+                key = messagePayload != null ? messagePayload.key : null;
                 break;
             case experienceList: // Handle a list of experiences in a room.
                 processExperienceList(groupKey, roomKey);
                 break;
             default: break;
+        }
+    }
+
+    /** Build an instance given a chat list item. */
+    public Dispatcher(FragmentType type, ChatListItem item) {
+        this.type = type;
+        if (item != null) {
+            groupKey = item.groupKey;
+            roomKey = item.key;
         }
     }
 
@@ -122,6 +133,9 @@ public class Dispatcher {
                 break;
             case 1: // A single experience in the room.
                 experiencePayload = experiences.iterator().next();
+                groupKey = experiencePayload.getGroupKey();
+                roomKey = experiencePayload.getRoomKey();
+                key = experiencePayload.getExperienceKey();
                 type = getFragmentType(experiencePayload.getExperienceType());
                 break;
             default: // Show a room list.
@@ -141,6 +155,9 @@ public class Dispatcher {
                 break;
             case 1: // There is exactly one experience of this type.  Use it.
                 experiencePayload = experienceList.get(0);
+                groupKey = experiencePayload.getGroupKey();
+                roomKey = experiencePayload.getRoomKey();
+                key = experiencePayload.getExperienceKey();
                 break;
             default: // There are multiple experiences of this type.  Present a list of
                 // them by changing the type to the corresponding list type.

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -101,10 +101,14 @@ public enum DBUtils {
     /** Get the list data given a list type. */
     public List<ChatListItem> getList(@NonNull final ChatListType type, final ChatListItem item) {
         switch (type) {
-            case group: return GroupManager.instance.getGroupListData();
-            case message: return MessageManager.instance.getMessageListData(item);
-            case room: return RoomManager.instance.getRoomListData(item.groupKey);
-            case joinRoom: return JoinManager.instance.getJoinableRoomsListData(item);
+            case group:
+                return GroupManager.instance.getGroupListData();
+            case message:
+                return MessageManager.instance.getMessageListData(item);
+            case room:
+                return RoomManager.instance.getRoomListData(item.groupKey);
+            case joinRoom:
+                return JoinManager.instance.getJoinableRoomsListData(item);
             default:
                 // TODO: log a message here.
                 break;


### PR DESCRIPTION
<h1>Rationale:</h1>

The previous commit broke the code that handles chat page chaining.  This commit fixes those errors.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): fix the case handling breakage.
- processPayload(): use the modified chainFragment() call.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

- onClick(): use the modified chainFragment() call.

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java

- chainFragment(): overhaul and add an argument to convey the item extracted from the list adapter.
- getDispatcher(): modify per the changes to chainFragment().

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- Dispatcher(): modify and add constructors to provide group and room keys where appropriate.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java

- Summary: cosmetic changes.