### PR TITLE
Fix a few null pointer problems.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -134,8 +134,6 @@ public class CreateGroupFragment extends BaseCreateFragment {
 
         // Give the user a snackbar message offering to join friends to the group.
         NotificationManager.instance.notifyGroupCreate(this, mGroup.key, mGroup.name);
-
-        activity.onBackPressed();
     }
 
     /** Set the name of the managed object conditionally to the given value. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -118,8 +118,6 @@ public class CreateRoomFragment extends BaseCreateFragment {
 
         // Give the user a snackbar message offering to join friends to the room.
         NotificationManager.instance.notifyRoomCreate(this, mRoom.key, mRoom.name);
-
-        activity.onBackPressed();
     }
 
     /** Set the room name conditionally to the given value. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -92,6 +92,7 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
         switch (type) {
             case contactHeader:
             case date:
+            case resourceHeader:
             case roomsHeader:
                 return new HeaderViewHolder(getView(parent, R.layout.item_header));
             case contact:
@@ -125,6 +126,7 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
         if (item != null) {
             switch (item.type) {
                 case date:
+                case resourceHeader:
                 case roomsHeader:
                     // The header item types simply update the section title.
                     int id = item.nameResourceId;


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a few cases where null pointer exceptions have been introduced:

1) the most recent push introduced a problem with generating lists (breaks the recycler list view),

2) the introduction of a back press in the save operations for create group and create room chat operations causes the context (activity) to become null leading to very unhappy DispatchManager code.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java

- save(): do not generate a back press.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java

- onCreateViewHolder(), onBindViewHolder(): add cases for the 'resourceHeader' type.