### PR TITLE
Invitation work: add fragment to handle room / group selection for invitations

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -54,7 +54,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
     /** The current create type. */
     protected CreateType mCreateType;
 
-    /** Set the room or group type. */
+    /** Set the room type. */
     protected abstract void setType(final RoomType type);
 
     // Public instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -26,7 +26,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.model.Account;
@@ -38,6 +38,8 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.PRIVATE;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.PUBLIC;
 
 /** Provide a base class for fragments that create something. */
 public abstract class BaseCreateFragment extends BaseChatFragment {
@@ -53,7 +55,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
     protected CreateType mCreateType;
 
     /** Set the room or group type. */
-    protected abstract void setType(final int type);
+    protected abstract void setType(final RoomType type);
 
     // Public instance methods.
 
@@ -88,11 +90,11 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
                 break;
 
             case R.id.PublicButton:
-                setType(Room.PUBLIC);
+                setType(PUBLIC);
                 break;
 
             case R.id.PrivateButton:
-                setType(Room.PRIVATE);
+                setType(PRIVATE);
                 break;
 
             default:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
@@ -37,6 +37,9 @@ public class ChatListItem {
     static final int ROOMS_HEADER_ITEM_TYPE = 6;
     public static final int SELECTABLE_MEMBER_ITEM_TYPE = 7;
     public static final int SELECTABLE_ROOM_ITEM_TYPE = 8;
+    public static final int INVITE_ROOM_ITEM_TYPE = 9;
+    public static final int INVITE_GROUP_ITEM_TYPE = 10;
+    public static final int INVITE_COMMON_ROOM_ITEM_TYPE = 11;
 
     // Public enums
 
@@ -65,6 +68,9 @@ public class ChatListItem {
 
     /** The item selection state. */
     public boolean selected;
+
+    /** The item enabled state */
+    public boolean enabled;
 
     /** The item type, always non-null. */
     public int type;
@@ -178,6 +184,45 @@ public class ChatListItem {
         text = item.text;
         String format = "Selectable room item with name {%s} and text: {%s}.";
         mDesc = String.format(Locale.US, format, name, text);
+        enabled = true;
+    }
+
+    /** Build an instance for a room item used for invitations */
+    public ChatListItem(final InviteRoomItem item) {
+        type = INVITE_ROOM_ITEM_TYPE;
+        groupKey = item.groupKey;
+        key = item.roomKey;
+        name = item.name;
+        text = item.text;
+        String format = "Selectable room item with name {%s} and text: {%s}.";
+        mDesc = String.format(Locale.US, format, name, text);
+        enabled = true;
+    }
+
+    /** Build an instance for a common room item where selection is reflected but never enabled */
+    public ChatListItem(final CommonRoomItem item) {
+        type = INVITE_COMMON_ROOM_ITEM_TYPE;
+        groupKey = item.groupKey;
+        key = item.roomKey;
+        name = item.name;
+        text = item.text;
+        String format = "Common room item with name {%s} and text: {%s}.";
+        mDesc = String.format(Locale.US, format, name, text);
+        enabled = false;
+    }
+
+    /**
+     * Build an instance for a given selectable group
+     */
+    public ChatListItem(final SelectableGroupItem item) {
+        type = INVITE_GROUP_ITEM_TYPE;
+        groupKey = item.groupKey;
+        key = item.groupKey;
+        name = item.name;
+        text = "";
+        String format = "Selectable group item with name {%s}.";
+        mDesc = String.format(Locale.US, format, name);
+        enabled = true;
     }
 
     // Public instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/CommonRoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/CommonRoomItem.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+package com.pajato.android.gamechat.chat.adapter;
+
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.database.GroupManager;
+import com.pajato.android.gamechat.database.RoomManager;
+
+/**
+ * Provide a POJO to encapsulate a recycler view list item that presents common rooms for join and
+ * invite operations.
+ */
+public class CommonRoomItem {
+
+    // Public instance variables.
+
+    /** The group key */
+    public String groupKey;
+
+    /** The room key. */
+    public String roomKey;
+
+    /** The room name. */
+    public String name;
+
+    /** The list of group members with messages.  Bold items are associated with new messages. */
+    String text;
+
+    // Public constructors.
+
+    /** Build an instance for the given group. */
+    public CommonRoomItem(final String groupKey, final String roomKey) {
+        // Generate the name value (the room name) and the text value (the group name).
+        this.groupKey = groupKey;
+        this.roomKey = roomKey;
+        Room room = RoomManager.instance.getRoomProfile(roomKey);
+        name = room.name;
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        text = group != null ? group.name : "";
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/CommonRoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/CommonRoomItem.java
@@ -19,8 +19,8 @@ import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.RoomManager;
 
 /**
- * Provide a POJO to encapsulate a recycler view list item that presents common rooms for join and
- * invite operations.
+ * Provide a POJO to encapsulate a recycler view list item that presents common rooms for
+ * invitations.
  */
 public class CommonRoomItem {
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/InviteRoomItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/InviteRoomItem.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+package com.pajato.android.gamechat.chat.adapter;
+
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.database.GroupManager;
+import com.pajato.android.gamechat.database.RoomManager;
+
+/**
+ * Provide a POJO to encapsulate a recycler view list item: one that allows rooms to be selected for
+ * invitations.
+ */
+
+public class InviteRoomItem {
+
+    // Public instance variables.
+
+    /** The group key */
+    public String groupKey;
+
+    /** The room key. */
+    public String roomKey;
+
+    /** The room name. */
+    public String name;
+
+    /** Group name. */
+    String text;
+
+    // Public constructors.
+
+    /** Build an instance for the given group. */
+    public InviteRoomItem(final String groupKey, final String roomKey) {
+        // Generate the name value (the room name) and the text value (the group name).
+        this.groupKey = groupKey;
+        this.roomKey = roomKey;
+        Room room = RoomManager.instance.getRoomProfile(roomKey);
+        name = room.name;
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        text = group != null ? group.name : "";
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/adapter/SelectableGroupItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/adapter/SelectableGroupItem.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+
+package com.pajato.android.gamechat.chat.adapter;
+
+import com.pajato.android.gamechat.chat.model.Group;
+import com.pajato.android.gamechat.database.GroupManager;
+
+/**
+ * Provide a POJO to encapsulate a recycler view list item: one that allows a group to be
+ * selected.
+ */
+
+public class SelectableGroupItem {
+
+    // public instance varaibles
+
+    /** the group key */
+    public String groupKey;
+
+    /** the group name */
+    public String name;
+
+    /** Build an instance for a given group */
+    public SelectableGroupItem(final String groupKey) {
+        this.groupKey = groupKey;
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        name = group.name;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -41,7 +42,7 @@ import java.util.Locale;
 
 import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
-import static com.pajato.android.gamechat.chat.model.Room.PUBLIC;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.COMMON;
 
 public class CreateGroupFragment extends BaseCreateFragment {
 
@@ -102,7 +103,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
         GroupManager.instance.createGroupProfile(mGroup);
 
         // Create and persist the default (common) room.
-        Room room = new Room(roomKey, mGroup.owner, "Common", groupKey, 0, 0, PUBLIC);
+        Room room = new Room(roomKey, mGroup.owner, "Common", groupKey, 0, 0, COMMON);
         room.addMember(account.id);
         RoomManager.instance.createRoomProfile(room);
 
@@ -133,5 +134,5 @@ public class CreateGroupFragment extends BaseCreateFragment {
     @Override protected void setName(final String value) {if (mGroup != null) mGroup.name = value;}
 
     /** Implement the set type as a nop. */
-    @Override protected void setType(final int type) {}
+    @Override protected void setType(final RoomType type) {}
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -24,6 +24,7 @@ import android.view.inputmethod.InputMethodManager;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -79,7 +80,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
         mRoom.name = getDefaultName();
         mRoom.groupKey = mGroup.key;
         mRoom.owner = mMember.id;
-        mRoom.type = Room.PUBLIC;
+        mRoom.type = RoomType.PUBLIC;
     }
 
     // Protected instance methods.
@@ -116,5 +117,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
     @Override protected void setName(final String value) {if (mRoom != null) mRoom.name = value;}
 
     /** Implement the set type. */
-    @Override protected void setType(final int type) {mRoom.type = type;}
+    @Override protected void setType(final RoomType type) {
+        mRoom.type = type;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
@@ -16,47 +16,257 @@
  */
 package com.pajato.android.gamechat.chat.fragment;
 
-import com.pajato.android.gamechat.chat.BaseChatFragment;
-import com.pajato.android.gamechat.chat.model.Group;
-import com.pajato.android.gamechat.chat.model.Room;
-import com.pajato.android.gamechat.common.ToolbarManager;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.CheckBox;
 
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.chat.adapter.ChatListAdapter;
+import com.pajato.android.gamechat.chat.adapter.ChatListItem;
+import com.pajato.android.gamechat.common.DispatchManager;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.InvitationManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.common.adapter.MenuEntry;
+import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.TagClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.pajato.android.gamechat.chat.adapter.ChatListItem.INVITE_COMMON_ROOM_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.ChatListItem.INVITE_GROUP_ITEM_TYPE;
+import static com.pajato.android.gamechat.chat.adapter.ChatListItem.INVITE_ROOM_ITEM_TYPE;
+import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
 
 /**
  * Provide a fragment class used to choose groups and rooms to include in an invite.
  */
 
 public class SelectForInviteFragment extends BaseChatFragment {
+
+    // Public constants.
+
+    /** The lookup key for the FAB chat selection memu. */
+    public static final String INVITE_SELECTION_FAM_KEY = "inviteSelectionFamKey";
+
     // Private instance variables.
 
     /** The groups selected. */
-    private List<Group> mGroups;
+    private Set<ChatListItem> mSelectedGroups = new HashSet<>();
 
     /** The groups selected. */
-    private List<Room> mRooms;
+    private Set<ChatListItem> mSelectedRooms = new HashSet<>();
+
+    // Public instance methods.
+
+    /** Provide subscriber to listen for click events. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        if (event == null || event.view == null)
+            return;
+
+        switch (event.view.getId()) {
+            case R.id.inviteButton:
+                // Handle the invitation
+                InvitationManager.instance.extendAppInvitation(getActivity(), getSelections());
+                mSelectedGroups.clear();
+                mSelectedRooms.clear();
+                DispatchManager.instance.startNextFragment(getActivity(), chat);
+                break;
+            case R.id.selectorCheck:
+                processSelection(event, (CheckBox) event.view);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** Process a menu click event ... */
+    @Subscribe public void onClick(final TagClickEvent event) {
+        Object payload = event.view.getTag();
+        if (payload == null || !(payload instanceof MenuEntry)) return;
+
+        // The event represents a menu entry.  Close the FAM and case on the title id.
+        FabManager.chat.dismissMenu(this);
+        MenuEntry entry = (MenuEntry) payload;
+        switch (entry.titleResId) {
+            case R.string.SelectAllMenuTitle:
+                updateSelections(true);
+                break;
+            case R.string.ClearSelectionsMenuTitle:
+                updateSelections(false);
+                break;
+            default:
+                break;
+
+        }
+    }
 
     @Override public void onStart() {
         // Establish the create type, the list type, setup the toolbar and turn off the access
         // control.
         super.onStart();
         ToolbarManager.instance.init(this);
-//        FabManager.chat.setMenu(CHAT_GROUP_FAM_KEY, getGroupMenu());
-
-
-
+        FabManager.chat.setMenu(INVITE_SELECTION_FAM_KEY, getSelectionMenu());
     }
 
     /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
     @Override public void onResume() {
         // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
-        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
-        // the group list display.
+        // FAM is not and the FAM is set to the home chat menu.
         super.onResume();
-//        FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
-//        FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
-//        FabManager.chat.setVisibility(this, View.VISIBLE);
+        FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.chat.init(this);
+        FabManager.chat.setVisibility(this, View.VISIBLE);
+
+        // Clear selections - is this the correct place to do this (onResume)??????
+        mSelectedGroups.clear();
+        mSelectedRooms.clear();
     }
 
+    // Private instance methods
+
+    /** Return the home FAM used in the top level show games and show no games fragments. */
+    private List<MenuEntry> getSelectionMenu() {
+        final List<MenuEntry> menu = new ArrayList<>();
+        menu.add(getTintEntry(R.string.SelectAllMenuTitle, R.drawable.ic_done_all_black_24dp));
+        menu.add(getTintEntry(R.string.ClearSelectionsMenuTitle, R.drawable.ic_clear_black_24dp));
+        return menu;
+    }
+
+    /** Process a selection */
+    private void processSelection(@NonNull final ClickEvent event, @NonNull final CheckBox checkBox) {
+        // Set the checkbox visibility and get the item object from the event payload.
+        ChatListItem clickedItem = null;
+        Object payload = event.view != null ? event.view.getTag() : null;
+        if (payload != null && payload instanceof ChatListItem) clickedItem = (ChatListItem) payload;
+        if (clickedItem == null) return;
+
+        // Toggle the selection state and operate accordingly on the selected items lists.
+        clickedItem.selected = !clickedItem.selected;
+        checkBox.setChecked(clickedItem.selected);
+
+        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.chatList);
+        ChatListAdapter adapter = (ChatListAdapter) view.getAdapter();
+        List <ChatListItem> adapterList = adapter.getItems();
+
+        // If the item is a group, then if it's selected, also select it's common room. If it's
+        // deselected, deselect all of it's rooms.
+        if (clickedItem.type == INVITE_GROUP_ITEM_TYPE) {
+            if (clickedItem.selected)
+                mSelectedGroups.add(clickedItem);
+            else
+                mSelectedGroups.remove(clickedItem);
+
+            for (ChatListItem adapterItem : adapterList) {
+                switch (adapterItem.type) {
+                    case INVITE_COMMON_ROOM_ITEM_TYPE:
+                        if (adapterItem.groupKey.equals(clickedItem.key)) {
+                            adapterItem.selected = clickedItem.selected;
+                            if(clickedItem.selected) {
+                                mSelectedRooms.add(adapterItem);
+                            } else {
+                                mSelectedRooms.remove(adapterItem);
+                            }
+                        }
+                        break;
+                    case INVITE_ROOM_ITEM_TYPE:
+                        if (adapterItem.groupKey.equals(clickedItem.key) && !clickedItem.selected) {
+                            adapterItem.selected = false;
+                            mSelectedRooms.remove(adapterItem);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+        } else if (clickedItem.type == INVITE_ROOM_ITEM_TYPE) {
+            // if the item is a room, and it's selection is enabled, make sure to also enable
+            // the group and the group's common room.
+            if (clickedItem.selected) {
+                mSelectedRooms.add(clickedItem);
+                for (ChatListItem adapterItem : adapterList) {
+                    if (adapterItem.type == INVITE_GROUP_ITEM_TYPE &&
+                            adapterItem.key.equals(clickedItem.groupKey)) {
+                        mSelectedGroups.add(adapterItem);
+                        adapterItem.selected = true;
+                    }
+                    else if (adapterItem.type == INVITE_COMMON_ROOM_ITEM_TYPE &&
+                            adapterItem.groupKey.equals(clickedItem.groupKey)) {
+                        adapterItem.selected = true;
+                        mSelectedRooms.add(adapterItem);
+                    }
+                }
+            } else {
+                mSelectedRooms.remove(clickedItem);
+            }
+        }
+
+        adapter.notifyDataSetChanged();
+
+        // Set the 'invite' button enabled or disabled based on whether there are selections
+        updateSendInviteButton();
+    }
+
+    /** Called from FAM click handling */
+    private void updateSelections(final boolean state) {
+        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.chatList);
+        ChatListAdapter adapter = (ChatListAdapter) view.getAdapter();
+        List <ChatListItem> itemList = adapter.getItems();
+
+        // Select all or clear all items, depending on 'state'. Update all items in the adapter
+        // and set group and room lists accordingly.
+        mSelectedGroups.clear();
+        mSelectedRooms.clear();
+
+        for (ChatListItem item : itemList) {
+            item.selected = state;
+            switch (item.type) {
+                case INVITE_GROUP_ITEM_TYPE:
+                    if (state)
+                        mSelectedGroups.add(item);
+                    break;
+                case INVITE_ROOM_ITEM_TYPE:
+                case INVITE_COMMON_ROOM_ITEM_TYPE:
+                    if (state)
+                        mSelectedRooms.add(item);
+                    break;
+                default:
+                    break;
+            }
+        }
+        adapter.notifyDataSetChanged();
+
+        // Set the 'invite' button enabled or disabled based on whether there are selections
+        updateSendInviteButton();
+    }
+
+    /** Update the invite button state based on the current join map content. */
+    private void updateSendInviteButton() {
+        View inviteButton = mLayout.findViewById(R.id.inviteButton);
+        inviteButton.setEnabled(mSelectedGroups.size() > 0 || mSelectedRooms.size() > 0);
+    }
+
+    private Map<String, List<String>> getSelections() {
+        Map<String, List<String>> selections = new HashMap<>();
+        for (ChatListItem groupItem : mSelectedGroups) {
+            selections.put(groupItem.key, new ArrayList<String>());
+        }
+        for (ChatListItem roomItem : mSelectedRooms) {
+            List<String> rooms = selections.get(roomItem.groupKey);
+            rooms.add(roomItem.key);
+            selections.put(roomItem.groupKey, rooms);
+        }
+        return selections;
+    }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -35,15 +35,12 @@ import java.util.Map;
 public class Room {
 
     // The room types.
-
-    /** A room no one can join. */
-    public final static int ME = 0;
-
-    /** A room for two or more members by implicit or explicit invitation. */
-    public final static int PRIVATE = 1;
-
-    /** A room in which any User can join. */
-    public final static int PUBLIC = 2;
+    public enum RoomType {
+        ME, // a room no one can join
+        PRIVATE, // a room for two or more members by implicit or explicit invitation
+        PUBLIC, // a room in which any user can join
+        COMMON // the 'general' room for a group; all group members are joined automatically
+    }
 
     /** The creation timestamp. */
     public long createTime;
@@ -67,14 +64,14 @@ public class Room {
     public String owner;
 
     /** The room type, one of "public", "private" or "me". */
-    public int type;
+    public RoomType type;
 
     /** Build an empty args constructor for the database. */
     public Room() {}
 
     /** Build a default room. */
     public Room(final String key, final String owner, final String name, final String groupKey,
-                final long createTime, final long modTime, final int type) {
+                final long createTime, final long modTime, final RoomType type) {
         this.createTime = createTime;
         this.groupKey = groupKey;
         this.key = key;
@@ -119,7 +116,7 @@ public class Room {
 
     /** Determine if this room is a member-to-member chat room */
     @Exclude public boolean isMemberPrivateRoom(final String member1, final String member2) {
-        return (this.type == Room.PRIVATE && memberIdList.size() == 2 &&
+        return (this.type == RoomType.PRIVATE && memberIdList.size() == 2 &&
                 memberIdList.contains(member1) && memberIdList.contains(member2));
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -159,6 +159,7 @@ public enum DispatchManager {
             case createRoom:
             case joinRoom:
             case messageList:
+            case selectGroupsAndRooms:
             case chatRoomList:  // Handle a chat dispatch providing both a type and an item.
                 return new Dispatcher(type, item);
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -57,6 +57,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.expC
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.expMain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.joinRoomTT;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.none;
+import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.selectInviteTT;
 import static com.pajato.android.gamechat.exp.ExpType.ttt;
 
 /**
@@ -82,7 +83,7 @@ public enum FragmentType {
     messageList (ShowMessagesFragment.class, chatChain, R.layout.chat_messages),
     noExperiences (ShowNoExperiencesFragment.class, chatMain, R.layout.exp_none),
     noMessages (ShowNoMessagesFragment.class, chatMain, R.layout.chat_no_messages),
-    selectGroupsAndRooms (SelectForInviteFragment.class, chatChain, R.layout.select_for_invite),
+    selectGroupsAndRooms (SelectForInviteFragment.class, selectInviteTT, R.layout.select_for_invite),
     showNoJoinedRooms (ShowNoJoinedRoomsFragment.class, chatChain, R.layout.chat_no_joined_rooms),
     tictactoeList (ExpShowTypeListFragment.class, expMain, R.layout.chat_no_joined_rooms),
     tictactoe (TTTFragment.class, expChain, R.layout.exp_ttt, ttt, tictactoeList),

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -31,6 +32,12 @@ import com.google.android.gms.appinvite.AppInviteReferral;
 import com.google.android.gms.common.api.ResultCallback;
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.adapter.ChatListItem;
+import com.pajato.android.gamechat.chat.adapter.CommonRoomItem;
+import com.pajato.android.gamechat.chat.adapter.InviteRoomItem;
+import com.pajato.android.gamechat.chat.adapter.ResourceHeaderItem;
+import com.pajato.android.gamechat.chat.adapter.SelectableGroupItem;
+import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -55,6 +62,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.COMMON;
 
 /**
  * Handle invitations to groups.
@@ -223,6 +231,30 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         DBUtils.instance.updateChildren(path, group.toMap());
     }
 
+    /** Extend an invitation to join GameChat using AppInviteInvitation and specify a map of
+     *  groups and their rooms to join (always has at least the Common room). */
+    public void extendAppInvitation(final FragmentActivity fragmentActivity,
+                                    final Map<String, List<String>> keys) {
+        Log.i(TAG, "extendAppInvitation with list of keys");
+
+        Uri dynLinkUri = buildDefaultDynamicLink();
+
+        // add a "group" item to the dynamic link for each group specified
+        for(String groupKey : keys.keySet()) {
+            String encodedInfo = encodeGroupInfo(groupKey, keys.get(groupKey));
+            if (!encodedInfo.equals(""))
+                dynLinkUri.buildUpon().appendQueryParameter("group", encodedInfo);
+        }
+        String dynamicLink = dynLinkUri.toString();
+        Log.i(TAG, "dynamicLink=" + dynamicLink);
+
+        Intent intent = new AppInviteInvitation.IntentBuilder(fragmentActivity.getString(R.string.InviteTitle))
+                .setMessage(fragmentActivity.getString(R.string.InviteMessage))
+                .setDeepLink(Uri.parse(dynamicLink))
+                .build();
+        fragmentActivity.startActivityForResult(intent, MainActivity.RC_INVITE);
+    }
+
     /** Extend a group invite to a given account by registering both. */
     public void extendGroupInvite(@NonNull final Account account, @NonNull final String groupKey) {
         // Insert the account id into the list associated with the group key.
@@ -249,20 +281,18 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         return true;
     }
 
-    /** Extend an invitation to join GameChat using AppInviteInvitation Intent */
-    public void extendAppInvitation(final FragmentActivity fragmentActivity) {
-        String firebaseUrl = FirebaseDatabase.getInstance().getReference().toString();
-        String dynamicLink = new Uri.Builder()
-                .scheme("https")
-                .authority(APP_CODE + ".app.goo.gl")
-                .path("/")
-                .appendQueryParameter("link", firebaseUrl)
-                .appendQueryParameter("apn", APP_PACKAGE_NAME)
-                .appendQueryParameter("afl", PLAY_STORE_LINK)
-                .appendQueryParameter("ifl", WEB_LINK)
-                .toString();
+    /** Extend an invitation to join GameChat using AppInviteInvitation and specify a group to join. */
+    public void extendAppInvitation(final FragmentActivity fragmentActivity, final String groupKey) {
 
+        Log.i(TAG, "extendAppInvitation with groupKey=" + groupKey);
+
+        Uri dynLinkUri = buildDefaultDynamicLink();
+
+        String encodedInfo = encodeGroupInfo(groupKey, null);
+        dynLinkUri.buildUpon().appendQueryParameter("group", encodedInfo);
+        String dynamicLink = dynLinkUri.toString();
         Log.i(TAG, "dynamicLink=" + dynamicLink);
+
         Intent intent = new AppInviteInvitation.IntentBuilder(fragmentActivity.getString(R.string.InviteTitle))
                 .setMessage(fragmentActivity.getString(R.string.InviteMessage))
                 .setDeepLink(Uri.parse(dynamicLink))
@@ -270,39 +300,41 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         fragmentActivity.startActivityForResult(intent, MainActivity.RC_INVITE);
     }
 
-    /** Extend an invitation to join GameChat using AppInviteInvitation and specify a group to join. */
-    public void extendAppInvitation(final FragmentActivity fragmentActivity, final String groupKey) {
-
-        Log.i(TAG, "extendAppInvitation with groupKey=" + groupKey);
-        Group grp = GroupManager.instance.getGroupProfile(groupKey);
-        if (grp == null) {
-            Log.e(TAG, "Received invitation with groupKey: " + groupKey + " but GroupManager " +
-                    "can't find this group");
-            return;
-        }
-
+    private Uri buildDefaultDynamicLink() {
         String firebaseUrl = FirebaseDatabase.getInstance().getReference().toString();
-        firebaseUrl += GroupManager.GROUPS_PATH;
-        firebaseUrl += groupKey;
-
-        String dynamicLink = new Uri.Builder()
+        return new Uri.Builder()
                 .scheme("https")
                 .authority(APP_CODE + ".app.goo.gl")
                 .path("/")
                 .appendQueryParameter("link", firebaseUrl)
                 .appendQueryParameter("apn", APP_PACKAGE_NAME)
                 .appendQueryParameter("afl", PLAY_STORE_LINK)
-                .appendQueryParameter("ifl", WEB_LINK)
-                .appendQueryParameter("commonRoomKey", grp.commonRoomKey)
-                .appendQueryParameter("groupName", grp.name)
-                .toString();
+                .appendQueryParameter("ifl", WEB_LINK).build();
+    }
 
-        Log.i(TAG, "dynamicLink=" + dynamicLink);
-        Intent intent = new AppInviteInvitation.IntentBuilder(fragmentActivity.getString(R.string.InviteTitle))
-                .setMessage(fragmentActivity.getString(R.string.InviteMessage))
-                .setDeepLink(Uri.parse(dynamicLink))
-                .build();
-        fragmentActivity.startActivityForResult(intent, MainActivity.RC_INVITE);
+    private String encodeGroupInfo(final String groupKey, List<String> roomKeys) {
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        if (group == null) {
+            Log.e(TAG, "Received invitation with groupKey: " + groupKey + " but GroupManager " +
+                    "can't find this group");
+            return "";
+        }
+
+        // If no roomkeys were specified, get the common room key - we must always have it
+        if (roomKeys == null) {
+            roomKeys = new ArrayList<>();
+            roomKeys.add(group.commonRoomKey);
+        }
+
+        // make a list of items we need to encode into our URI for this group
+        List<String> items = new ArrayList<>();
+        items.add(groupKey);
+        items.add(group.name);
+        // add a comma-separated list of room keys for the specified group to the list
+        items.add(TextUtils.join(",", roomKeys));
+
+        // Create a string like this: groupKey/groupName/commonRoomKey[,roomkey...]
+        return TextUtils.join("/", items);
     }
 
     public void onResult(@NonNull AppInviteInvitationResult result) {
@@ -347,4 +379,40 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         mInvitedGroups.put(groupKey, new GroupInviteData(groupName, commonRoomKey));
     }
 
+    /** Return a set of explicit (public) and implicit (member) rooms the current User can join. */
+    public List<ChatListItem> getListItemData() {
+        // Determine if there are any rooms to present (excludes joined rooms).
+        List<ChatListItem> result = new ArrayList<>();
+        result.addAll(getSelectItems());
+        if (result.size() > 0) return result;
+
+        // There is nothing to join.  Provide a header message to that effect.
+        result.add(new ChatListItem(new ResourceHeaderItem(R.string.NoSelectableItemsHeaderText)));
+        return result;
+    }
+
+    /**
+     * Return a list of items which represent the available groups and their rooms.
+     */
+    private List<ChatListItem> getSelectItems() {
+        // Determine if there are groups to look at.  If not, return an empty result.
+        List<ChatListItem> result = new ArrayList<>();
+        if (GroupManager.instance.groupMap.size() == 0) {
+            result.add(new ChatListItem(new ResourceHeaderItem(R.string.NoSelectableItemsHeaderText)));
+            return result;
+        }
+
+        for (Map.Entry<String, Group> entry : GroupManager.instance.groupMap.entrySet()) {
+            result.add(new ChatListItem(new SelectableGroupItem(entry.getKey())));
+            List<Room> rooms = RoomManager.instance.getRooms(entry.getKey(), true);
+            for (Room aRoom : rooms) {
+                if (aRoom.type == COMMON)
+                    result.add(new ChatListItem(new CommonRoomItem(aRoom.groupKey, aRoom.key)));
+                else
+                    result.add(new ChatListItem(new InviteRoomItem(aRoom.groupKey, aRoom.key)));
+            }
+        }
+
+        return result;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -379,14 +379,13 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         mInvitedGroups.put(groupKey, new GroupInviteData(groupName, commonRoomKey));
     }
 
-    /** Return a set of explicit (public) and implicit (member) rooms the current User can join. */
+    /** Return a set of groups and rooms for invitations */
     public List<ChatListItem> getListItemData() {
-        // Determine if there are any rooms to present (excludes joined rooms).
         List<ChatListItem> result = new ArrayList<>();
-        result.addAll(getSelectItems());
+        result.addAll(getInviteItems());
         if (result.size() > 0) return result;
 
-        // There is nothing to join.  Provide a header message to that effect.
+        // There is nothing available for invitations.  Provide a header message to that effect.
         result.add(new ChatListItem(new ResourceHeaderItem(R.string.NoSelectableItemsHeaderText)));
         return result;
     }
@@ -394,7 +393,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
     /**
      * Return a list of items which represent the available groups and their rooms.
      */
-    private List<ChatListItem> getSelectItems() {
+    private List<ChatListItem> getInviteItems() {
         // Determine if there are groups to look at.  If not, return an empty result.
         List<ChatListItem> result = new ArrayList<>();
         if (GroupManager.instance.groupMap.size() == 0) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -35,6 +35,7 @@ import com.pajato.android.gamechat.main.MainActivity;
 import com.pajato.android.gamechat.main.NavigationManager;
 
 import static android.view.Menu.NONE;
+import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.selectInviteTT;
 
 /** Provide a singleton to manage the rooms panel fab button. */
 public enum ToolbarManager {
@@ -95,6 +96,8 @@ public enum ToolbarManager {
         expChain (R.drawable.ic_more_vert_white_24dp, R.drawable.ic_arrow_back_white_24dp),
         joinRoomTT (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp,
                 R.string.JoinRoomsMenuTitle),
+        selectInviteTT(R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp,
+                R.string.PickForInvitationTitle),
         none ();
 
         // Instance variables.
@@ -142,14 +145,14 @@ public enum ToolbarManager {
 
     // Private instance variables.
 
-    /** The standard overlow item click handler that posts an app event. */
+    /** The standard overflow item click handler that posts an app event. */
     private final OverflowMenuItemHandler mOverflowMenuItemClickHandler;
 
     // Sole Constructor.
 
     /** Build the instance with the given resource ids. */
     ToolbarManager() {
-        // Create the overflowm menu item click handler.
+        // Create the overflow menu item click handler.
         mOverflowMenuItemClickHandler = new OverflowMenuItemHandler();
     }
 
@@ -164,7 +167,7 @@ public enum ToolbarManager {
         if (toolbar == null || toolbarType == null)
             return;
         switch (toolbarType) {
-            case chatMain: // Setup the group (home) toolbar using the naviation manager.
+            case chatMain: // Setup the group (home) toolbar using the navigation manager.
                 NavigationManager.instance.init(fragment.getActivity(), toolbar);
                 break;
             case none:
@@ -228,6 +231,10 @@ public enum ToolbarManager {
                            // name, if one is available.
                 int resId = toolbarType.titleResourceId;
                 setTitles(fragment, bar, resId, item);
+                break;
+            case selectInviteTT:
+                int resourceId = toolbarType.titleResourceId;
+                setTitles(fragment, bar, resourceId, item);
                 break;
             case chatMain:
             case chatChain:     // Set the title and subtitle based on the item content.

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -47,7 +47,6 @@ import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.AuthenticationChangeHandled;
 import com.pajato.android.gamechat.event.ClickEvent;
-import com.pajato.android.gamechat.event.GroupJoinedEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
 import com.pajato.android.gamechat.event.RegistrationChangeEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
@@ -63,7 +62,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
-import static com.pajato.android.gamechat.chat.model.Room.ME;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.ME;
 import static com.pajato.android.gamechat.event.RegistrationChangeEvent.REGISTERED;
 
 /**

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -24,6 +24,7 @@ import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.common.FragmentType;
+import com.pajato.android.gamechat.common.InvitationManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,6 +66,8 @@ public enum DBUtils {
                 return RoomManager.instance.getListItemData(item.groupKey);
             case joinRoom:      // Get the candidate list of rooms and members.
                 return JoinManager.instance.getListItemData(item);
+            case selectGroupsAndRooms:
+                return InvitationManager.instance.getListItemData();
             default:
                 // TODO: log a message here.
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -40,7 +40,9 @@ import java.util.Map;
 
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
-import static com.pajato.android.gamechat.chat.model.Room.PRIVATE;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.COMMON;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.PRIVATE;
+import static com.pajato.android.gamechat.chat.model.Room.RoomType.PUBLIC;
 
 /**
  * Provide a fragment to handle the display of the rooms available to the current user.
@@ -125,7 +127,7 @@ public enum JoinManager {
                 Room room = RoomManager.instance.roomMap.get(roomKey);
                 if (room == null)
                     Log.e(TAG, "RoomManager roomMap doesn't contain roomKey " + roomKey);
-                else if (room.type == Room.PUBLIC)
+                else if (room.type == PUBLIC || room.type == COMMON)
                     result.add(roomKey);
             }
         return result;

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -23,6 +23,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.chat.adapter.ChatListItem;
 import com.pajato.android.gamechat.chat.adapter.DateHeaderItem;
+import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.adapter.RoomItem;
 import com.pajato.android.gamechat.chat.model.Message;
 import com.pajato.android.gamechat.chat.model.Room;
@@ -39,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import static com.pajato.android.gamechat.R.string.Group;
 
 /**
  * Provide a class to manage database access to Room objects.
@@ -99,6 +102,21 @@ public enum RoomManager {
     public String getRoomKey(final String groupKey) {
         String roomsPath = String.format(Locale.US, ROOMS_PATH, groupKey);
         return FirebaseDatabase.getInstance().getReference().child(roomsPath).push().getKey();
+    }
+
+    /** Return a list of rooms for a specified group, optionally excluding the common room */
+    public List<Room> getRooms(final String groupKey, final boolean includeCommonRoom) {
+        List<Room> rooms = new ArrayList<>();
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        if (group == null) return rooms;
+        for (String roomKey : group.roomList) {
+            if (!includeCommonRoom && roomKey.equals(group.commonRoomKey)) {
+                continue;
+            }
+            Room aRoom = RoomManager.instance.getRoomProfile(roomKey);
+            rooms.add(aRoom);
+        }
+        return rooms;
     }
 
     /** Get the data as a set of room items for a given group key. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
@@ -189,7 +190,8 @@ public class CheckersFragment extends BaseExperienceFragment {
         // Determine the second account, if any, based on the room.
         String key = dispatcher.roomKey;
         Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
-        int type = room != null ? room.type : -1;
+        if (room == null) return players;
+
         switch (type) {
             //case MEMBER:
             // Handle another User by providing their account.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Room;
+import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
@@ -178,7 +179,8 @@ public class ChessFragment extends BaseExperienceFragment {
         // Determine the second account, if any, based on the room.
         String key = dispatcher.roomKey;
         Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
-        int type = room != null ? room.type : -1;
+        if (room == null) return players;
+
         switch (type) {
             //case MEMBER:
             // Handle another User by providing their account.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -214,7 +214,8 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         // Determine the second account, if any, based on the room.
         String key = dispatcher.roomKey;
         Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
-        int type = room != null ? room.type : -1;
+        if (room == null) return players;
+
         switch (type) {
             //case MEMBER:
             // Handle another User by providing their account.

--- a/app/src/main/res/drawable/ic_people_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_people_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3zM8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5C6.34,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5L1,19h14v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45L17,19h6v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5z"/>
+</vector>

--- a/app/src/main/res/layout/item_select_for_invites.xml
+++ b/app/src/main/res/layout/item_select_for_invites.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+        <CheckBox style="@style/ChatListItemSelector" android:id="@+id/selectorCheck" />
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+            android:tint="@color/colorPrimaryDark"
+            android:contentDescription="@string/RoomListIcon"
+            app:srcCompat="@drawable/ic_people_black_24dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+                tools:text="My Group Name"/>
+        </LinearLayout>
+    </LinearLayout>
+    <View style="@style/ChatListItemFooter" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_select_invites_room.xml
+++ b/app/src/main/res/layout/item_select_invites_room.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+        <CheckBox style="@style/InviteRoomItemSelector" android:id="@+id/selectorCheck" />
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+            android:tint="@color/colorPrimaryDark"
+            android:contentDescription="@string/RoomListIcon"
+            app:srcCompat="@drawable/ic_casino_black_24dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+                tools:text="Fred C. Jones"/>
+            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+                tools:text="The Jones Boys Group" />
+        </LinearLayout>
+    </LinearLayout>
+    <View style="@style/ChatListItemFooter" />
+</LinearLayout>

--- a/app/src/main/res/layout/select_for_invite.xml
+++ b/app/src/main/res/layout/select_for_invite.xml
@@ -1,70 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright (C) 2016 Pajato Technologies LLC.
-
 This file is part of Pajato GameChat.
-
 GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
 General Public License as published by the Free Software Foundation, either version 3 of the
 License, or (at your option) any later version.
-
 GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 Public License for more details.
-
 You should have received a copy of the GNU General Public License along with GameChat.  If not, see
 http://www.gnu.org/licenses
 -->
 <!-- The main content for the fragment to select groups and rooms for invitations -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:ads="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/emptyListContent"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.design.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:context="com.pajato.android.gamechat.main.MainActivity">
-        <android.support.design.widget.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/AppTheme.AppBarOverlay">
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                app:popupTheme="@style/AppTheme.PopupOverlay">
-            </android.support.v7.widget.Toolbar>
-        </android.support.design.widget.AppBarLayout>
-    </android.support.design.widget.CoordinatorLayout>
+        android:layout_height="?attr/actionBarSize"
+        android:background="@drawable/border">
 
-    <com.google.android.gms.ads.AdView
-        android:id="@+id/adView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        ads:adSize="SMART_BANNER"
-        ads:adUnitId="@string/banner_ad_unit_id"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/inviteButton"
+            android:layout_gravity="center|end"
+            android:enabled="false"
+            android:onClick="onClick"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:text="@string/action_invite"/>
+
+    </android.support.v7.widget.Toolbar>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/chatList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="32dp"
-        android:tag="@integer/groupList"/>
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="24dp"
-        android:text="@string/InviteFriends"
-        android:textAlignment="center"
-        android:textSize="24sp" />
+        android:layout_marginBottom="32dp"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="SwitchToChat">Switch to Chat</string>
     <string name="SwitchToExp">Switch to Game</string>
     <string name="action_save">SAVE</string>
+    <string name="action_invite">INVITE</string>
     <string name="app_name">GameChat</string>
     <string name="arrow_left"><![CDATA[<]]></string>
     <string name="arrow_right"><![CDATA[>]]></string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -13,6 +13,7 @@
     <string name="DefaultRoomName">Common</string>
     <string name="FutureFeature">is a future feature.  Volunteer by sending feedback using the overflow menu.</string>
     <string name="Group">Group</string>
+    <string name="GroupsAvailableHeaderText">Groups</string>
     <string name="ListIconDesc">The list icon.</string>
     <string name="InsertEmoticon">Inserting an emoticon</string>
     <string name="InsertEmoticonDesc">Insert emoticon image button.</string>
@@ -31,6 +32,8 @@
     <string name="NoJoinableRoomsHeaderText">No Available Rooms or Members</string>
     <string name="NoMessagesText">There are no messages to show in this room. That\'s weird.</string>
     <string name="NoRoomsMessageText">You must join a room to see messages.</string>
+    <string name="NoSelectableItemsHeaderText">No Groups or Rooms to select</string>
+    <string name="PickForInvitationTitle">Room Invitations</string>
     <string name="RoomListIcon">The room list icon.</string>
     <string name="RoomsAvailableHeaderText">Rooms</string>
     <string name="SelectAllMenuTitle">Select All</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,6 +48,14 @@ http://www.gnu.org/licenses
         <item name="android:contentDescription">@string/ListIconDesc</item>
     </style>
 
+    <style name="InviteRoomItemSelector">
+        <item name="android:layout_width">36dp</item>
+        <item name="android:layout_height">36dp</item>
+        <item name="android:layout_marginStart">36dp</item>
+        <item name="android:layout_gravity">center</item>
+        <item name="android:contentDescription">@string/ListIconDesc</item>
+    </style>
+
     <style name="ChatListItemSelectorImage">
         <item name="android:layout_width">36dp</item>
         <item name="android:layout_height">36dp</item>


### PR DESCRIPTION
# Rationale
Get fragment working so from navigation drawer we can send invitations after first selecting rooms / groups for the new invitation. While here, change the room type from int values to RoomType enum.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java

* setType(): use RoomType enum rather than int.
* onClick(): use RoomType enum rather than int.

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListAdapter.java

* Add ChatListCheckBoxClickListener instance (rather than building a new one every time we need one)
* onCreateViewHolder(): add cases for invite items
* onBindViewHolder(): add cases for invite items
* setChatIcon(): only check for holder icon and item URL based on item type (originally new items were added here, and then removed, so this will now allow for other items in the future)
* updateChatHolder(): check for item.text not null (prevent null pointer exception). Also, enforce the common room item's check box is always disabled (user can't click on it)
* onClick(): better comment
* ChatListViewHolder constructor: always use check box listener member variable rather than building a new one every time

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/ChatListItem.java
* Add new values for invite items. These should really be an enum!!!
* Add 'enabled' member variable
* Add constructors which build the different invitation related items (group, room and common room)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
* save(): Use RoomType enum rather that int values
* setType(): Use RoomType enum rather that int values

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* onStart: Use RoomType enum rather that int values
* setType(): Use RoomType enum rather that int values

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
* Implement invitation / select room fragment based loosely on the code for JoinRoomsFragment.

#### app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
* Add RoomType enum to replace int values. Use in constructor and in isMemberPrivateRoom().

#### app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
* getDispatcher(): add case for selecting groups/rooms for invites

#### app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
* Update selectGroupsAndRooms enum value to use selectInviteTT rather than chatChain tool bar type.

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
* This is still in progress. Add extendAppInvitation method to handle a map of group keys to a list of room keys. This will be utilized properly in the next check-in.  Remove the unused version of extendAppInvitation() which had no group (or room) keys specified.
* getListItemData(): return a list of rooms for invitations
* getInviteItems(): used by getListItemData to build the list of groups and rooms.

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* add selectInviteTT enum value to be used for the tool bar for selecting groups and rooms for invitations
* fix some typos
* setTitles(): add case for selectInviteTT setup

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* Use RoomType enum rather than int values

#### app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
* getList(): add case for handling selection of groups and rooms for invitations

#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* Use RoomType enum rather than int values and in getJoinableRooms account for new common room type

#### app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
* getRooms: return a list of room profile objects, optionally including the common room

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
* getPlayers(): since room type can no longer be -1, eliminate the use of an int for the room type; instead, return an empty list if the room is null

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
* getPlayers(): since room type can no longer be -1, eliminate the use of an int for the room type; instead, return an empty list if the room is null

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
* getPlayers(): since room type can no longer be -1, eliminate the use of an int for the room type; instead, return an empty list if the room is null

#### app/src/main/res/layout/select_for_invite.xml
* Rework for actual implementation of invitation room selection.

#### app/src/main/res/values/strings.xml
* Add action_invite for invitation room selection fragment.

#### app/src/main/res/values/strings_chat.xml
* Add new strings for invitation room selection fragment.

#### app/src/main/res/values/styles.xml
* Add style to present rooms on the invitation room selection.

## Files Added

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/CommonRoomItem.java
* POJO to encapsulate a recycler view list item that presents common rooms for invitations.

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/InviteRoomItem.java
* POJO to encapsulate a recycler view list item that allows rooms to be selected for invitations.

#### app/src/main/java/com/pajato/android/gamechat/chat/adapter/SelectableGroupItem.java
* POJO to encapsulate a recycler view list item that allows a group to be selected.

#### app/src/main/res/drawable/ic_people_black_24dp.xml
* New icon for "group" used in the invitation fragment

#### app/src/main/res/layout/item_select_for_invites.xml
* New layout for invite group items

#### app/src/main/res/layout/item_select_invites_room.xml
* New layout for invite room items
