### PR TITLE
First take on the experience navigation feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -60,11 +60,6 @@ public abstract class BaseChatFragment extends BaseFragment {
     /** Extra information format string. */
     private static final String SUFFIX_FORMAT = "Fragment Type: %s; State: %s; Bundle: %s.";
 
-    // Protected instance variables.
-
-    /** Show an ad at the top of the view. */
-    protected AdView mAdView;
-
     // Public instance methods.
 
     /** Log the lifecycle event and kill the ads. */
@@ -73,16 +68,11 @@ public abstract class BaseChatFragment extends BaseFragment {
         if (mAdView != null) mAdView.destroy();
     }
 
-    /** Initialize chat list fragments by dealing with ads. */
-    @Override public void onStart() {
-        super.onStart();
-        initAdView(mLayout);
-    }
-
     /** Log the lifecycle event, stop showing ads and turn off the app event bus. */
     @Override public void onPause() {
         super.onPause();
-        if (mAdView != null) mAdView.pause();
+        if (mAdView != null)
+            mAdView.pause();
     }
 
     /** Log the lifecycle event and resume showing ads. */
@@ -106,7 +96,12 @@ public abstract class BaseChatFragment extends BaseFragment {
                 default:            // Ignore all other fragments.
                     break;
             }
-        ToolbarManager.instance.setTitles(this, mItem);
+    }
+
+    /** Initialize chat list fragments by dealing with ads. */
+    @Override public void onStart() {
+        super.onStart();
+        initAdView(mLayout);
     }
 
     /** Set the item defining this fragment (passed from the parent (spawning) fragment. */
@@ -115,15 +110,6 @@ public abstract class BaseChatFragment extends BaseFragment {
     }
 
     // Protected instance methods.
-
-    /** Initialize the ad view by building and loading an ad request. */
-    protected void initAdView(@NonNull final View layout) {
-        mAdView = (AdView) layout.findViewById(R.id.adView);
-        if (mAdView != null) {
-            AdRequest adRequest = new AdRequest.Builder().build();
-            mAdView.loadAd(adRequest);
-        }
-    }
 
     /** Log a lifecycle event that has no bundle. */
     @Override protected void logEvent(final String event) {
@@ -157,8 +143,7 @@ public abstract class BaseChatFragment extends BaseFragment {
             case chatRoomList:  // The rooms in a group need the group key.
                 if (dispatcher.groupKey == null)
                     return false;
-                GroupItem groupItem = new GroupItem(dispatcher.groupKey);
-                mItem = new ListItem(groupItem);
+                mItem = new ListItem(dispatcher.groupKey, null, 0, null);
                 return true;
             default:
                 return false;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -37,7 +37,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.PRIVATE;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.PUBLIC;
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -31,7 +31,6 @@ import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.common.InvitationManager;
-import com.pajato.android.gamechat.common.adapter.GroupItem;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -45,7 +44,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.FragmentType.chatGroupList;
 import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;
 import static com.pajato.android.gamechat.common.FragmentType.selectChatGroupsRooms;
@@ -81,8 +80,8 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
             return;
         switch (event.item.getItemId()) {
             case R.id.nav_me_room:
-                GroupItem groupItem = new GroupItem(AccountManager.instance.getMeGroupKey());
-                ListItem listItem = new ListItem(groupItem);
+                String groupKey = AccountManager.instance.getMeGroupKey();
+                ListItem listItem = new ListItem(groupKey, null, 0, null);
                 DispatchManager.instance.chainFragment(getActivity(), chatRoomList, listItem);
                 break;
             case R.id.nav_groups:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -28,12 +28,12 @@ import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
+import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.main.PaneManager;
-import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -126,15 +126,6 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
             updateAdapterList();
     }
 
-    /** Initialize ... */
-    @Override public void onStart() {
-        super.onStart();
-        if (ProgressManager.instance.isShowing())
-            ProgressManager.instance.hide();
-        ToolbarManager.instance.init(this, game, search);
-        FabManager.chat.setMenu(CHAT_GROUP_FAM_KEY, getGroupMenu());
-    }
-
     /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
     @Override public void onResume() {
         // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
@@ -144,6 +135,13 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
         FabManager.chat.setVisibility(this, View.VISIBLE);
+    }
+
+    /** Initialize ... */
+    @Override public void onStart() {
+        super.onStart();
+        ToolbarManager.instance.init(this, getTitleResId(), game, search);
+        FabManager.chat.setMenu(CHAT_GROUP_FAM_KEY, getGroupMenu());
     }
 
     // Private instance methods.
@@ -162,4 +160,16 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         return menu;
     }
 
+    /** Return the toolbar title resource id based on the presence or absence of groups. */
+    private int getTitleResId() {
+        // Show the app title if there is no current account (impossible), the standard groups
+        // toolbar title if there are joined groups, otherwise show the me room name (account
+        // display name.)
+        Account account = AccountManager.instance.getCurrentAccount();
+        if (account == null)
+            return R.string.app_name;
+        if (account.joinList.size() > 0)
+            return R.string.GroupsToolbarTitle;
+        return R.string.GroupMeToolbarTitle;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -118,7 +118,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
     /** Initialize ... */
     @Override public void onStart() {
         super.onStart();
-        ToolbarManager.instance.init(this, game, search);
+        ToolbarManager.instance.init(this, mItem, game, search);
         FabManager.chat.setMenu(CHAT_ROOM_FAM_KEY, getRoomMenu());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
@@ -19,24 +19,20 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
-import android.util.Log;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.main.PaneManager;
-import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
-import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
@@ -52,11 +48,8 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
 
     /** Handle a group profile change by trying again to start a better fragment. */
     @Subscribe public void onChatListChange(@NonNull final ChatListChangeEvent event) {
-        // On the first chat list change event, dismiss the sign in progress spinner.  In any case
-        // attempt to present another fragment based on the chat list change.
-        if (ProgressManager.instance.isShowing()) {
-            ProgressManager.instance.hide();
-        }
+        // On the first chat list change event, attempt to present another fragment based on the
+        // chat list change.
         DispatchManager.instance.startNextFragment(this.getActivity(), chat);
     }
 
@@ -81,7 +74,8 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
         // Provide an account loading indicator for a brief period before showing the fragment.
         // This will likely be enough time to load the account and message data.
         super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, game, settings);
+        int titleResId = R.string.SignedOutToolbarTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, game, settings);
         FabManager.chat.setVisibility(this, View.GONE);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -62,7 +62,8 @@ public class CreateGroupFragment extends BaseCreateFragment {
         // control.
         super.onStart();
         mCreateType = CreateType.group;
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
+        int titleResId = R.string.CreateGroupMenuTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
         RadioGroup accessControl = (RadioGroup) mLayout.findViewById(R.id.AccessControl);
         accessControl.setVisibility(View.GONE);
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.view.inputmethod.InputMethodManager;
 
+import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
@@ -75,7 +76,8 @@ public class CreateRoomFragment extends BaseCreateFragment {
 
         // Establish the list type and setup the toolbar.
         mCreateType = CreateType.room;
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
+        int titleResId = R.string.CreateRoomMenuTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
 
         // Set up the room profile.
         mRoom = new Room();

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import static com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment.SelectionType.all;
 import static com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment.SelectionType.members;
 import static com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment.SelectionType.rooms;
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.selectableMember;
@@ -129,7 +129,8 @@ public class JoinRoomsFragment extends BaseChatFragment {
     /** Establish the toolbar and FAB. */
     @Override public void onStart() {
         super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
+        int titleResId = R.string.JoinRoomsMenuTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
         FabManager.chat.setMenu(CHAT_SELECTION_FAM_KEY, getSelectionMenu());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
@@ -46,7 +46,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.set
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.inviteCommonRoom;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.inviteGroup;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.inviteRoom;
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 
 /**
  * Provide a fragment class used to choose groups and rooms to include in an invite.
@@ -105,7 +105,8 @@ public class SelectChatInviteFragment extends BaseChatFragment {
         // Establish the create type, the list type, setup the toolbar and turn off the access
         // control.
         super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
+        int titleResId = R.string.PickForInvitationTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
         FabManager.chat.setMenu(INVITE_CHAT_FAM_KEY, getSelectionMenu());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -125,18 +125,17 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         }
     }
 
-    /** Establish the create time state. */
-    @Override public void onStart() {
-        // Establish the list type and setup the toolbar.
-        super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, game, search, invite, settings);
-    }
-
     /** Deal with the fragment's lifecycle by managing the FAB. */
     @Override public void onResume() {
         super.onResume();        // Turn off the FAB and force a recycler view update.
         initEditText(mLayout);
         FabManager.chat.setVisibility(this, View.GONE);
+    }
+
+    /** Setup the toolbar. */
+    @Override public void onStart() {
+        super.onStart();
+        ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java
@@ -23,7 +23,7 @@ import com.pajato.android.gamechat.event.MessageChangeEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -31,6 +31,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
 
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.adapter.ListAdapter;
 import com.pajato.android.gamechat.common.adapter.ListItem;
@@ -74,6 +76,9 @@ public abstract class BaseFragment extends Fragment {
 
     /** The fragment active state; set when entering onResume and cleared in onPause. */
     protected boolean mActive;
+
+    /** An ad view to be conditionally shown at the top of the view. */
+    protected AdView mAdView;
 
     /** The item information passed from the parent fragment. */
     protected ListItem mItem;
@@ -203,6 +208,15 @@ public abstract class BaseFragment extends Fragment {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_TINT_TYPE, titleId, iconId));
     }
 
+    /** Initialize the ad view by building and loading an ad request. */
+    protected void initAdView(@NonNull final View layout) {
+        mAdView = (AdView) layout.findViewById(R.id.adView);
+        if (mAdView != null) {
+            AdRequest adRequest = new AdRequest.Builder().build();
+            mAdView.loadAd(adRequest);
+        }
+    }
+
     /** Provide a logger to show the given message and the given bundle. */
     protected abstract void logEvent(String message, Bundle bundle);
 
@@ -258,13 +272,15 @@ public abstract class BaseFragment extends Fragment {
     private List<ListItem> getList(@NonNull final FragmentType type, final ListItem item) {
         switch (type) {
             case chatGroupList: // Get the data to be shown in a list of groups.
-                return GroupManager.instance.getListItemData();
-            case messageList:   // Get the data to be shown in a room.
-                return MessageManager.instance.getListItemData(item);
+                return GroupManager.instance.getListItemData(type.getKind());
             case chatRoomList:  // Get the data to be show in a list of rooms.
                 return RoomManager.instance.getListItemData(item.groupKey);
+            case expGroupList:  // Get the groups with experiences.
+                return GroupManager.instance.getListItemData(type.getKind());
             case joinRoom:      // Get the candidate list of rooms and members.
                 return JoinManager.instance.getListItemData(item);
+            case messageList:   // Get the data to be shown in a room.
+                return MessageManager.instance.getListItemData(item);
             case selectExpGroupsRooms:
             case selectChatGroupsRooms: // Get the group and room selections.
                 return InvitationManager.instance.getListItemData();

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.FragmentType.chatGroupList;
 import static com.pajato.android.gamechat.common.FragmentType.chatOffline;
 import static com.pajato.android.gamechat.common.FragmentType.chatSignedOut;
@@ -48,9 +48,6 @@ import static com.pajato.android.gamechat.common.FragmentType.expSignedOut;
 public enum DispatchManager {
     instance;
 
-    /** Provide a discriminant to differentiate a chat vs experience dispatcher. */
-    public enum DispatcherKind {chat, exp}
-
     // Private class constants.
 
     /** The logcat tag. */
@@ -62,6 +59,16 @@ public enum DispatchManager {
     private Map<FragmentType, BaseFragment> mFragmentMap = new HashMap<>();
 
     // Public instance methods.
+
+    /**
+     * Attach a drill down fragment identified by a type, creating that fragment as necessary.
+     *
+     * @param context The activity attached to the fragment that spawned this call.
+     * @param type The type of the fragment to drill into.  One will be created if necessary.
+     */
+    public void chainFragment(final FragmentActivity context, final FragmentType type) {
+        chainFragment(context, type, null);
+    }
 
     /**
      * Attach a drill down fragment identified by a type, creating that fragment as necessary.
@@ -109,7 +116,7 @@ public enum DispatchManager {
      *
      * @return TRUE iff the next fragment is started.
      */
-    public boolean startNextFragment(final FragmentActivity context, final DispatcherKind kind) {
+    public boolean startNextFragment(final FragmentActivity context, final FragmentKind kind) {
         // Ensure that the dispatcher has a valid kind.  If not then abort, otherwise create a
         // dispatcher of the given kind and determine if an associated fragment can be started.
         // Return false if not, otherwise start the fragment and return true iff the fragment is
@@ -191,7 +198,7 @@ public enum DispatchManager {
     }
 
     /** Return a dispatcher object based on the current message list state. */
-    private Dispatcher getDispatcher(final DispatcherKind kind) {
+    private Dispatcher getDispatcher(final FragmentKind kind) {
         // Deal with an off line user, a signed out user, or no messages or experiences at all, in
         // that order.  In each case, return an empty dispatcher but for the fragment type of the
         // next screen to show.
@@ -207,7 +214,8 @@ public enum DispatchManager {
                 type = kind == chat ? chatSignedOut : expSignedOut;
                 return new Dispatcher(type);
 
-            default: return new Dispatcher(kind == chat ? chatGroupList : expGroupList);
+            default:
+                return new Dispatcher(kind == chat ? chatGroupList : expGroupList);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentKind.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentKind.java
@@ -1,0 +1,4 @@
+package com.pajato.android.gamechat.common;
+
+/** Provide a discriminant to differentiate a chat vs experience fragment. */
+public enum FragmentKind {chat, exp}

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -32,7 +32,6 @@ import com.pajato.android.gamechat.chat.fragment.SelectChatInviteFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowMessagesFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoJoinedRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoMessagesFragment;
-import com.pajato.android.gamechat.common.DispatchManager.DispatcherKind;
 import com.pajato.android.gamechat.common.ToolbarManager.ToolbarType;
 import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.fragment.CheckersFragment;
@@ -49,8 +48,8 @@ import com.pajato.android.gamechat.exp.fragment.ShowExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.ShowNoExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.TTTFragment;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.chat;
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.chat;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.chatChain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.chatMain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.createGroupTT;
@@ -81,7 +80,7 @@ public enum FragmentType {
     createGroup (CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
     createRoom (CreateRoomFragment.class, createRoomTT, R.layout.chat_create),
     expEnvelope (ExpEnvelopeFragment.class, none, R.layout.exp_envelope),
-    expGroupList (ExpShowGroupsFragment.class, expMain, R.layout.exp_none),
+    expGroupList (ExpShowGroupsFragment.class, expMain, R.layout.exp_list),
     expOffline (ExpShowOfflineFragment.class, expMain, R.layout.exp_offline),
     expRoomList (ExpShowRoomsFragment.class, expChain, R.layout.exp_none),
     expSignedOut (ExpShowSignedOutFragment.class, expMain, R.layout.exp_signed_out),
@@ -146,7 +145,7 @@ public enum FragmentType {
     }
 
     /** Return the dispatch kind for this fragment type. */
-    public DispatcherKind getKind() {
+    public FragmentKind getKind() {
         switch(this) {
             case chatEnvelope:
             case chatGroupList:

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -151,6 +151,16 @@ public class ListItem {
 
     // Public constructors.
 
+    /** Build an item instance for the given group. */
+    public ListItem(final String groupKey, final String name, final int count, final String text) {
+        // Set the type and populate the member fields for the given group.
+        type = group;
+        this.groupKey = groupKey;
+        this.name = name;
+        this.count = count;
+        this.text = text;
+    }
+
     /** Build a header instance for a given resource id. */
     public ListItem(final ItemType type, int resId) {
         this.type = type;
@@ -173,17 +183,6 @@ public class ListItem {
         groupKey = item.groupKey;
         roomKey = item.roomKey;
         key = item.key;
-    }
-
-    /** Build an instance for a given group list item. */
-    public ListItem(final GroupItem item) {
-        type = group;
-        groupKey = item.groupKey;
-        name = item.name;
-        count = item.count;
-        text = item.text;
-        String format = "Group item with name {%s}, key: {%s}, count: {%s} and text {%s}.";
-        mDesc = String.format(Locale.US, format, name, key, count, text);
     }
 
     /** Build an instance for a given room list item. */
@@ -325,6 +324,9 @@ public class ListItem {
             case experience:
                 format = "Experience item with group/room/exp keys {%s/%s/%s} and mode {%s}.";
                 return String.format(Locale.US, format, groupKey, roomKey, key, playMode);
+            case group:
+                format = "Group item with name {%s}, key: {%s}, count: {%s} and text {%s}.";
+                return String.format(Locale.US, format, name, key, count, text);
             case inviteCommonRoom:
                 format = "Common room item with name {%s} and text: {%s}.";
                 return String.format(Locale.US, format, name, text);

--- a/app/src/main/java/com/pajato/android/gamechat/event/ExpListChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ExpListChangeEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+/**
+ * Provides an empty event class to mark a chat list change.  No data is necessary.  When these
+ * events occur, the various chat list fragments should update their lists.  For example on a new
+ * message from the database, the group, room and message lists should be updated.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ExpListChangeEvent {
+    // No data is needed as it is all contained in the DatabaseListManager class.
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -105,6 +105,26 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         }
     }
 
+    /** Log the lifecycle event and resume showing ads. */
+    @Override public void onResume() {
+        // Log the event, update the FAB for this fragment, process the ad, determine if a list
+        // adapter update needs be processed and set the toolbar titles.
+        super.onResume();
+        FabManager.chat.init(this);
+        if (mAdView != null)
+            mAdView.resume();
+        if (type != null)
+            switch (type) {
+                case expGroupList:
+                case expRoomList:
+                case experienceList: // Update the state of the list adapter.
+                    updateAdapterList();
+                    break;
+                default:        // Ignore all other fragments.
+                    break;
+            }
+    }
+
     /**
      * Provide a default implementation for setting up an experience.  There are two scenarios
      * where an experience fragment needs to be set up.  First, when a User asks to start a game,
@@ -133,6 +153,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         // Provide a loading indicator, enable the options menu, layout the fragment, set up the ad
         // view and the listeners for backend data changes.
         super.onStart();
+        initAdView(mLayout);
         FabManager.game.addMenu(EXP_MODE_FAM_KEY, getExpModeFam());
     }
 
@@ -257,7 +278,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         // Ensure that the name text view exists. Abort if not.  Set the value from the model if it
         // does.
         TextView name = (TextView) mLayout.findViewById(R.id.roomName);
-        if (name == null) return;
+        if (name == null)
+            return;
         name.setText(RoomManager.instance.getRoomName(model.getRoomKey()));
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
@@ -28,6 +28,9 @@ import java.util.Map;
  */
 public interface Experience {
 
+    /** Return the experience create time. */
+    long getCreateTime();
+
     /** Return the experience group push key. */
     String getGroupKey();
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -33,7 +33,6 @@ import com.pajato.android.gamechat.exp.NotificationManager;
 import com.pajato.android.gamechat.exp.model.Checkers;
 import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.PaneManager;
-import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -143,6 +142,15 @@ public class CheckersFragment extends BaseExperienceFragment {
         resume();
     }
 
+    /** Handle taking the foreground by updating the UI based on the current experience. */
+    @Override public void onResume() {
+        // Determine if there is an experience ready to be enjoyed.  If not, hide the layout and
+        // present a spinner.  When an experience is posted by the app event manager, the game can
+        // be shown
+        super.onResume();
+        resume();
+    }
+
     @Override public void onStart() {
         // Setup the FAM, add a new game item to the overflow menu, and obtain the board (grid).
         super.onStart();
@@ -155,15 +163,6 @@ public class CheckersFragment extends BaseExperienceFragment {
         playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
         ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
         playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
-    }
-
-    /** Handle taking the foreground by updating the UI based on the current experience. */
-    @Override public void onResume() {
-        // Determine if there is an experience ready to be enjoyed.  If not, hide the layout and
-        // present a spinner.  When an experience is posted by the app event manager, the game can
-        // be shown
-        super.onResume();
-        resume();
     }
 
     /** Return a default, partially populated, Checkers experience. */
@@ -289,7 +288,6 @@ public class CheckersFragment extends BaseExperienceFragment {
         } else {
             // Start the game and update the views using the current state of the experience.
             mLayout.setVisibility(View.VISIBLE);
-            ProgressManager.instance.hide();
             updateUiFromExperience();
         }
     }
@@ -505,7 +503,7 @@ public class CheckersFragment extends BaseExperienceFragment {
      */
     private void startGame() {
         grid.removeAllViews();
-        Checkers model = (Checkers)mExperience;
+        Checkers model = (Checkers) mExperience;
         boolean isNewBoard = false;
         if (model.board == null) {
             isNewBoard = true;
@@ -559,7 +557,7 @@ public class CheckersFragment extends BaseExperienceFragment {
         }
 
         boolean hasChanged = false;
-        boolean turn = ((Checkers)mExperience).turn;
+        boolean turn = ((Checkers) mExperience).turn;
         String highlightedIdxTag = (String) mHighlightedTile.getTag();
         int highlightedIndex = Integer.parseInt(highlightedIdxTag);
         findPossibleMoves(board, highlightedIndex, mPossibleMoves);
@@ -838,7 +836,7 @@ public class CheckersFragment extends BaseExperienceFragment {
      */
     private void handleTurnChange(final boolean switchPlayer) {
 
-        boolean turn = ((Checkers)mExperience).turn;
+        boolean turn = ((Checkers) mExperience).turn;
         if(switchPlayer) {
             turn = ((Checkers) mExperience).toggleTurn();
         }
@@ -869,7 +867,7 @@ public class CheckersFragment extends BaseExperienceFragment {
         @Override public void onClick(final View v) {
             int index = Integer.parseInt((String)v.getTag());
             boolean changedBoard = false;
-            Map<String, String> board = ((Checkers)mExperience).board;
+            Map<String, String> board = ((Checkers) mExperience).board;
             if (mHighlightedTile != null) {
                 changedBoard = showPossibleMoves(index, board);
                 mHighlightedTile = null;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -35,7 +35,6 @@ import com.pajato.android.gamechat.exp.model.ChessBoard;
 import com.pajato.android.gamechat.exp.model.ChessHelper;
 import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.PaneManager;
-import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -276,7 +275,6 @@ public class ChessFragment extends BaseExperienceFragment {
         } else {
             // Start the game and update the views using the current state of the experience.
             mLayout.setVisibility(View.VISIBLE);
-            ProgressManager.instance.hide();
             updateUiFromExperience();
         }
     }
@@ -468,7 +466,7 @@ public class ChessFragment extends BaseExperienceFragment {
     private void startGame() {
         // Initialize the new board state.
         grid.removeAllViews();
-        Chess model = (Chess)mExperience;
+        Chess model = (Chess) mExperience;
         if (model.board == null) model.board = new ChessBoard();
         TextView winner = (TextView) mLayout.findViewById(R.id.winner);
         if (winner != null) winner.setText("");
@@ -622,7 +620,7 @@ public class ChessFragment extends BaseExperienceFragment {
             return;
         }
 
-        Chess model = (Chess)mExperience;
+        Chess model = (Chess) mExperience;
         possibleMoves.clear();
         ChessPiece.PieceType highlightedPieceType = board.getPieceType(highlightedIndex);
 
@@ -734,7 +732,7 @@ public class ChessFragment extends BaseExperienceFragment {
 
         // Handle the Castling Booleans.
         ChessPiece currentPiece = board.retrieve(highlightedIndex);
-        Chess model = (Chess)mExperience;
+        Chess model = (Chess) mExperience;
         if (currentPiece != null) {
             if (currentPiece.isTeamPiece(ChessPiece.PieceType.KING, ChessPiece.ChessTeam.PRIMARY)) {
                 model.primaryKingHasMoved = true;
@@ -766,7 +764,7 @@ public class ChessFragment extends BaseExperienceFragment {
      * @param switchPlayer if false, just set up the UI views but don't switch the player turn.
      */
     private void handleTurnChange(final boolean switchPlayer) {
-        boolean turn = ((Chess)mExperience).turn;
+        boolean turn = ((Chess) mExperience).turn;
         if(switchPlayer) {
             turn = ((Chess) mExperience).toggleTurn();
         }
@@ -886,7 +884,7 @@ public class ChessFragment extends BaseExperienceFragment {
                     break;
             }
 
-            ChessBoard board = ((Chess)mExperience).board;
+            ChessBoard board = ((Chess) mExperience).board;
             board.add(position, pieceType, team);
             TextView promotedPieceTile = (TextView) grid.getChildAt(position);
             promotedPieceTile.setText(ChessPiece.getUnicodeText(pieceType));

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
@@ -38,7 +38,7 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.checkers;
 import static com.pajato.android.gamechat.common.FragmentType.chess;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
@@ -71,7 +71,7 @@ public class ExpEnvelopeFragment extends BaseExperienceFragment {
     /** There has been a handled authentication change event.  Deal with the fragment to display. */
     @Subscribe public void onAuthenticationChange(final AuthenticationChangeHandled event) {
         // Simply start the next logical fragment.
-        DispatchManager.instance.startNextFragment(this.getActivity(), exp);
+        DispatchManager.instance.startNextFragment(getActivity(), exp);
     }
 
     /** Process a button click event with a tag value. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -31,7 +31,7 @@ import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
@@ -41,11 +41,18 @@ import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
 import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
 import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
 
+/**
+ * Provide a fragment to show joined groups that contain experiences.  This is the top level (home)
+ * view in the experience hierarchy.  From this view the User can drill into rooms within a group
+ * and then experiences in a room.
+ *
+ * @author Paul Michael Reilly
+ */
 public class ExpShowGroupsFragment extends BaseExperienceFragment {
 
     // Public instance methods.
 
-    /** Handle an experience list change event. */
+    /** Handle an experience list change event by dispatching again. */
     @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {
         switch (event.changeType) {
             case CHANGED:
@@ -65,7 +72,7 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
         switch (event.item != null ? event.item.getItemId() : -1) {
             case R.string.InviteFriendsOverflow:
                 if (isInMeGroup())
-                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms, null);
+                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
                 else
                     InvitationManager.instance.extendGroupInvitation(getActivity(),
                             mExperience.getGroupKey());
@@ -73,18 +80,12 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
             case R.string.SwitchToChat:
                 // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
                 ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
+                if (viewPager != null)
+                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 break;
             default:
                 break;
         }
-    }
-
-    /** Initialize the fragment by setting up the FAB and toolbar. */
-    @Override public void onStart() {
-        super.onStart();
-        FabManager.game.init(this);
-        ToolbarManager.instance.init(this, helpAndFeedback, chat, invite, settings);
     }
 
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
@@ -96,6 +97,13 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
         super.onResume();
         FabManager.game.setImage(R.drawable.ic_add_white_24dp);
         FabManager.game.init(this, GAME_HOME_FAM_KEY);
-        ToolbarManager.instance.setTitle(this, R.string.NoGamesTitleText);
+    }
+
+    /** Initialize the fragment by setting up the FAB and toolbar. */
+    @Override public void onStart() {
+        super.onStart();
+        FabManager.game.init(this);
+        int titleResId = R.string.ExpGroupsToolbarTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, invite, settings);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
@@ -32,7 +32,7 @@ import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
@@ -76,7 +76,6 @@ public class ExpShowSignedOutFragment extends BaseExperienceFragment {
         super.onResume();
         FabManager.game.setImage(R.drawable.ic_add_white_24dp);
         FabManager.game.init(this, GAME_HOME_FAM_KEY);
-        ToolbarManager.instance.setTitle(this, R.string.SignedOutTitleText);
     }
 
     /** Initialize the fragment by setting up the FAB/FAM. */
@@ -84,6 +83,7 @@ public class ExpShowSignedOutFragment extends BaseExperienceFragment {
         // Set up the FAB.
         super.onStart();
         FabManager.game.init(this);
-        ToolbarManager.instance.init(this, helpAndFeedback, chat, settings);
+        int titleResId = R.string.SignedOutTitleText;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, settings);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.inviteCommonRoom;
@@ -105,7 +105,8 @@ public class SelectExpInviteFragment extends BaseChatFragment {
         // Establish the create type, the list type, setup the toolbar and turn off the access
         // control.
         super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
+        int titleResId = R.string.InviteTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
         FabManager.game.setMenu(INVITE_EXP_FAM_KEY, getSelectionMenu());
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectRoomFragment.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
+import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -40,17 +41,17 @@ public class SelectRoomFragment extends BaseExperienceFragment {
         logEvent("onClick (playModeSetup)");
     }
 
-    /** Initialize the fragment by setting up the FAB and toolbar. */
-    @Override public void onStart() {
-        super.onStart();
-        ToolbarManager.instance.init(this, helpAndFeedback, settings);
-    }
-
     /** .... */
     @Override public void onResume() {
         super.onResume();
         FabManager.game.init(this);
         updateAdapterList();
-        ToolbarManager.instance.setTitle(this, this.type.toolbarType.titleResourceId);
+    }
+
+    /** Initialize the fragment by setting up the FAB and toolbar. */
+    @Override public void onStart() {
+        super.onStart();
+        int titleResId = R.string.SelectRoomToolbarTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
@@ -63,13 +63,12 @@ public class SelectUserFragment extends BaseExperienceFragment {
         super.onResume();
         FabManager.game.init(this);
         updateAdapterList();
-        ToolbarManager.instance.setTitle(this, R.string.SelectUserToolbarTitle);
     }
 
     /** Initialize the fragment by setting up the FAB and toolbar. */
     @Override public void onStart() {
         super.onStart();
-        ToolbarManager.instance.init(this);
+        ToolbarManager.instance.init(this, R.string.SelectUserToolbarTitle);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
@@ -22,6 +22,7 @@ import android.support.v4.view.ViewPager;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
@@ -30,7 +31,8 @@ import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.DispatchManager.DispatcherKind.exp;
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
+import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
@@ -60,21 +62,22 @@ public class ShowNoExperiencesFragment extends BaseExperienceFragment {
             return;
         // Case on the item resource id if there is one to be had.
         switch (event.item != null ? event.item.getItemId() : -1) {
+            case R.string.InviteFriendsOverflow:
+                String groupKey = mExperience.getGroupKey();
+                if (isInMeGroup())
+                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
+                else
+                    InvitationManager.instance.extendGroupInvitation(getActivity(), groupKey);
+                break;
             case R.string.SwitchToChat:
                 // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
                 ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
+                if (viewPager != null)
+                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 break;
             default:
                 break;
         }
-    }
-
-    /** Initialize the fragment by setting up the FAB and toolbar. */
-    @Override public void onStart() {
-        super.onStart();
-        FabManager.game.init(this);
-        ToolbarManager.instance.init(this, helpAndFeedback, chat, settings);
     }
 
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
@@ -85,6 +88,13 @@ public class ShowNoExperiencesFragment extends BaseExperienceFragment {
         super.onResume();
         FabManager.game.setImage(R.drawable.ic_add_white_24dp);
         FabManager.game.init(this, GAME_HOME_FAM_KEY);
-        ToolbarManager.instance.setTitle(this, R.string.NoGamesTitleText);
+    }
+
+    /** Initialize the fragment by setting up the FAB and toolbar. */
+    @Override public void onStart() {
+        super.onStart();
+        FabManager.game.init(this);
+        int titleResId = R.string.NoGamesToolbarTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, settings);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -48,7 +48,6 @@ import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.exp.model.TTTBoard;
 import com.pajato.android.gamechat.exp.model.TicTacToe;
 import com.pajato.android.gamechat.main.PaneManager;
-import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -433,7 +432,6 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
             mLayout.setVisibility(View.GONE);
         } else {
             // Start the game and update the views using the current state of the experience.
-            ProgressManager.instance.hide();
             mLayout.setVisibility(View.VISIBLE);
             updateUiFromExperience();
         }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -119,6 +119,11 @@ public class Checkers implements Experience {
         return ExpType.valueOf(type);
     }
 
+    /** Return the create time to satisfy the Experience contract. */
+    @Override public long getCreateTime() {
+        return createTime;
+    }
+
     /** Return the group push key. */
     @Exclude @Override public String getGroupKey() {
         return groupKey;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
@@ -145,6 +145,11 @@ import static com.pajato.android.gamechat.exp.ExpType.chessET;
         return result;
     }
 
+    /** Return the create time to satisfy the Experience contract. */
+    @Override public long getCreateTime() {
+        return createTime;
+    }
+
     /** Return the experience push key. */
     @Exclude @Override public String getExperienceKey() {
         return key;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -131,6 +131,11 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
         return result;
     }
 
+    /** Return the create time to satisfy the Experience contract. */
+    @Override public long getCreateTime() {
+        return createTime;
+    }
+
     /** Return the experience push key. */
     @Exclude @Override public String getExperienceKey() {
         return key;

--- a/app/src/main/res/layout/exp_list.xml
+++ b/app/src/main/res/layout/exp_list.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+    <include layout="@layout/exp_toolbar_inc" />
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        ads:adSize="SMART_BANNER"
+        ads:adUnitId="@string/banner_ad_unit_id"/>
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/ItemList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp"
+        android:tag="@integer/groupList"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,9 +18,9 @@
     <string name="MenuItemManageRooms">Manage rooms</string>
     <string name="MenuItemSearch">Search</string>
     <string name="MenuItemSettings">Settings</string>
-    <string name="SelectUserToolbarTitle">Select User</string>
     <string name="SignInPrefixMessageText">Use the</string>
     <string name="SignInSuffixMessageText">menu in the toolbar to sign in.</string>
+    <string name="SignedOutToolbarTitle">Signed Out</string>
     <string name="SwitchToChat">Switch to Chat</string>
     <string name="SwitchToExp">Switch to Game</string>
     <string name="action_save">SAVE</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -13,6 +13,8 @@
     <string name="DefaultRoomName">Common</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>
     <string name="Group">Group</string>
+    <string name="GroupsToolbarTitle">Groups with Messages</string>
+    <string name="GroupMeToolbarTitle">My Chat Room</string>
     <string name="ListIconDesc">The list icon.</string>
     <string name="InsertEmoticon">Inserting an emoticon</string>
     <string name="InsertEmoticonDesc">Insert emoticon image button.</string>
@@ -20,7 +22,6 @@
     <string name="InsertMapDesc">Insert map image button.</string>
     <string name="InsertPhoto">Inserting a photo from your device</string>
     <string name="InsertPhotoDesc">Insert photo from file image button.</string>
-    <string name="InviteMembersFeature">Inviting group or room members</string>
     <string name="InviteFriendsOverflow">Invite friends</string>
     <string name="JoinedGroupsMessage">You have joined group %s</string>
     <string name="JoinedOneRoom">You have joined the %1$s room in group %2$s</string>
@@ -36,6 +37,7 @@
     <string name="PickForInvitationTitle">Room Invitations</string>
     <string name="RoomListIcon">The room list icon.</string>
     <string name="RoomsAvailableHeaderText">Rooms</string>
+    <string name="RoomsToolbarTitle">Rooms with Messages</string>
     <string name="SelectAllMenuTitle">Select All</string>
     <string name="SelectMembersMenuTitle">Select All Members</string>
     <string name="SelectRoomsMenuTitle">Select All Rooms</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -4,6 +4,7 @@
     <string name="ErrorCheckersCreation">Error: cannot create a Checkers experience</string>
     <string name="ErrorChessCreation">Error: cannot create a Chess experience</string>
     <string name="ErrorTTTCreation">Error: cannot create a TicTacToe experience</string>
+    <string name="ExpGroupsToolbarTitle">Groups with Games</string>
     <string name="FutureSelectModes">Select playing modes</string>
     <string name="FutureSelectRooms">Select rooms</string>
     <string name="InvalidButton">You must click on an empty button!  Try again.</string>
@@ -12,7 +13,7 @@
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyRooms">Go To My Rooms</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
-    <string name="NoGamesTitleText">Games</string>
+    <string name="NoGamesToolbarTitle">No Games</string>
     <string name="PlayAgain">Play again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
@@ -21,6 +22,8 @@
     <string name="PlayModeUserMenuTitle">Play a User</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
     <string name="PromotePawnMsg">Promote Your Pawn:</string>
+    <string name="SelectRoomToolbarTitle">Select Room</string>
+    <string name="SelectUserToolbarTitle">Select User</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>
     <string name="StalemateMessage">Stalemate!</string>
     <string name="StartNewGame">Starting a new game.  Enjoy!</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This is the first commit of a handful that will focus on providing parity between navigation experiences and navigating messages.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- mAdView, initAdView(): move to the base class to allow for ads on both the chat and game fragments.
- onStart(); move per RNF.
- onDispatch(): do not use a GroupItem to build the list item, instead do it directly.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowNoMessagesFragment.java

- Summary: use the renamed and moved FragmentKind enum.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java

- Summary: use the renamed and moved FragmentKind enum.
- onDispatch(): do not use a GroupItem to build the list item, instead do it directly.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java

- onStart(): move per RNF and include the title resource id when initializing the tool bar.
- getTitleResid(): new method used to obtain the various toolbar title resource ids.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

- onStart(): pass an item to use when establishing the toolbar title.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java

- onChatListChange(): do not deal with the progress spinner.
- onStart(): pass a toolbar title resource id on toolbar initialization.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java

- onStart(): pass a toolbar title resource id on toolbar initialization.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java

- onStart(): move per RNF and pass an item to assist with the toolbar title.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- mAdView, initAdView(): move from the base chat fragment class to allow for ads in both experience and chat navigation.
- getList(): apply RNF and add a case for the experience group list.

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java

- Summary: use the renamed and moved FragmentKind enum.
- chainFragment(): add an overload for chaining based on fragment type.

new file:   app/src/main/java/com/pajato/android/gamechat/common/FragmentKind.java

- Summary: move to it's own class for clarity, simplicity and convenience.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java

- Summary: move to it's own class for clarity, simplicity and convenience.
- expGroupList: use a real layout file instead of a placeholder.

modified:   app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java

- ToolbarType: simplify by removing the toolbar title resource id from the constant definition to toolbar initialization.
- init(): add overloads for various parameters used to establish a toolbar title.
- setTitle(), setTitles(), update(): remove as these are now stale.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java

- ListItem(): do not use a GroupItem class to build a list item for a group item.

modified:   app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

- mDateHeaderTypeToGroupListMap, mGroupToLastNewExpMap, onExperienceChangeEvent(), updateGroupHeader(), isNew(): add support for experience navigation.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- getListItemData(), getGroupsItemList(): add a parameter for fragment kind and handle both messages and experiences; apply RNF.
- addItem(), getGroupText(), getNewCount(), getNewExpCount(), getNewMessageCount(): new support for handling both messages and experiences.
- updateGroupHeaders(): filter out me group headers.

new file:   app/src/main/java/com/pajato/android/gamechat/event/ExpListChangeEvent.java

- Summary: new file to support detection of experience list changes.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- onResume(): new method to support experience list navigation.
- onStart(): support ads.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/Experience.java

- Summary: add support for getting the create time stamp.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java

- onResume: move per RNF.
- resume(): do not deal with the progress spinner.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java

- resume(): do not deal with the progress spinner.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java

- onAuthenticationChange(): simplify ('this' not needed).

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java

- Summary: lose the placeholder code and add parity code to allow for experience navigation.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java

- Summary: use the moved and renamed FragmentKind enum.
- onClick(): extend a group invitation (correctly).
- onStart(): pass a title resource id when initializing the toolbar; move per RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

- Summary: do not deal with the progress spinner.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java

- Summary: implement the new get create time interface.

new file:   app/src/main/res/layout/exp_list.xml

- Summary: layout file for showing experience groups, rooms and lists of experiences.

modified:   app/src/main/res/values/strings.xml
modified:   app/src/main/res/values/strings_chat.xml
modified:   app/src/main/res/values/strings_exp.xml

- Summary: add new localized string resources and remove stale ones.