### PR TITLE
Refactor database list item getters.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.common;
+
+/** Provide a singleton to manage the rooms panel fab button. */
+enum ToolbarManager {
+    instance;
+
+    // Public enums
+
+    /** The toolbar types. */
+    enum ToolbarType {
+        chatMain(),
+        chatChain(),
+        create(),
+        join(),
+        expMain(),
+        expChain();
+
+        // Instance variables.
+
+        /** The overflow menu icon resource id. */
+        int overflowMenuIconResourceId;
+
+        /** The overflow menu resource id. */
+        int overflowMenuResourceId;
+
+        /** The navigation icon resource id. */
+        int navigationIconResourceId;
+
+        /** The toolbar title resource id. */
+        int titleResourceId;
+
+        // Constructors.
+
+        /** Build a default instance. */
+        ToolbarType() {}
+    }
+
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = ToolbarManager.class.getSimpleName();
+
+    // Private instance variables.
+
+    // Sole Constructor.
+
+    /** Build the instance with the given resource ids. */
+    ToolbarManager() {}
+
+    // Public instance methods
+
+    // Private instance methods.
+}

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -102,13 +102,13 @@ public enum DBUtils {
     public List<ChatListItem> getList(@NonNull final ChatListType type, final ChatListItem item) {
         switch (type) {
             case group:         // Get the data to be shown in a list of groups.
-                return GroupManager.instance.getGroupListData();
+                return GroupManager.instance.getListItemData();
             case message:       // Get the data to be shown in a room.
-                return MessageManager.instance.getMessageListData(item);
+                return MessageManager.instance.getListItemData(item);
             case room:          // Get the data to be show in a list of rooms.
-                return RoomManager.instance.getRoomListData(item.groupKey);
+                return RoomManager.instance.getListItemData(item.groupKey);
             case joinRoom:      // Get the candidate list of rooms and members.
-                return JoinManager.instance.getJoinableRoomsListData(item);
+                return JoinManager.instance.getListItemData(item);
             default:
                 // TODO: log a message here.
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -105,7 +105,7 @@ public enum GroupManager {
     }
 
     /** Get the data as a set of list items for all groups. */
-    public List<ChatListItem> getGroupListData() {
+    public List<ChatListItem> getListItemData() {
         // Determine whether to handle no groups (a set of welcome list items), one group (a set of
         // group rooms) or more than one group (a set of groups).
         switch (groupMap.size()) {

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -78,8 +78,8 @@ public enum JoinManager {
         DBUtils.instance.updateChildren(path, member.toMap());
     }
 
-    /** Return a set of room the current user might choose to join. */
-    public List<ChatListItem> getJoinableRoomsListData(final ChatListItem item) {
+    /** Return a set of explicit (public) and implicit (member) rooms the current User can join. */
+    public List<ChatListItem> getListItemData(final ChatListItem item) {
         // Determine if there are any rooms to present (excludes joined rooms).
         List<ChatListItem> result = new ArrayList<>();
         result.addAll(getAvailableRooms(item));

--- a/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
@@ -131,7 +131,7 @@ public enum MessageManager {
     }
 
     /** Return a list of messages, an empty list if there are none to be had, for a given item. */
-    public List<ChatListItem> getMessageListData(@NonNull final ChatListItem item) {
+    public List<ChatListItem> getListItemData(@NonNull final ChatListItem item) {
         // Generate a map of date header types to a list of messages, i.e. a chronological ordering
         // of the messages.
         String groupKey = item.groupKey;

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -94,7 +94,7 @@ public enum RoomManager {
     }
 
     /** Get the data as a set of room items for a given group key. */
-    public List<ChatListItem> getRoomListData(final String groupKey) {
+    public List<ChatListItem> getListItemData(final String groupKey) {
         // Generate a list of items to render in the chat group list by extracting the items based
         // on the date header type ordering.
         Map<String, Map<String, Message>> roomMap;


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit continues the practice of making small edits (no functional changes) that enhance the app in some way.  In this case there are methods in the database managers that access list item data for list adapters.  Like the setWatcher() methods, these mthods have been given a normalized name, getListItemData().

Also in this push, the basic ToolbarManager class has been included.  It is not referenced but does reveal a design plan.