### PR TITLE
Fixes for various 'join room' issues. Correctly tint icon for sending invitations.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -176,7 +176,10 @@ public abstract class BaseChatFragment extends BaseFragment {
                 mItem = new ChatListItem(roomItem);
                 return true;
             case createRoom:
+            case joinRoom:
             case chatRoomList:  // The rooms in a group need the group key.
+                if (dispatcher.groupKey == null)
+                    return false;
                 GroupItem groupItem = new GroupItem(dispatcher.groupKey);
                 mItem = new ChatListItem(groupItem);
                 return true;
@@ -214,8 +217,10 @@ public abstract class BaseChatFragment extends BaseFragment {
             mAdView.resume();
         if (type != null)
             switch (type) {
+                case joinRoom:
                 case chatGroupList:
                 case chatRoomList:
+                case selectGroupsAndRooms:
                 case messageList:   // Update the state of the list adapter.
                     updateAdapterList();
                     break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java
@@ -223,9 +223,17 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
         // Set the check box using the item selection state.
         if (holder.checkBox == null) return;
         holder.checkBox.setChecked(item.selected);
+        holder.checkBox.setTag(item);
     }
 
     // Inner classes.
+
+    private class ChatListCheckBoxClickListener implements View.OnClickListener {
+        public void onClick(View v) {
+            // Perform action on click
+            AppEventManager.instance.post(new ClickEvent(v));
+        }
+    }
 
     /** Provide a view holder for a chat list item. */
     private class ChatListViewHolder extends RecyclerView.ViewHolder {
@@ -243,6 +251,9 @@ public class ChatListAdapter extends RecyclerView.Adapter<ViewHolder>
             text = (TextView) itemView.findViewById(R.id.chatText);
             icon = (ImageView) itemView.findViewById(R.id.chatIcon);
             checkBox = (CheckBox) itemView.findViewById(R.id.selectorCheck);
+            if (checkBox != null) {
+                checkBox.setOnClickListener(new ChatListCheckBoxClickListener());
+            }
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -82,7 +82,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
                 DispatchManager.instance.chainFragment(getActivity(), createRoom, mItem);
                 break;
             case R.string.JoinRoomsMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);
+                DispatchManager.instance.chainFragment(getActivity(), joinRoom, mItem);
                 break;
             case R.string.InviteFriendFromChat:
                 InvitationManager.instance.extendAppInvitation(getActivity(), mItem.groupKey);
@@ -118,7 +118,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         if(AccountManager.instance.getCurrentAccount().chaperone == null) {
             menu.add(getTintEntry(R.string.CreateGroupMenuTitle, R.drawable.ic_group_add_black_24dp));
         }
-        menu.add(getNoTintEntry(R.string.InviteFriendFromChat, R.drawable.ic_email_black_24dp));
+        menu.add(getTintEntry(R.string.InviteFriendFromChat, R.drawable.ic_email_black_24dp));
         return menu;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -103,7 +104,8 @@ public class CreateGroupFragment extends BaseCreateFragment {
 
         // Create and persist the default (common) room.
         Room room = new Room(roomKey, mGroup.owner, "Common", groupKey, 0, 0, PUBLIC);
-        room.memberIdList.add(account.id);
+        Log.i(CreateGroupFragment.class.getSimpleName(), "******** adding " + account.id + " to room " + room.key);
+        room.addMember(account.id);
         RoomManager.instance.createRoomProfile(room);
 
         // Create and persist a member object to the database joined to the default room.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -104,7 +103,6 @@ public class CreateGroupFragment extends BaseCreateFragment {
 
         // Create and persist the default (common) room.
         Room room = new Room(roomKey, mGroup.owner, "Common", groupKey, 0, 0, PUBLIC);
-        Log.i(CreateGroupFragment.class.getSimpleName(), "******** adding " + account.id + " to room " + room.key);
         room.addMember(account.id);
         RoomManager.instance.createRoomProfile(room);
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -88,7 +88,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
     @Override protected void save(@NonNull Account account) {
         // Persist the configured room.
         mRoom.key = RoomManager.instance.getRoomKey(mGroup.key);
-        mRoom.memberIdList.add(account.id);
+        mRoom.addMember(account.id);
         RoomManager.instance.createRoomProfile(mRoom);
 
         // Update and persist the group adding the new room to it's room list.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -21,7 +21,6 @@ import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.CheckBox;
-import android.widget.LinearLayout;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
@@ -79,15 +78,13 @@ public class JoinRoomsFragment extends BaseChatFragment {
                 // Implement the save operation.
                 for (ChatListItem item : mJoinMap.values())
                     JoinManager.instance.joinRoom(item);
+                mJoinMap.clear();
                 DispatchManager.instance.startNextFragment(getActivity(), chat);
                 break;
-            default: // Determine if the view might be a click on a list view row.  Abort if not,
-                     // look for a checkbox if so and if that is found, process the selection.
-                if (!(event.view instanceof LinearLayout))
-                    return;
-                CheckBox checkBox = (CheckBox) event.view.findViewById(R.id.selectorCheck);
-                if (checkBox != null)
-                    processSelection(event, checkBox);
+            case R.id.selectorCheck:
+                processSelection(event, (CheckBox) event.view);
+                break;
+            default:
                 break;
         }
     }
@@ -149,7 +146,7 @@ public class JoinRoomsFragment extends BaseChatFragment {
 
     /** Process a selection by toggling the selected state and managing the item map. */
     private void processSelection(@NonNull final ClickEvent event, @NonNull final CheckBox checkBox) {
-        // Set the check icon visility and get the item object from the event payload.
+        // Set the check icon visibility and get the item object from the event payload.
         ChatListItem item = null;
         Object payload = event.view != null ? event.view.getTag() : null;
         if (payload != null && payload instanceof ChatListItem) item = (ChatListItem) payload;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
@@ -41,8 +41,21 @@ public class SelectForInviteFragment extends BaseChatFragment {
         // control.
         super.onStart();
         ToolbarManager.instance.init(this);
+//        FabManager.chat.setMenu(CHAT_GROUP_FAM_KEY, getGroupMenu());
 
-        // Get a list of known groups?
+
+
+    }
+
+    /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
+        // the group list display.
+        super.onResume();
+//        FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
+//        FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
+//        FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -157,6 +157,7 @@ public enum DispatchManager {
                 return new Dispatcher(type);
 
             case createRoom:
+            case joinRoom:
             case messageList:
             case chatRoomList:  // Handle a chat dispatch providing both a type and an item.
                 return new Dispatcher(type, item);

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -115,7 +115,8 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         mMessageMap.clear();
         mMessageMap.put(R.string.HasJoinedMessage, context.getString(R.string.HasJoinedMessage));
     }
-        /** Handle an account state change by updating the navigation drawer header. */
+
+    /** Handle an account state change by updating the navigation drawer header. */
     @Subscribe
     public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         Account account = event != null ? event.account : null;
@@ -143,13 +144,13 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
 
     /** Handle the room profile change */
     @Subscribe public void onRoomProfileChange(@NonNull final ProfileRoomChangeEvent event) {
-        // If this room is in the mInvitedGroups list, add the current account to the room memberIdList.
+        // If this room is in the invite list, add the current account to the room member list.
         Account currAccount = AccountManager.instance.getCurrentAccount();
         if (currAccount == null) return;
         for (Map.Entry<String, GroupInviteData> entry : mInvitedGroups.entrySet()) {
             GroupInviteData data = entry.getValue();
             if (data.commonRoomKey.equals(event.key)) {
-                event.room.memberIdList.add(currAccount.id);
+                event.room.addMember(currAccount.id);
                 RoomManager.instance.updateRoomProfile(event.room);
                 data.addedToCommRoomMemberList = true;
                 mInvitedGroups.put(entry.getKey(), data);
@@ -311,11 +312,10 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
             return;
         }
 
-        // Extract deep link from Intent
+        // Extract deep link from Intent. If no deep link exists, just log and return
         Intent intent = result.getInvitationIntent();
         String deepLink = AppInviteReferral.getDeepLink(intent);
         Log.i(TAG, "getInvitation with deepLink: " + deepLink);
-        // If deep link doesn't exist, just log and return
         if (deepLink == null || deepLink.equals("")) {
             Log.e(TAG, "getInvitation: can't get group key - deepLink is not set");
             return;

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -172,8 +172,13 @@ public enum GroupManager {
             return;
         for (String key : event.group.memberList)
             MemberManager.instance.setWatcher(groupKey, key);
-        if (!groupKey.equals(AccountManager.instance.getMeGroupKey()))
+        if (!groupKey.equals(AccountManager.instance.getMeGroupKey())) {
             groupMap.put(event.key, event.group);
+            // if this isn't the me group, add watchers for all the rooms
+            for (String roomKey : event.group.roomList) {
+                RoomManager.instance.setWatcher(groupKey, roomKey);
+            }
+        }
     }
 
     /** Return a list of joined group push keys based on the given item. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
@@ -106,7 +106,7 @@ public enum MessageManager {
         String url = type == SYSTEM ? systemUrl : account.url;
         long tstamp = new Date().getTime();
         List<String> members = new ArrayList<>();
-        members.addAll(room.memberIdList);
+        members.addAll(room.getMemberIdList());
         Message message = new Message(key, account.id, name, url, tstamp, text, type, members);
 
         // Persist the message.

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.database;
 
 import android.support.annotation.NonNull;
 
+import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.chat.adapter.DateHeaderItem;

--- a/app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
@@ -11,5 +11,7 @@ public class GroupJoinedEvent {
     public String groupName;
 
     /** Build the event and indicate the specified group (or null) */
-    public GroupJoinedEvent(String grp) { groupName = grp; }
+    public GroupJoinedEvent(String groupName) {
+        this.groupName = groupName;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
@@ -169,7 +169,7 @@ public class ExpEnvelopeFragment extends BaseExperienceFragment {
         menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
         menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getNoTintEntry(R.string.InviteFriendFromExpEnv, R.drawable.ic_email_black_24dp));
+        menu.add(getTintEntry(R.string.InviteFriendFromExpEnv, R.drawable.ic_email_black_24dp));
         return menu;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -337,7 +337,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
         menu.add(getTintEntry(R.string.MyRooms, R.drawable.ic_casino_black_24dp));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_tictactoe_red));
-        menu.add(getNoTintEntry(R.string.InviteFriendFromTTT, R.drawable.ic_email_black_24dp));
+        menu.add(getTintEntry(R.string.InviteFriendFromTTT, R.drawable.ic_email_black_24dp));
         return menu;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -42,6 +42,7 @@ import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.credentials.CredentialsManager;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.DBUtils;
+import com.pajato.android.gamechat.database.JoinManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -308,6 +309,7 @@ public class MainActivity extends BaseActivity
         NetworkManager.instance.init(this);
         PaneManager.instance.init(this);
         InvitationManager.instance.init(this);
+        JoinManager.instance.init(this);
         NavigationManager.instance.init(this, (Toolbar) findViewById(R.id.toolbar));
     }
 

--- a/app/src/main/res/layout/select_for_invite.xml
+++ b/app/src/main/res/layout/select_for_invite.xml
@@ -52,12 +52,12 @@ http://www.gnu.org/licenses
         ads:adSize="SMART_BANNER"
         ads:adUnitId="@string/banner_ad_unit_id"/>
 
-    <ImageView
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:tint="@color/colorRed"
-        android:contentDescription="@string/GridRoomIconRed"
-        app:srcCompat="@drawable/ic_casino_black_24dp" />
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/chatList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp"
+        android:tag="@integer/groupList"/>
 
     <TextView
         android:layout_width="match_parent"


### PR DESCRIPTION
# Rationale
While developing invitations, a number of 'join room' bugs were encountered. Also noted that the various menu items for sending invitations had a black icon, rather than a properly tinted icon.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

* onDispatch(): add a case for 'joinRoom' type and also check for null groupKey value to avoid null pointer exception.

* redisplay(): add case for 'joinRoom' type and 'selectGroupsAndRooms'. The latter is incomplete work for invites.

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

* updateChatHolder(): set the checkBox tag value which is expected in later processing

* class ChatListCheckBoxClickListener: new inner class to handle clicks on the checkBox and post a ClickEvent. (Because anonymous classes are yucko).

* class ChatListViewHolder constructor: if the checkBox exists, add a click listener to it.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

* onClick(): when handling "join rooms", pass "mItem" to chainFragment()
* getRoomMenu(): set proper tint for invitation menu item icon

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java

* use accessor method for Room member list

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java

* use accessor method for Room member list

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java

* onClick(): after 'save' handling is complete, clear the mJoinMap so we don't have detritus on the next join function. Also, use a specific case for the R.id.selectorCheck value, rather than hiding it under the 'default' case.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java

* This can be ignored as it was some evolving thoughts (totally incomplete) while fiddling with invites. Much more to come.

#### app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

* Make the memberIdList private and provide access (and Firebase usage) through the various (new) accessors.  The purpose of this is to enforce a check which prevents duplicate copies of a member Id from being added to the list.  Note that Firebase appears to need the "get" and "set" methods when the member variable is private. Add setMemberIdList(), getMemberIdList(), addMember(): new accessor methods.

* isMemberPrivateRoom(): new method to determine if a room is a private, member-to-member (1x1) chat room.

* getName(): some nitty reformatting and rewriting of comment

#### app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java

* getDispatcher(): add case for 'joinRoom' type

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java

* onRoomProfileChange(): use Room's new accessor method for adding the account Id to the member list, since the list is now private.
* Nits: rewrite of some comments

#### app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

* onGroupProfileChange(): if this group isn't the "me" group, add listeners for all rooms (the "me" group is handled differently). This makes it possible to present a list of all rooms to a user for the "join" function.

#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java

* Add an init() function which obtains the necessary messages (currently only one) since later this class doesn't have access to a context to obtain locale-specific strings.
* Change joinMember and joinRoom return Room objects rather than room keys. This allows the addition of sending a message to the room indicating that a new user has joined.
* joinRoom(): deal with Room object rather than roomKey returned from joinMember and joinRooms. Send message to newly joined room.
* getJoinableRooms(): check for null room returned and log error.
* getAvailableMembers(): if an existing private member-to-member room already exists in the room map, don't present it as an option to the user.

#### app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
* createMessage(): use Room's new accessor method for getting room  member list, since the list is now private.

#### app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
* Remove unused import

#### app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
* nitty reformat of constructor.


#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
* Fix invitation menu item to use proper tint

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
* Fix invitation menu item to use proper tint

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* init(): call JoinManager's init method

#### app/src/main/res/layout/select_for_invite.xml
* work in progress

