### PR TITLE
Refactor the protected user feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
@@ -206,7 +206,8 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         // Set the title and list text view content based on the given item.  Provide the item in
         // the view holder tag field.
         holder.name.setText(item.name);
-        holder.text.setText(CompatUtils.fromHtml(item.text));
+        if (item.text != null)
+            holder.text.setText(CompatUtils.fromHtml(item.text));
         setChatIcon(holder, item);
         holder.itemView.setTag(item);
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java
@@ -73,15 +73,16 @@ public class RoomItem {
         Map<String, Boolean> memberNameMap = new HashMap<>();
         Map<String, Map<String, Message>> rooms;
         rooms = MessageManager.instance.messageMap.get(groupKey);
-        for (Message message : rooms.get(roomKey).values()) {
-            // Ensure that the member who posted the message is in the member display name map.
-            String displayName = message.owner.equals(accountId) ? "me" : message.name;
-            if (!memberNameMap.containsKey(displayName)) memberNameMap.put(displayName, false);
-            if (message.unreadList != null && message.unreadList.contains(accountId)) {
-                memberNameMap.put(displayName, true);
-                count++;
+        if (rooms != null)
+            for (Message message : rooms.get(roomKey).values()) {
+                // Ensure that the member who posted the message is in the member display name map.
+                String displayName = message.owner.equals(accountId) ? "me" : message.name;
+                if (!memberNameMap.containsKey(displayName)) memberNameMap.put(displayName, false);
+                if (message.unreadList != null && message.unreadList.contains(accountId)) {
+                    memberNameMap.put(displayName, true);
+                    count++;
+                }
             }
-        }
 
         // Update the members text field by walking the members name map.
         for (String displayName : memberNameMap.keySet()) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -42,6 +42,7 @@ import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MemberChangeEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
+import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -98,7 +99,7 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                AccountManager.instance.mChaperoneUser = AccountManager.instance.getCurrentAccountId();
+                AccountManager.instance.mChaperone = AccountManager.instance.getCurrentAccountId();
                 FirebaseAuth.getInstance().signOut();
                 AccountManager.instance.signIn(getContext());
                 break;
@@ -149,6 +150,9 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
     @Override public void onStart() {
         // Declare the use of the options menu and intialize the FAB and it's menu.
         super.onStart();
+        String title = getString(R.string.SignInDialogTitleText);
+        String message = getString(R.string.SignInDialogMessageText);
+        ProgressManager.instance.show(this.getContext(), title, message);
         FabManager.chat.setTag(this.getTag());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -31,6 +31,7 @@ import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.DBUtils;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
+import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -114,8 +115,10 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
         // the group list display.
         super.onResume();
+        if (ProgressManager.instance.isShowing())
+            ProgressManager.instance.hide();
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
-        FabManager.chat.init(this);
+        FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
         FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 
@@ -127,8 +130,11 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         menu.add(getTintEntry(R.string.JoinRoomsMenuTitle, R.drawable.ic_casino_black_24dp));
         // TODO: add this when group selection is included:
         //menu.add(getTintEntry(R.string.CreateRoomMenuTitle, R.drawable.ic_casino_black_24dp));
-        if(AccountManager.instance.getCurrentAccount().chaperone == null) {
-            menu.add(getTintEntry(R.string.CreateGroupMenuTitle, R.drawable.ic_group_add_black_24dp));
+        if (!AccountManager.instance.isRestricted()) {
+            menu.add(getTintEntry(R.string.CreateGroupMenuTitle,
+                    R.drawable.ic_group_add_black_24dp));
+            menu.add(getTintEntry(R.string.CreateRestrictedUserTitle,
+                    R.drawable.ic_person_add_black_24px));
         }
         return menu;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -107,7 +107,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         // the group list display.
         super.onResume();
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
-        FabManager.chat.init(this);
+        FabManager.chat.init(this, CHAT_ROOM_FAM_KEY);
         FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.os.Bundle;
-import android.os.CountDownTimer;
 import android.support.annotation.NonNull;
 
 import com.pajato.android.gamechat.R;
@@ -49,11 +48,6 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
 
     /** The sign in floating action menu (FAM) key. */
     public static final String SIGN_IN_FAM_KEY = "signInFamKey";
-
-    // Public instance variables.
-
-    /** A timer to handle signin initialization. */
-    CountDownTimer mTimer;
 
     // Public instance methods.
 
@@ -94,7 +88,6 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
         // On the first chat list change event, dismiss the sign in progress spinner.  In any case
         // attempt to present another fragment based on the chat list change.
         if (ProgressManager.instance.isShowing()) {
-            mTimer.cancel();
             ProgressManager.instance.hide();
         }
         DispatchManager.instance.startNextFragment(this.getActivity(), chat);
@@ -106,10 +99,6 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
         // after 10 seconds.
         super.onCreate(bundle);
         super.setLayoutId(R.layout.fragment_chat_signed_out);
-        mTimer = new CountDownTimer(10000, 1000) {
-            @Override public void onTick(long millisUntilFinished) {}
-            @Override public void onFinish() { ProgressManager.instance.hide(); }
-        };
     }
 
     /** Handle the setup for the groups panel. */
@@ -117,10 +106,6 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
         // Provide an account loading indicator for a brief period before showing the fragment.
         // This will likely be enough time to load the account and message data.
         super.onStart();
-        mTimer.start();
-        String title = getString(R.string.SignInDialogTitleText);
-        String message = getString(R.string.SignInDialogMessageText);
-        ProgressManager.instance.show(this.getContext(), title, message);
         FabManager.chat.init(this);
         FabManager.chat.setMenu(SIGN_IN_FAM_KEY, getSignInMenu());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -87,7 +87,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
         return String.format(Locale.getDefault(), "%s %s", value, group);
     }
 
-    /** Save the room being created to the Firebase realtime database. */
+    /** Save the group being created to the Firebase realtime database. */
     @Override protected void save(@NonNull Account account) {
         // Generate push keys for new group and it's default room; set the self reference key and
         // the owner field values on the group.
@@ -121,12 +121,12 @@ public class CreateGroupFragment extends BaseCreateFragment {
         MessageManager.instance.createMessage(text, STANDARD, account, room);
 
         // Dismiss the Keyboard and return to the previous fragment.
-        Activity a = getActivity();
-        InputMethodManager imm = (InputMethodManager) a.getSystemService(INPUT_METHOD_SERVICE);
-        if(imm.isAcceptingText() && a.getCurrentFocus() != null) {
-            imm.hideSoftInputFromWindow(a.getCurrentFocus().getWindowToken(), 0);
-        }
-        getActivity().onBackPressed();
+        Activity activity = getActivity();
+        InputMethodManager manager;
+        manager = (InputMethodManager) activity.getSystemService(INPUT_METHOD_SERVICE);
+        if (manager.isAcceptingText() && activity.getCurrentFocus() != null)
+            manager.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        activity.onBackPressed();
     }
 
     /** Set the name of the managed object conditionally to the given value. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -81,6 +81,7 @@ import java.util.Map;
         this.name = name;
         this.owner = owner;
         this.type = type;
+        memberIdList.add(owner);
     }
 
     /** Provide a default map for a Firebase create/update. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.fragment.ChatShowRoomsFragment;
 import com.pajato.android.gamechat.common.adapter.MenuAdapter;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 
@@ -130,6 +131,12 @@ public enum FabManager {
         dismissMenu(fragment, layout);
     }
 
+    /** Initialize to use the given fragment and FAM. */
+    public void init(final Fragment fragment, final String name) {
+        this.init(fragment);
+        mDefaultMenuName = name;
+    }
+
     /** Set the named floating action menu (FAM) making it the default. */
     public void setMenu(@NonNull final String name, @NonNull final List<MenuEntry> menu) {
         // Test for a reasonable (non-empty) name.  Abort if not.
@@ -138,21 +145,6 @@ public enum FabManager {
         // Cache the menu and make it the default.
         mMenuMap.put(name, menu);
         mDefaultMenuName = name;
-    }
-
-    /** Set the current FAM using the cached item with the given name. */
-    private void setMenu(final Fragment fragment, final String name) {
-        // Ensure that the game fragment layout is accessible and that there is an adapter on the
-        // recycler view.  Abort quietly if not.
-        View layout = getFragmentLayout(fragment);
-        RecyclerView recyclerView;
-        recyclerView = layout != null ? (RecyclerView) layout.findViewById(R.id.MenuList) : null;
-        MenuAdapter adapter = recyclerView != null ? (MenuAdapter) recyclerView.getAdapter() : null;
-        if (layout == null || recyclerView == null || adapter == null) return;
-
-        // Add the menu to initialize the recycler view's data items.
-        adapter.clearEntries();
-        adapter.addEntries(mMenuMap.get(name));
     }
 
     /** Set the FAB state. */
@@ -274,4 +266,18 @@ public enum FabManager {
         return null;
     }
 
+    /** Set the current FAM using the cached item with the given name. */
+    private void setMenu(final Fragment fragment, final String name) {
+        // Ensure that the game fragment layout is accessible and that there is an adapter on the
+        // recycler view.  Abort quietly if not.
+        View layout = getFragmentLayout(fragment);
+        RecyclerView recyclerView;
+        recyclerView = layout != null ? (RecyclerView) layout.findViewById(R.id.MenuList) : null;
+        MenuAdapter adapter = recyclerView != null ? (MenuAdapter) recyclerView.getAdapter() : null;
+        if (layout == null || recyclerView == null || adapter == null) return;
+
+        // Add the menu to initialize the recycler view's data items.
+        adapter.clearEntries();
+        adapter.addEntries(mMenuMap.get(name));
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -56,11 +56,6 @@ import java.util.Map;
 
     // ? public final static int ADMIN = 1;
 
-    /** A STANDARD account has a real email address and uses encryption on messaging. */
-    public final static int STANDARD = 2;
-
-    /** A PROTECTED account has a fake email address and does not use encrypted messaging. */
-    public final static int PROTECTED = 3;
 
     // Public instance variables
 
@@ -100,10 +95,10 @@ import java.util.Map;
     public String nickname;
 
     /** The account provider id, a string like "google.com". */
-    public /*final*/ String providerId;
+    public String providerId;
 
     /** The account type. */
-    public /*final*/ int type;
+    public String type;
 
     /** The account photo URL (icon). */
     public String url;

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -126,7 +126,7 @@ public enum GroupManager {
     /** Return a name for the group with the given key, "Anonymous" if a name is not available. */
     public String getGroupName(final String groupKey) {
         Group group = groupMap.get(groupKey);
-        return group != null ? group.name : "Anonymous";
+        return group != null ? group.name : null;
     }
 
     /** Get the profile for a given group, queueing it up to be loaded if necessary. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java
@@ -84,7 +84,7 @@ public class AccountChangeHandler extends DatabaseEventHandler implements ValueE
         account.displayName = user.getDisplayName();
         account.url = getPhotoUrl(user);
         account.providerId = user.getProviderId();
-        account.type = Account.STANDARD;
+        account.type = AccountManager.AccountType.standard.name();
         account.createTime = tstamp;
 
         return account;

--- a/app/src/main/res/drawable/ic_person_add_black_24px.xml
+++ b/app/src/main/res/drawable/ic_person_add_black_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M15,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM6,10L6,7L4,7v3L1,10v2h3v3h2v-3h3v-2L6,10zM15,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"
+        android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/menu/drawer_body.xml
+++ b/app/src/main/res/menu/drawer_body.xml
@@ -19,8 +19,8 @@
             <group>
                 <item
                     android:id="@+id/manageProtectedUsers"
-                    android:title="@string/navigation_drawer_protected_user"
-                    android:icon="@drawable/ic_group_add_black_24dp" />
+                    android:title="@string/CreateRestrictedUserTitle"
+                    android:icon="@drawable/ic_person_add_black_24px" />
                 <item
                     android:id="@+id/manageAccounts"
                     android:title="@string/manage_accounts"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="CreateRestrictedUserTitle">Create Protected User</string>
     <string name="GridRoomIconRed">Red room icon</string>
     <string name="GridRoomIconBlue">Blue room icon</string>
     <string name="GridRoomIconGray">Gray room icon</string>
@@ -34,7 +35,6 @@
     <string name="navigation_drawer_action_close">Close navigation drawer</string>
     <string name="navigation_drawer_action_open">Open navigation drawer</string>
     <string name="navigation_drawer_account_management">Account Management</string>
-    <string name="navigation_drawer_protected_user">Add a Protected User</string>
     <string name="navigation_drawer_label_your_groups">Your Group List</string>
     <string name="navigation_drawer_label_your_room">Your Private Room</string>
     <string name="navigation_drawer_label_yours">Your Groups</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -38,7 +38,7 @@
     <string name="SelectRoomsMenuTitle">Select All Rooms</string>
     <string name="SetCreateIconFeature">Setting the create group or room icon</string>
     <string name="SetCreateIconDesc">Set the group or room icon</string>
-    <string name="SignInDialogTitleText">Attempting to sign in …</string>
+    <string name="SignInDialogTitleText">Logging in …</string>
     <string name="SignInDialogMessageText">Hold on a few moments while we sign you in …</string>
     <string name="SignInLastAccountMenuTitle">Use Current Account</string>
     <string name="SwitchAccountDesc">Switch account menu item.</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit basically adds a "create protected user" menu item in the chat FAB, change the menu text and menu icon.  Also, a few bugs have been fixed: the message unread list was not being created correctly for a new User and the delay mechanism created to hide the login spinner was not working correctly.

<h1>Rationale:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

- updateChatHolder(): guard against the text being null.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/adapter/RoomItem.java

- generateCountList(): guard agains the rooms being null.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java

- onClick(): use the renamed mChaperone variable.
- onStart(): handle the login progress spinner.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java

- onStart(): move the progress spinner handling to the chat envelope fragment.
- onResume(): use the new FAB manager API to explicitly set the FAM.
- getGroupMenu(): use the account manager convenience method isRestricted(); deal with long line formatting.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

- onResume(): use the new FAB manager API to explicitly set the FAM.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java

- Summary: lose the timer functionality and move the login progress spinner handling to the chat envelope fragment.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java

- save(): fix some, too, short names used in dismissing the keyboard.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

- Room(): ensure that the owner is in the member list.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- init(): add an overload that selects a menu.
- setMenu(): move per RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/common/model/Account.java

- type: make a string type.
- STANDARD, PROTECTED: lose now that type is tied to an enum.

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- AccountType: use this over the int constants.
- mChaperoneUser: rename to mChaperone.
- isRestricted(): new convenience method to handle restrictions for a protected User.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- getGroupName(): use null instead of anonymous to deal with the Me group.

modified:   app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java

- getAccount(): use the new enum AccountType.

new file:   app/src/main/res/drawable/ic_person_add_black_24px.xml

- Summary: add new icon for adding a protected user.

modified:   app/src/main/res/menu/drawer_body.xml

- Summary: change the create protected user menu text and icon.

modified:   app/src/main/res/values/strings.xml

- CreateRestrictedUserTitle: new string to define the create protected user menu title.
- navigation_drawer_protected_user: remove, now stale.

modified:   app/src/main/res/values/strings_chat.xml

- SignInDialogTitleTest: simplify.