### PR TITLE
Fix broken "create room" feature. Work in progress on invites.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -175,6 +175,7 @@ public abstract class BaseChatFragment extends BaseFragment {
                 RoomItem roomItem = new RoomItem(dispatcher.groupKey, dispatcher.roomKey);
                 mItem = new ChatListItem(roomItem);
                 return true;
+            case createRoom:
             case chatRoomList:  // The rooms in a group need the group key.
                 GroupItem groupItem = new GroupItem(dispatcher.groupKey);
                 mItem = new ChatListItem(groupItem);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -49,9 +49,9 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.chatGroupList;
 import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;
+import static com.pajato.android.gamechat.common.FragmentType.selectGroupsAndRooms;
 
 /**
  * Provide a fragment class that decides which alternative chat fragment to show to the User.
@@ -104,7 +104,8 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 AccountManager.instance.signIn(getContext());
                 break;
             case R.id.inviteFriends:
-                InvitationManager.instance.extendAppInvitation(getActivity());
+                DispatchManager.instance.chainFragment(getActivity(), selectGroupsAndRooms, null);
+//                InvitationManager.instance.extendAppInvitation(getActivity());
                 break;
             default:
                 // Todo: add more menu button handling as a future feature.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -105,7 +105,6 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 break;
             case R.id.inviteFriends:
                 DispatchManager.instance.chainFragment(getActivity(), selectGroupsAndRooms, null);
-//                InvitationManager.instance.extendAppInvitation(getActivity());
                 break;
             default:
                 // Todo: add more menu button handling as a future feature.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -80,7 +80,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
                 DispatchManager.instance.chainFragment(getActivity(), createGroup, null);
                 break;
             case R.string.CreateRoomMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createRoom, null);
+                DispatchManager.instance.chainFragment(getActivity(), createRoom, mItem);
                 break;
             case R.string.JoinRoomsMenuTitle:
                 DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -17,7 +17,9 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.view.inputmethod.InputMethodManager;
 
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
@@ -30,6 +32,7 @@ import com.pajato.android.gamechat.database.MemberManager;
 import com.pajato.android.gamechat.database.MessageManager;
 import com.pajato.android.gamechat.database.RoomManager;
 
+import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 
 /**
@@ -99,6 +102,14 @@ public class CreateRoomFragment extends BaseCreateFragment {
         // Post a welcome message to the new room from the owner.
         String text = "Welcome to my new room!";
         MessageManager.instance.createMessage(text, STANDARD, account, mRoom);
+
+        // Dismiss the Keyboard and return to the previous fragment.
+        Activity activity = getActivity();
+        InputMethodManager manager;
+        manager = (InputMethodManager) activity.getSystemService(INPUT_METHOD_SERVICE);
+        if (manager.isAcceptingText() && activity.getCurrentFocus() != null)
+            manager.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        activity.onBackPressed();
     }
 
     /** Set the room name conditionally to the given value. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+package com.pajato.android.gamechat.chat.fragment;
+
+import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.common.ToolbarManager;
+
+import java.util.List;
+
+/**
+ * Provide a fragment class used to choose groups and rooms to include in an invite.
+ */
+
+public class SelectForInviteFragment extends BaseChatFragment {
+    // Private instance variables.
+
+    /** The groups selected. */
+    private List<Group> mGroups;
+
+    /** The groups selected. */
+    private List<Room> mRooms;
+
+    @Override public void onStart() {
+        // Establish the create type, the list type, setup the toolbar and turn off the access
+        // control.
+        super.onStart();
+        ToolbarManager.instance.init(this);
+
+        // Get a list of known groups?
+    }
+
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -106,7 +106,13 @@ import java.util.Map;
             case ME:
                 return account.getDisplayName();
             case PRIVATE:
-                return memberNames(account);
+                // if name is not set, try to get memberNames value
+                if (name == null || name.equals("")) {
+                    name = memberNames(account);
+                }
+                if (!name.equals("")) return name;
+                // when no other name is available, use account display name
+                return account.getDisplayName();
             default:
                 return name;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -156,6 +156,7 @@ public enum DispatchManager {
             case tictactoe:     // Handle an experience dispatch providing a type.
                 return new Dispatcher(type);
 
+            case createRoom:
             case messageList:
             case chatRoomList:  // Handle a chat dispatch providing both a type and an item.
                 return new Dispatcher(type, item);

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.chat.fragment.CreateGroupFragment;
 import com.pajato.android.gamechat.chat.fragment.CreateRoomFragment;
 import com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowGroupsFragment;
+import com.pajato.android.gamechat.chat.fragment.SelectForInviteFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowMessagesFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoJoinedRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoMessagesFragment;
@@ -80,6 +81,8 @@ public enum FragmentType {
     messageList (ShowMessagesFragment.class, chatChain, R.layout.fragment_chat_messages),
     noExperiences (ShowNoExperiencesFragment.class, chatMain, R.layout.fragment_game_no_games),
     noMessages (ShowNoMessagesFragment.class, chatMain, R.layout.fragment_chat_no_messages),
+    selectGroupsAndRooms (SelectForInviteFragment.class, chatChain,
+            R.layout.fragment_select_for_invite),
     showNoJoinedRooms (ShowNoJoinedRoomsFragment.class, chatChain,
                        R.layout.fragment_chat_no_joined_rooms),
     tictactoeList (ExpShowTypeListFragment.class, expMain, R.layout.fragment_chat_no_joined_rooms),
@@ -156,6 +159,7 @@ public enum FragmentType {
             case createRoom:
             case joinRoom:
             case messageList:
+            case selectGroupsAndRooms:
             case showNoJoinedRooms:
                 return chat;
             default:

--- a/app/src/main/res/layout/fragment_select_for_invite.xml
+++ b/app/src/main/res/layout/fragment_select_for_invite.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<!-- The main content for the fragment to select groups and rooms for invitations -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/emptyListContent"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:context="com.pajato.android.gamechat.main.MainActivity">
+        <android.support.design.widget.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay">
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                app:popupTheme="@style/AppTheme.PopupOverlay">
+            </android.support.v7.widget.Toolbar>
+        </android.support.design.widget.AppBarLayout>
+    </android.support.design.widget.CoordinatorLayout>
+
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        ads:adSize="SMART_BANNER"
+        ads:adUnitId="@string/banner_ad_unit_id"/>
+
+    <ImageView
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:tint="@color/colorRed"
+        android:contentDescription="@string/GridRoomIconRed"
+        app:srcCompat="@drawable/ic_casino_black_24dp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp"
+        android:text="@string/InviteFriends"
+        android:textAlignment="center"
+        android:textSize="24sp" />
+
+</LinearLayout>


### PR DESCRIPTION
# Rationale
Fix broken "create rooms" code, enabling comparison for development of fragment to select groups and rooms for invites.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
* onDispatch(): add createRoom case which preserves group identity

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* onClick(): for inviteFriends, open new (under construction) fragment to select groups and rooms

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
* onClick(): pass mItem when calling chainFragment

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* save(): dismiss keyboard after saving room

#### app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
* getName(): for a private room, make sure we have something to show for the name

#### app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
* getDispatcher(): add case for createRoom to create a valid dispatcher

####  app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
* add selectGroupsAndRooms fragment type
* getKind(): add case for selectGroupsAndRooms and return 'chat'

## New Files
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
* Fragment to handle selecting groups and rooms for invites. VERY much a work in progress - just scratched the surface so far.

#### app/src/main/res/layout/fragment_select_for_invite.xml
* Layout for the SelectForInviteFragment.  Also very much a placeholder as this is a work in progress.

