### PR TITLE
Invite links

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java
@@ -114,6 +114,14 @@ public class Room {
         memberIdList.add(member);
     }
 
+    /** determine if a member already has been added to this room */
+    @Exclude public boolean hasMember(final String member) {
+        if (memberIdList.contains(member)) {
+            return true;
+        }
+        return false;
+    }
+
     /** Determine if this room is a member-to-member chat room */
     @Exclude public boolean isMemberPrivateRoom(final String member1, final String member2) {
         return (this.type == RoomType.PRIVATE && memberIdList.size() == 2 &&

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -184,7 +184,6 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
     private void handleOutstandingInvite(String inviteId) {
         DatabaseReference invite = FirebaseDatabase.getInstance().getReference()
                 .child(String.format(APP_INVITE_ID_PATH, inviteId));
-//            invite.addListenerForSingleValueEvent(new ValueEventListener() {
         invite.addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot dataSnapshot) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/GroupInviteData.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/GroupInviteData.java
@@ -1,0 +1,101 @@
+package com.pajato.android.gamechat.common.model;
+
+import com.google.firebase.database.Exclude;
+import com.google.firebase.database.IgnoreExtraProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A POJO and Firebase model to hold group/room selections while an invitation is processed.
+ */
+
+@IgnoreExtraProperties
+public class GroupInviteData {
+
+    /** The group key */
+    public String groupKey;
+
+    /** The group name */
+    public String groupName;
+
+    /** The group common room key */
+    public String commonRoomKey;
+
+    /** A list of selected room keys */
+    public List<String> rooms;
+
+    // Booleans for invitation processing, used to determine when all processing is complete
+
+    /** Indicates that the group has been added to the account in the database */
+    public boolean addedToAccountJoinList;
+
+    /** Indicates that the account has been added to the group member list in the database */
+    public boolean addedToGroupMemberList;
+
+    /** Indicates that the account has been added to the common room member list in the database */
+    public boolean addedToCommRoomMemberList;
+
+    /** Number of rooms for which processing has been completed; doesn't include the common room */
+    public int roomsCompleted;
+
+    /** Empty args constructor for the database */
+    public GroupInviteData() {}
+
+    /** Constructor */
+    public GroupInviteData(String groupKey, String groupName) {
+        this.groupKey = groupKey;
+        this.groupName = groupName;
+        addedToAccountJoinList = false;
+        addedToGroupMemberList = false;
+        addedToCommRoomMemberList = false;
+        rooms = new ArrayList<>();
+        this.roomsCompleted = 0;
+    }
+
+    /** Constructor */
+    public GroupInviteData(String groupKey, String groupName, String commonRoomKey, List<String> rooms) {
+        this.groupKey = groupKey;
+        this.groupName = groupName;
+        this.commonRoomKey = commonRoomKey;
+        addedToAccountJoinList = false;
+        addedToGroupMemberList = false;
+        addedToCommRoomMemberList = false;
+        this.rooms = rooms;
+        this.roomsCompleted = 0;
+    }
+
+    /** Constructor */
+    public GroupInviteData(String groupKey, String groupName, String commonRoomKey) {
+        this.groupKey = groupKey;
+        this.groupName = groupName;
+        this.commonRoomKey = commonRoomKey;
+        addedToAccountJoinList = false;
+        addedToGroupMemberList = false;
+        addedToCommRoomMemberList = false;
+        this.rooms = new ArrayList<>();
+        this.roomsCompleted = 0;
+    }
+
+    /** Provide a default map for Firebase create/update */
+    @Exclude public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("groupKey", groupKey);
+        result.put("groupName", groupName);
+        result.put("commonRoomKey", commonRoomKey);
+        result.put("rooms", rooms);
+        result.put("addedToAccountJoinList", addedToAccountJoinList);
+        result.put("addedToGroupMemberList", addedToGroupMemberList);
+        result.put("addedToCommRoomMemberList", addedToCommRoomMemberList);
+        result.put("roomsCompleted", roomsCompleted);
+        return result;
+    }
+
+    /** Determine if all processing of an invitation is complete */
+    @Exclude public boolean isDone() {
+        return addedToAccountJoinList && addedToGroupMemberList && addedToCommRoomMemberList &&
+                roomsCompleted == rooms.size();
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
@@ -77,15 +77,10 @@ public class ExpEnvelopeFragment extends BaseExperienceFragment {
         Object payload = event.view.getTag();
         if (payload == null || !(payload instanceof MenuEntry)) return;
 
-        // Handle invitation - extend app invitation, dismiss menu and return (there is no
-        // new experience to start).
-        if (((MenuEntry) payload).titleResId == R.string.InviteFriendFromExpEnv) {
-            InvitationManager.instance.extendInvitation(getActivity(), mExperience.getGroupKey());
-            FabManager.game.dismissMenu(this);
-            return;
-        } else if (((MenuEntry) payload).titleResId == R.string.InviteFriendFromChat ||
+        // these aren't handled here so just return
+        if (((MenuEntry) payload).titleResId == R.string.InviteFriendFromExpEnv ||
+                ((MenuEntry) payload).titleResId == R.string.InviteFriendFromChat ||
                 ((MenuEntry)payload).titleResId == R.string.InviteFriendFromTTT) {
-            // These aren't handled here so we want to return
             return;
         }
 
@@ -169,7 +164,6 @@ public class ExpEnvelopeFragment extends BaseExperienceFragment {
         menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
         menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getTintEntry(R.string.InviteFriendFromExpEnv, R.drawable.ic_email_black_24dp));
         return menu;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -102,13 +102,6 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         Object tag = event.view.getTag();
         FabManager.game.dismissMenu(this);
 
-        // Handle invitation - extend app invitation, dismiss menu and return (there is no
-        // new experience to start).
-        if (((MenuEntry) tag).titleResId == R.string.InviteFriendFromChat) {
-            InvitationManager.instance.extendInvitation(getActivity(), mExperience.getGroupKey());
-            return;
-        }
-
         // The event is either a snackbar action (start a new game) or a menu (FAM or Player2)
         // entry.  Detect and handle start a new game first.
         if (isPlayAgain(tag, TAG))
@@ -305,7 +298,6 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
         menu.add(getTintEntry(R.string.MyRooms, R.drawable.ic_casino_black_24dp));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_tictactoe_red));
-        menu.add(getTintEntry(R.string.InviteFriendFromTTT, R.drawable.ic_email_black_24dp));
         return menu;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -202,13 +202,18 @@ public class MainActivity extends BaseActivity
             String key = ACCOUNT_AVAILABLE_KEY;
             editor.putBoolean(key, intent.getBooleanExtra(key, uid != null));
             editor.apply();
-        } else if (requestCode == RC_INVITE && resultCode == RESULT_OK) {
-            // For now, just log
-            Log.d(TAG, "onActivityResult: requestCode=" + requestCode + ", resultCode=" + resultCode);
-            // Get the invitation IDs of all sent messages
-            String[] ids = AppInviteInvitation.getInvitationIds(resultCode, intent);
-            for (String id : ids) {
-                Log.d(TAG, "onActivityResult: sent invitation " + id);
+        } else if (requestCode == RC_INVITE) {
+            if (resultCode != RESULT_OK) {
+                InvitationManager.instance.clearInvitationMap();
+            } else {
+                // For now, just log
+                Log.d(TAG, "onActivityResult: requestCode=" + requestCode + ", resultCode=" + resultCode);
+                // Get the invitation IDs of all sent messages
+                String[] ids = AppInviteInvitation.getInvitationIds(resultCode, intent);
+                for (String id : ids) {
+                    Log.d(TAG, "onActivityResult: sent invitation " + id);
+                    InvitationManager.instance.saveInvitation(id);
+                }
             }
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -203,11 +203,10 @@ public class MainActivity extends BaseActivity
             editor.putBoolean(key, intent.getBooleanExtra(key, uid != null));
             editor.apply();
         } else if (requestCode == RC_INVITE) {
-            if (resultCode != RESULT_OK) {
+            Log.d(TAG, "onActivityResult: requestCode=RC_INVITE, resultCode=" + resultCode);
+            if (resultCode != RESULT_OK)
                 InvitationManager.instance.clearInvitationMap();
-            } else {
-                // For now, just log
-                Log.d(TAG, "onActivityResult: requestCode=" + requestCode + ", resultCode=" + resultCode);
+            else {
                 // Get the invitation IDs of all sent messages
                 String[] ids = AppInviteInvitation.getInvitationIds(resultCode, intent);
                 for (String id : ids) {


### PR DESCRIPTION
# Rationale

Rather than encoding group and room selections in the deep link in an invitation, save this information in Firebase, using the invitation id as the push key.

Since Firebase invitations are not currently reliable, this commit is a step toward invitation processing, but will need to be modified. Currently, it is assumed that the Firebase invitation will (probably) not be delivered.  Therefore, a value change listener is added to the database to watch for invitations.  All invitations are processed. If an account has already joined the indicated rooms and groups, the invitation is benign. However, the invitation is not currently deleted after processing, since it could easily be processed and deleted by the sender, which makes testing complicated for a separate receiver. Invitations can easily be deleted from the database using the Firebase console after the receiver testing is completed. This will need to be cleaned up after stable invitation delivery is completed.

The invitation id is used as the key to manage invitation data, since the Firebase invitation intent returns only the invitation id. This would work nicely if Firebase invitations worked reliably, but will probably be changed after determining a stable invitation mechanism.

As suggested in pull request #212, in SelectForInviteFragment, track the selected items only when the INVITE button is clicked which simplifies that code greatly.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectForInviteFragment.java
* Eliminate the mSelectedGroups and mSelectedRooms lists which were used to track selections as each change was made. Remove all references to these and the logic to track selections in updateSelections() method
* getSelections(): create the selections based on the contents of the RecyclerView's adapter contents, since the selected groups and rooms lists have been removed
* updateSendInvitationButton(): determine whether the button should be enabled based on the contents of the RecyclerView's adapter rather than the selected rooms and group lists (now removed)

#### app/src/main/java/com/pajato/android/gamechat/chat/model/Room.java

* hasMember(): new convenience method

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java

* move GroupInviteData to it's own class
* save external app invites in /invites/app in Firebase
* maintain a map of group data used while processing an invitation
* maintain a list of invitation ids waiting to be processed
* clearInvitationMap(): added convenience method
* onAuthenticationChange(): For any existing invitation ids in the list (which can be encountered if the Firebase invitation delivery works correctly), kick of the handling of the invitation. Add a child event listener to handle invitations from the database - this is temporary and will be reworked when a stable invitation mechanism is developed; when an invitation is added, save it's ID in the list and start processing.
* handleOutstandingInvite(): new method to add a value listener for app invitations. When a change is received, extract the group and room data for the invitation from the snapshot, add it to the invitation map, and start processing.
* startInvitationProcessing(): for each group entry in the invitation map, begin the processing by adding the group to the account join list, and setting watchers for the common room and any other rooms specified in the invitation map data.
* onRoomProfileChange(): If the current account is already a member of the room (or common room), don't process it again.
* handleInvitationComplete(): new method to check for processing complete
* onGroupProfileChange(): If the current account is already a member of the group, don't process it again.
* extendInvitation(): refactor so both variants of this share common code and use the invitation map to save invitation information while running the Firebase invitation intent, and then save the sent invitation based on the id into the database
* buildDynamicLink(): new method; refactor shared code
* startInvitationIntend(): new method; refactor shared code
* encodeGroupInfo(): delete this method; no longer encoding group/room information in the dynamic link
* onResult(): remove code to process the Firebase deep link as it is no longer used; all data is exchanged via Firebase instead; on completion of the invitation intent, save the group and room data in Firebase and clear the invitation map.


#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java

* onClick(): remove invitation processing, as there is not a known group (can't extend an invitation to the 'me' group)
* getHomeMenu(): remove invitation menu item

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

* onClick(): remove invitation processing, as there is not a known group (can't extend an invitation to the 'me' group)
* getTTTMenu(): remove invitation menu item

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

* onActivityResult(): handle the case where the invitation is not successful by clearing the invitation map (to deal with user clicking the back button from the invitation intent)

## New files

#### app/src/main/java/com/pajato/android/gamechat/common/model/GroupInviteData.java
* Move the group invitation data into its own class as it will be used to maintain invitation information in Firebase.
* Expand to include a list of invited rooms, and also to remember when all rooms have been processed.
