### PR TITLE
Refactor envelope fragments.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -50,9 +50,9 @@ import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;
 /**
  * Provide a fragment class that decides which alternative chat fragment to show to the User.
  *
- * @author Paul Michael Reilly (based on ExperienceFragment written by Bryan Scott)
+ * @author Paul Michael Reilly (based on ExpEnvelopeFragment written by Bryan Scott)
  */
-public class ChatFragment extends BaseChatFragment {
+public class ChatEnvelopeFragment extends BaseChatFragment {
 
     // Public constants.
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -18,7 +18,7 @@
 package com.pajato.android.gamechat.common;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.fragment.ChatFragment;
+import com.pajato.android.gamechat.chat.fragment.ChatEnvelopeFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowOfflineFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowSignedOutFragment;
@@ -37,7 +37,7 @@ import com.pajato.android.gamechat.exp.fragment.ExpShowOfflineFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowRoomsFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowSignedOutFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowTypeListFragment;
-import com.pajato.android.gamechat.exp.fragment.ExperienceFragment;
+import com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment;
 import com.pajato.android.gamechat.exp.fragment.ShowExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.ShowNoExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.TTTFragment;
@@ -52,14 +52,14 @@ import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.
  * @author Paul Michael Reilly
  */
 public enum FragmentType {
-    chatEnvelope (chat, ChatFragment.class),
+    chatEnvelope (chat, ChatEnvelopeFragment.class),
     chatGroupList (chat, ChatShowGroupsFragment.class, R.id.chatFragmentContainer),
     chatOffline (chat, ChatShowOfflineFragment.class, R.id.chatFragmentContainer),
     chatRoomList (chat, ChatShowRoomsFragment.class, R.id.chatFragmentContainer),
     chatSignedOut (chat, ChatShowSignedOutFragment.class, R.id.chatFragmentContainer),
     createGroup (chat, CreateGroupFragment.class, R.id.chatFragmentContainer),
     createRoom (chat, CreateRoomFragment.class, R.id.chatFragmentContainer),
-    expEnvelope (exp, ExperienceFragment.class),
+    expEnvelope (exp, ExpEnvelopeFragment.class),
     expGroupList (exp, ExpShowGroupsFragment.class, R.id.expFragmentContainer),
     expOffline (exp, ExpShowOfflineFragment.class, R.id.expFragmentContainer),
     expRoomList (exp, ExpShowRoomsFragment.class, R.id.expFragmentContainer),

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
@@ -51,7 +51,7 @@ import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
  * @author Bryan Scott
  * @author Paul Reilly
  */
-public class ExperienceFragment extends BaseExperienceFragment {
+public class ExpEnvelopeFragment extends BaseExperienceFragment {
 
     // Public constants.
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -33,7 +33,7 @@ import android.view.View;
 
 import com.pajato.android.gamechat.BuildConfig;
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.fragment.ChatFragment;
+import com.pajato.android.gamechat.chat.fragment.ChatEnvelopeFragment;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.credentials.CredentialsManager;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -43,7 +43,7 @@ import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
-import com.pajato.android.gamechat.exp.fragment.ExperienceFragment;
+import com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment;
 import com.pajato.android.gamechat.intro.IntroActivity;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -261,8 +261,8 @@ public class MainActivity extends BaseActivity
         // unregistered, Firebase will be turned off.
         List<String> list = new ArrayList<>();
         list.add(this.getClass().getName());
-        list.add(ChatFragment.class.getName());
-        list.add(ExperienceFragment.class.getName());
+        list.add(ChatEnvelopeFragment.class.getName());
+        list.add(ExpEnvelopeFragment.class.getName());
         AccountManager.instance.init(list);
         CredentialsManager.instance.init(getSharedPreferences(PREFS, Context.MODE_PRIVATE));
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -28,8 +28,8 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.fragment.ChatFragment;
-import com.pajato.android.gamechat.exp.fragment.ExperienceFragment;
+import com.pajato.android.gamechat.chat.fragment.ChatEnvelopeFragment;
+import com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,8 +63,8 @@ public enum PaneManager {
         titleList.clear();
         titleList.add(context.getString(R.string.ChatTitle));
         titleList.add(context.getString(R.string.game));
-        fragmentList.add(new ChatFragment());
-        fragmentList.add(new ExperienceFragment());
+        fragmentList.add(new ChatEnvelopeFragment());
+        fragmentList.add(new ExpEnvelopeFragment());
 
         // Determine if a paging layout is active.
         ViewPager viewPager = (ViewPager) context.findViewById(R.id.viewpager);


### PR DESCRIPTION
<h1>Rationale:</h1>

There are two key fragments in GameChat.  Each acts as an envelope in which all other fragments are essentially placed/parented.  This commit gives those two fragments names consistent with their roles, i.e. ChatEnvelopeFragment and ExpEnvelopeFragment.  No functional or feature changes are made in this commit.