### PR TITLE
Add a toolbar to the default (no experiences) experience fragment.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -17,22 +17,51 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
+import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
+import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
+
 public class ExpShowGroupsFragment extends BaseExperienceFragment {
 
-    @Subscribe public void onClick(final ClickEvent event) {
-        // todo add some code here.
-        logEvent("onClick (showExpGroupList)");
+    // Public instance methods.
+
+    /** Handle an experience list change event. */
+    @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {
+        switch (event.changeType) {
+            case CHANGED:
+            case NEW:
+                DispatchManager.instance.startNextFragment(getActivity(), exp);
+                break;
+            default:
+                break;
+        }
     }
 
-    /** Initialize the fragment by setting in the FAB. */
+    /** Initialize the fragment by setting up the FAB and toolbar. */
     @Override public void onStart() {
         super.onStart();
         FabManager.game.init(this);
+        ToolbarManager.instance.init(this);
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
+        // the group list display.
+        super.onResume();
+        FabManager.game.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.game.init(this, GAME_HOME_FAM_KEY);
+        ToolbarManager.instance.setTitle(this, R.string.NoGamesTitleText);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
@@ -17,7 +17,10 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
+import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 
@@ -26,12 +29,13 @@ import org.greenrobot.eventbus.Subscribe;
 import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
+import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
 
 public class ShowNoExperiencesFragment extends BaseExperienceFragment {
 
     // Public instance methods.
 
-    /** Handle an experience profile list change event. */
+    /** Handle an experience list change event. */
     @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {
         switch (event.changeType) {
             case CHANGED:
@@ -41,5 +45,23 @@ public class ShowNoExperiencesFragment extends BaseExperienceFragment {
             default:
                 break;
         }
+    }
+
+    /** Initialize the fragment by setting up the FAB and toolbar. */
+    @Override public void onStart() {
+        super.onStart();
+        FabManager.game.init(this);
+        ToolbarManager.instance.init(this);
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
+        // the group list display.
+        super.onResume();
+        FabManager.game.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.game.init(this, GAME_HOME_FAM_KEY);
+        ToolbarManager.instance.setTitle(this, R.string.NoGamesTitleText);
     }
 }

--- a/app/src/main/res/layout/exp_toolbar_inc.xml
+++ b/app/src/main/res/layout/exp_toolbar_inc.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<!-- The main content for the no sign in fragment is a message imploring the User to sign in. -->
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:context="com.pajato.android.gamechat.main.MainActivity">
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/colorPink"
+            app:popupTheme="@style/AppTheme.PopupOverlay">
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/centeredTitle"
+                    android:textAlignment="center"
+                    android:textStyle="bold"
+                    android:textSize="22sp"
+                    tools:text="Some title..."/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/centeredSubtitle"
+                    android:textAlignment="center"
+                    android:textSize="18sp"
+                    tools:text="Some title..."/>
+            </LinearLayout>
+        </android.support.v7.widget.Toolbar>
+    </android.support.design.widget.AppBarLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_game_no_games.xml
+++ b/app/src/main/res/layout/fragment_game_no_games.xml
@@ -16,11 +16,14 @@ You should have received a copy of the GNU General Public License along with Gam
 http://www.gnu.org/licenses
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/init_panel">
+
+    <include layout="@layout/exp_toolbar_inc" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#0288D1</color>
     <color name="colorAccent">#8707ff</color>
+    <color name="colorPink">#FF4081</color>
     <color name="colorRed">#d50000</color>
     <color name="colorBlue">#3f51b5</color>
     <color name="colorGreen">#00c853</color>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -15,6 +15,7 @@
     <string name="NewGameCheckers">New Game (Checkers)</string>
     <string name="NewGameChess">New Game (Chess)</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
+    <string name="NoGamesTitleText">Games</string>
     <string name="PlayAgain">Play again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit breaks the ice for applying toolbars to the experience fragments.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java

- ToolbarType: flesh out the experience constant arguments, expMain and expChain.
- ToolbarType(): add a single arg constructor to handle expMain.
- init(): use a switch statement for more flexibility.
- setTitle(): provide an interface for centering a resource id specified title.
- setTitles(): ensure that the experience overload checks for a null experience.
- setupNonHomeToolbar(): rename to setupToolbar(); handle an empty/unspecified nav icon.
- update(): new method that handles centered titles in the style of the standard Toolbar class.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java

- Summary: temporary copy of the default no experience code to facilitate experience toolbar development.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java

- onStart(): new method to handle initialization.
- onResume(): new method to handle the FAB and the toolbar.

new file:   app/src/main/res/layout/exp_toolbar_inc.xml

- Summary: the default experience toolbar for handling "special" fragments like signed out, offline, no experiences, etc.

modified:   app/src/main/res/layout/fragment_game_no_games.xml

- Summary: utilize the new experience toolbar include.

modified:   app/src/main/res/values/colors.xml

- Summary: add a pink color to neutralize the two panes along a "boy/girl" color line.  Experimental.

modified:   app/src/main/res/values/strings_exp.xml

- NoGamesTitleText: new localized resource.