### PR TITLE
Improve selection of groups/rooms for invites. Process "Create Protected User" FAM item.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -35,8 +35,6 @@ import com.pajato.android.gamechat.common.adapter.GroupItem;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.adapter.RoomItem;
 
-import org.greenrobot.eventbus.Subscribe;
-
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -35,6 +35,8 @@ import com.pajato.android.gamechat.common.adapter.GroupItem;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.adapter.RoomItem;
 
+import org.greenrobot.eventbus.Subscribe;
+
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -120,7 +120,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
     // Protected instance methods.
 
-    /** Log and prsent a toast message to the User. */
+    /** Log and present a toast message to the User. */
     protected void abort(final String message) {
         logEvent(String.format(Locale.US, "Error: (create %s): %s.", mCreateType, message));
         // TODO: throw up a toast or snackbar.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -104,7 +104,6 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
                 break;
             default:
-                // Todo: add more menu button handling as a future feature.
                 break;
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -19,7 +19,9 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.v4.view.ViewPager;
 import android.view.View;
+import android.widget.Toast;
 
+import com.google.firebase.auth.FirebaseAuth;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
@@ -78,6 +80,16 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
                 break;
             case R.string.InviteFriendFromChat:
                 DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
+                break;
+            case R.string.CreateRestrictedUserTitle:
+                if (AccountManager.instance.getCurrentAccount().chaperone != null) {
+                    String protectedWarning = "Protected Users cannot make other Protected Users.";
+                    Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
+                    break;
+                }
+                AccountManager.instance.mChaperone = AccountManager.instance.getCurrentAccountId();
+                FirebaseAuth.getInstance().signOut();
+                AccountManager.instance.signIn(getContext());
                 break;
             default:
                 // ...

--- a/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Provide a Firebase model class repesenting a chat message, an icon, a name and text. */
+/** Provide a Firebase model class representing a chat message, an icon, a name and text. */
 @IgnoreExtraProperties public class Message {
 
     // Public class constants.
@@ -49,7 +49,7 @@ import java.util.Map;
     /** The poster's display name. */
     public String name;
 
-    /** The member account identifer who posted the message. */
+    /** The member account identifier who posted the message. */
     public String owner;
 
     /** The push key for the room in which the message was created. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -93,7 +93,7 @@ public abstract class BaseFragment extends Fragment {
         return mLayout != null ? (Toolbar) mLayout.findViewById(R.id.toolbar) : null;
     }
 
-    /** Return the, possibly null, toolbar type being used by this fragemnt. */
+    /** Return the, possibly null, toolbar type being used by this fragment. */
     public ToolbarManager.ToolbarType getToolbarType() {
         return type != null ? type.toolbarType : null;
     }
@@ -254,7 +254,7 @@ public abstract class BaseFragment extends Fragment {
         return true;
     }
 
-    /** Regturn null or a list to be displayed by a list adapter for a given fragment type. */
+    /** Return null or a list to be displayed by a list adapter for a given fragment type. */
     private List<ListItem> getList(@NonNull final FragmentType type, final ListItem item) {
         switch (type) {
             case chatGroupList: // Get the data to be shown in a list of groups.

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.common.adapter;
 
 import android.content.Context;
 import android.net.Uri;
-import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ViewHolder;
@@ -28,7 +27,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.RadioButton;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
@@ -72,10 +72,8 @@ public class SelectExpInviteFragment extends BaseChatFragment {
                 InvitationManager.instance.extendInvitation(getActivity(), getSelections());
                 DispatchManager.instance.startNextFragment(getActivity(), exp);
                 break;
-            case R.id.selector:
-                processSelection(event, (CheckBox) event.view);
-                break;
             default:
+                processSelection(event.view);
                 break;
         }
     }
@@ -156,32 +154,60 @@ public class SelectExpInviteFragment extends BaseChatFragment {
         }
     }
 
+    /** Return a boolean value obtained by processing the given item view */
+    private boolean getValue(@NonNull final View itemView) {
+        // Handle a checkbox (an unlikely but possible event.)
+        View view = itemView.findViewById(R.id.selector);
+        if (view != null && view instanceof CheckBox && view.getVisibility() == View.VISIBLE) {
+            ((CheckBox) view).toggle();
+            return ((CheckBox) view).isChecked();
+        }
+
+        // Handle other by doing nothing, i.e. return the current state of the save button.
+        View saveButton = mLayout.findViewById(R.id.inviteButton);
+        return saveButton.isEnabled();
+    }
+
     /** Process a selection by updating the recycler view adapter's items */
-    private void processSelection(@NonNull final ClickEvent event, @NonNull final CheckBox checkBox) {
+    private void processSelection(@NonNull final View view) {
         // Set the checkbox visibility and get the item object from the event payload.
-        ListItem clickedItem = null;
-        Object payload = event.view != null ? event.view.getTag() : null;
-        if (payload != null && payload instanceof ListItem) clickedItem = (ListItem) payload;
-        if (clickedItem == null) return;
+        Object payload = view.getTag();
+        if (payload == null || !(payload instanceof ListItem))
+            return;
+        ListItem clickedItem = (ListItem) payload;
+        // Ignore clicks on common room
+        if (clickedItem.type == inviteCommonRoom)
+            return;
+
+        boolean value;
+        switch (view.getId()) {
+            case R.id.selector:
+                // Checkbox click
+                value = ((CheckBox) view).isChecked();
+                break;
+            default:
+                // handle a view item clicked
+                value = getValue(view);
+                break;
+        }
 
         // Toggle the selection state and operate accordingly on the selected items lists.
         clickedItem.selected = !clickedItem.selected;
-        checkBox.setChecked(clickedItem.selected);
 
-        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.ItemList);
-        ListAdapter adapter = (ListAdapter) view.getAdapter();
+        RecyclerView recyclerView = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        ListAdapter adapter = (ListAdapter) recyclerView.getAdapter();
         List <ListItem> adapterList = adapter.getItems();
 
         // If a group is selected, also select it's common room; if deselected, also deselect all
         // of it's rooms. If a room is selected, also select it's group and common room. Common
         // room selection is disabled, so don't check for that.
         if (clickedItem.type == inviteGroup) {
-            if (clickedItem.selected)
+            if (value)
                 selectGroupForInvite(clickedItem, adapterList);
             else
                 deselectGroupForInvite(clickedItem, adapterList);
         } else if (clickedItem.type == inviteRoom) {
-            if (clickedItem.selected)
+            if (value)
                 selectRoomForInvite(clickedItem, adapterList);
         }
         adapter.notifyDataSetChanged();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
@@ -118,7 +118,7 @@ public class SelectUserFragment extends BaseExperienceFragment {
         saveButton.setEnabled(value);
     }
 
-    /** Return a boolean value obtaine by processing the given item view. */
+    /** Return a boolean value obtained by processing the given item view. */
     private boolean getValue(@NonNull final View itemView) {
         // Handle a radio button (the most likely event.)
         View view = itemView.findViewById(R.id.selector);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/ChessBoard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/ChessBoard.java
@@ -48,8 +48,7 @@ public class ChessBoard {
      * Add a piece to the board
      * @param index index into the board (valid indices are 0->63).
      * @param type piece type
-     * // TODO: change this to take one of the ChessTeam enum values
-     * @param team the team (0 = primary team, 1 = secondary team)
+     * @param team the team
      */
     public void add(final int index, final PieceType type, final ChessTeam team) {
         board.put(makeCellId(index), new ChessPiece(type, team));
@@ -86,7 +85,7 @@ public class ChessBoard {
     }
 
     /**
-     * Determine if specified peice type for the specified team is at the cell location indicates
+     * Determine if specified piece type for the specified team is at the cell location indicates
      * @return true if the primary king is at the specified index
      */
     private boolean cellHasTeamPiece(final int index, PieceType type, ChessTeam team) {

--- a/app/src/main/res/menu/drawer_body.xml
+++ b/app/src/main/res/menu/drawer_body.xml
@@ -26,7 +26,7 @@
                     android:title="@string/manage_accounts"
                     android:icon="@drawable/vd_login_2" />
                 <item
-                        android:id="@+id/manageGroups"
+                    android:id="@+id/manageGroups"
                     android:title="@string/MenuItemManageGroups"
                     android:icon="@drawable/vd_group_black_24px"/>
                 <item


### PR DESCRIPTION
# Rationale

Let the user click anywhere in the list view item when selecting or deselecting groups and rooms for invitations. Also, had code to handle selection of the "Create Protected User" in the chat groups list FAB.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
* Handle selection of the "Create Protected User" menu item.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
* Using SelectUserFragment as an example, allow a click on any part of the list item cause the check box selection for group and room selections.


#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
* Using SelectUserFragment as an example, allow a click on any part of the list item cause the check box selection for group and room selections.


### Nitty and non-functional fixes and typos:
* app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
* app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* app/src/main/java/com/pajato/android/gamechat/chat/model/Message.java
* app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
* app/src/main/java/com/pajato/android/gamechat/exp/model/ChessBoard.java
* app/src/main/res/menu/drawer_body.xml

