### PR TITLE
UI Fixes

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -26,6 +26,8 @@ import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.chat.adapter.ChatListItem;
+import com.pajato.android.gamechat.chat.adapter.GroupItem;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.Dispatcher;
@@ -79,7 +81,8 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
             return;
         switch (event.item.getItemId()) {
             case R.id.nav_me_room:
-                DispatchManager.instance.startNextFragment(getActivity(), chatRoomList);
+                ChatListItem item = new ChatListItem(new GroupItem(AccountManager.instance.getMeGroup()));
+                DispatchManager.instance.chainFragment(getActivity(), chatRoomList, item);
                 break;
             case R.id.nav_groups:
                 DispatchManager.instance.startNextFragment(getActivity(), chatGroupList);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -17,8 +17,10 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.RadioGroup;
 
@@ -37,6 +39,7 @@ import com.pajato.android.gamechat.database.RoomManager;
 import java.util.ArrayList;
 import java.util.Locale;
 
+import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 import static com.pajato.android.gamechat.chat.model.Room.PUBLIC;
 
@@ -61,7 +64,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
         accessControl.setVisibility(View.GONE);
 
         EditText hint = (EditText) mLayout.findViewById(R.id.NameText);
-        hint.setText(R.string.CreateGroupNameHint);
+        hint.setHint(R.string.CreateGroupNameHint);
 
         // Create the group to be configure and, optionally, persisted.
         mGroup = new Group();
@@ -116,6 +119,14 @@ public class CreateGroupFragment extends BaseCreateFragment {
         // Post a welcome message to the default room from the owner.
         String text = "Welcome to my new group!";
         MessageManager.instance.createMessage(text, STANDARD, account, room);
+
+        // Dismiss the Keyboard and return to the previous fragment.
+        Activity a = getActivity();
+        InputMethodManager imm = (InputMethodManager) a.getSystemService(INPUT_METHOD_SERVICE);
+        if(imm.isAcceptingText() && a.getCurrentFocus() != null) {
+            imm.hideSoftInputFromWindow(a.getCurrentFocus().getWindowToken(), 0);
+        }
+        getActivity().onBackPressed();
     }
 
     /** Set the name of the managed object conditionally to the given value. */


### PR DESCRIPTION
# Rationale

A few updates to bring back the missing functionality for accessing the me room, and some bug fixes for making a group.

## Changed Files

### chat.ChatEnvelopeFragment
* We now call *chainFragment* instead of *startNextFragment* when navigating to the me room, which allows us to return back to where we came from when we decided to go to the me room.
* This also requires the creation of a ChatListItem, which is where we can introduce the specific group (the me group) that we want to be accessing.

### CreateGroupFragment
* Instead of changing the text in the group header, we change the *hint* to be more relevant to making a group, rather than making a room.
* When we save, we now correctly leave the fragment the first time the save button is pressed.
* We also dismiss the keyboard when leaving the create group screen.
* This resolves the problems in Issue #190