### PR TITLE
Refactoring and revert changes so single group invite works.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
@@ -142,6 +142,48 @@ public class SelectForInviteFragment extends BaseChatFragment {
         return menu;
     }
 
+    /** When a group is selected, find it's common room and insure that it is also selected in
+     * the adapter list and add it to the list of selected rooms. */
+    private void selectGroupForInvite(ListItem groupItem, List<ListItem> adapterList) {
+        mSelectedGroups.add(groupItem);
+        for (ListItem adapterItem : adapterList) {
+            if (adapterItem.type == inviteCommonRoom &&
+                    adapterItem.groupKey.equals(groupItem.groupKey)) {
+                adapterItem.selected = true;
+                mSelectedRooms.add(adapterItem);
+            }
+        }
+    }
+
+    /** When a group is deselected, also deselect all of it's rooms (including the common room). */
+    private void deselectGroupForInvite(ListItem groupItem, List<ListItem> adapterList) {
+        mSelectedGroups.remove(groupItem);
+        for (ListItem adapterItem : adapterList) {
+            if ((adapterItem.type == inviteCommonRoom ||
+                    adapterItem.type == inviteRoom) &&
+                    adapterItem.groupKey.equals(groupItem.groupKey)) {
+                adapterItem.selected = false;
+                mSelectedRooms.remove(adapterItem);
+            }
+        }
+    }
+
+    /** When a non-common room is selected, make sure its group and common room are also selected
+     * and added to the respective list of selected groups/rooms */
+    private void selectRoomForInvite(ListItem groupItem, List<ListItem> adapterList) {
+        mSelectedRooms.add(groupItem);
+        for (ListItem adapterItem : adapterList) {
+            if (adapterItem.type == inviteGroup && adapterItem.key.equals(groupItem.groupKey)) {
+                adapterItem.selected = true;
+                mSelectedGroups.add(adapterItem);
+            } else if (adapterItem.type == inviteCommonRoom &&
+                    adapterItem.groupKey.equals(groupItem.groupKey)) {
+                adapterItem.selected = true;
+                mSelectedRooms.add(adapterItem);
+            }
+        }
+    }
+
     /** Process a selection */
     private void processSelection(@NonNull final ClickEvent event, @NonNull final CheckBox checkBox) {
         // Set the checkbox visibility and get the item object from the event payload.
@@ -161,56 +203,19 @@ public class SelectForInviteFragment extends BaseChatFragment {
         // If the item is a group, then if it's selected, also select it's common room. If it's
         // deselected, deselect all of it's rooms.
         if (clickedItem.type == inviteGroup) {
-            if (clickedItem.selected)
-                mSelectedGroups.add(clickedItem);
-            else
-                mSelectedGroups.remove(clickedItem);
-
-            for (ListItem adapterItem : adapterList) {
-                switch (adapterItem.type) {
-                    case inviteCommonRoom:
-                        if (adapterItem.groupKey.equals(clickedItem.key)) {
-                            adapterItem.selected = clickedItem.selected;
-                            if(clickedItem.selected) {
-                                mSelectedRooms.add(adapterItem);
-                            } else {
-                                mSelectedRooms.remove(adapterItem);
-                            }
-                        }
-                        break;
-                    case inviteRoom:
-                        if (adapterItem.groupKey.equals(clickedItem.key) && !clickedItem.selected) {
-                            adapterItem.selected = false;
-                            mSelectedRooms.remove(adapterItem);
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-        } else if (clickedItem.type == inviteRoom) {
-            // if the item is a room, and it's selection is enabled, make sure to also enable
-            // the group and the group's common room.
             if (clickedItem.selected) {
-                mSelectedRooms.add(clickedItem);
-                for (ListItem adapterItem : adapterList) {
-                    if (adapterItem.type == inviteGroup &&
-                            adapterItem.key.equals(clickedItem.groupKey)) {
-                        mSelectedGroups.add(adapterItem);
-                        adapterItem.selected = true;
-                    }
-                    else if (adapterItem.type == inviteCommonRoom &&
-                            adapterItem.groupKey.equals(clickedItem.groupKey)) {
-                        adapterItem.selected = true;
-                        mSelectedRooms.add(adapterItem);
-                    }
-                }
+                selectGroupForInvite(clickedItem, adapterList);
+            }
+            else {
+                deselectGroupForInvite(clickedItem, adapterList);
+            }
+        } else if (clickedItem.type == inviteRoom) {
+            if (clickedItem.selected) {
+                selectRoomForInvite(clickedItem, adapterList);
             } else {
                 mSelectedRooms.remove(clickedItem);
             }
         }
-
         adapter.notifyDataSetChanged();
 
         // Set the 'invite' button enabled or disabled based on whether there are selections

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -259,8 +259,8 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
 
     /** Extend an invitation to join GameChat using AppInviteInvitation and specify a map of
      *  groups and their rooms to join (always has at least the Common room). */
-    public void extendInvitation(final FragmentActivity fragmentActivity,
-                                    final Map<String, List<String>> keys) {
+    public void extendInvitation(final FragmentActivity activity,
+                                 final Map<String, List<String>> keys) {
         Log.i(TAG, "extendInvitation with list of keys");
 
         Uri dynLinkUri = buildDefaultDynamicLink();
@@ -274,15 +274,15 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         String dynamicLink = dynLinkUri.toString();
         Log.i(TAG, "dynamicLink=" + dynamicLink);
 
-        Intent intent = new AppInviteInvitation.IntentBuilder(fragmentActivity.getString(R.string.InviteTitle))
-                .setMessage(fragmentActivity.getString(R.string.InviteMessage))
+        Intent intent = new AppInviteInvitation.IntentBuilder(activity.getString(R.string.InviteTitle))
+                .setMessage(activity.getString(R.string.InviteMessage))
                 .setDeepLink(Uri.parse(dynamicLink))
                 .build();
-        fragmentActivity.startActivityForResult(intent, MainActivity.RC_INVITE);
+        activity.startActivityForResult(intent, MainActivity.RC_INVITE);
     }
 
     /** Extend an invitation to join GameChat using AppInviteInvitation and specify a group to join. */
-    public void extendInvitation(final FragmentActivity fragmentActivity, final String groupKey) {
+    public void extendInvitation(final FragmentActivity activity, final String groupKey) {
 
         Log.i(TAG, "extendInvitation with groupKey=" + groupKey);
         Group grp = GroupManager.instance.getGroupProfile(groupKey);
@@ -309,11 +309,11 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
                 .toString();
 
         Log.i(TAG, "dynamicLink=" + dynamicLink);
-        Intent intent = new AppInviteInvitation.IntentBuilder(fragmentActivity.getString(R.string.InviteTitle))
-                .setMessage(fragmentActivity.getString(R.string.InviteMessage))
+        Intent intent = new AppInviteInvitation.IntentBuilder(activity.getString(R.string.InviteTitle))
+                .setMessage(activity.getString(R.string.InviteMessage))
                 .setDeepLink(Uri.parse(dynamicLink))
                 .build();
-        fragmentActivity.startActivityForResult(intent, MainActivity.RC_INVITE);
+        activity.startActivityForResult(intent, MainActivity.RC_INVITE);
     }
 
     private Uri buildDefaultDynamicLink() {


### PR DESCRIPTION
# Rationale: some refactoring in SelectForInviteFragment to break up processSelection method and revert the change in InvitationManager so single group invite works from a room FAM.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
* Refactor processSelection method and split out portions of the code into some smaller easier-to-grok methods.
#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
* Undo previous changes (still work in progress) so that an invitation sent from the room fragment's FAM will work (unblock).
