### PR TITLE
Snackbar/FAB interactions improved and move protected user 'breadcrumb'.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
@@ -5,12 +5,6 @@ import android.support.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-
 /**
  * All tests are based on the the following documentation:
  * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -29,7 +29,6 @@ import android.util.Log;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.fragment.ChatShowRoomsFragment;
 import com.pajato.android.gamechat.common.adapter.MenuAdapter;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 
@@ -170,7 +169,7 @@ public enum FabManager {
         mTag = fragmentTag;
     }
 
-    /** Ensure that the FAb is being shown. */
+    /** Ensure that the FAB is being shown. */
     public void show(@NonNull final Fragment fragment) {
         View layout = getFragmentLayout(fragment);
         if (layout == null) return;
@@ -203,13 +202,13 @@ public enum FabManager {
             switch (value) {
                 case opened:
                     // The FAB is showing 'X' and it's menu is visible.  Set the icon to '+', close
-                    // the menu and undim the frame.
+                    // the menu and un-dim the frame.
                     dismissMenu(fragment, layout);
                     break;
                 case closed:
                     // The FAB is showing '+' and the menu is not visible.  Set the icon to X and
                     // open the named menu (if name is set) or the last one used.
-                    if (name != null) setMenu(fragment, name);
+                    setMenu(fragment, name);
                     fab.setImageResource(R.drawable.ic_clear_white_24dp);
                     fab.setTag(R.integer.fabStateKey, opened);
                     dimmerView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -178,16 +178,16 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
     public void extendGroupInvitation(final FragmentActivity activity, final String groupKey) {
 
         Log.i(TAG, "extendGroupInvitation with groupKey=" + groupKey);
-        Group grp = GroupManager.instance.getGroupProfile(groupKey);
-        if (grp == null) {
+        Group group = GroupManager.instance.getGroupProfile(groupKey);
+        if (group == null) {
             Log.e(TAG, "Received invitation with groupKey: " + groupKey + " but GroupManager " +
                     "can't find this group");
             return;
         }
         // Create an entry for the invite map for the specified group.
-        GroupInviteData data = new GroupInviteData(grp.key, grp.name, grp.commonRoomKey);
+        GroupInviteData data = new GroupInviteData(group.key, group.name, group.commonRoomKey);
         mInviteMap.put(data.groupKey, data);
-        startInvitationIntent(activity, grp.name);
+        startInvitationIntent(activity, group.name);
     }
 
     /** Return a set of groups and rooms for invitations */

--- a/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
@@ -20,11 +20,9 @@ package com.pajato.android.gamechat.common;
 import android.support.annotation.NonNull;
 
 import com.pajato.android.gamechat.common.adapter.ListItem;
-import com.pajato.android.gamechat.common.adapter.SelectableMemberItem;
 import com.pajato.android.gamechat.common.adapter.UserItem;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
-import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.MemberManager;
 
 import java.util.ArrayList;

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/SelectableGroupItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/SelectableGroupItem.java
@@ -24,7 +24,7 @@ import com.pajato.android.gamechat.database.GroupManager;
 
 public class SelectableGroupItem {
 
-    // public instance varaibles
+    // public instance variables
 
     /** the group key */
     public String groupKey;

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * In the GameChat account context, the class provides a list (named 'joinList') of group
  * identifiers for which the account holder is a member.
  *
- * In the GameChat group member context, the class provides a list ('joinList') of room identifers
+ * In the GameChat group member context, the class provides a list ('joinList') of room identifiers
  * which the member holder has joined.  In this context, the email address and the FirebaseUser
  * provided identifier are and will remain identical to the the values provided by the FirebaseUser
  * object they come from.  The full name (display name) and the photo url may be changed at will.

--- a/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
@@ -52,7 +52,7 @@ public enum CredentialsManager {
     /** The email provider type. */
     private static final String EMAIL_PROVIDER = "emailProvider";
 
-    /** The format used to perist a credential email address. */
+    /** The format used to persist a credential email address. */
     private static final String FORMAT_EMAIL = "%s:email:%s";
 
     /** The format used to persist a credential provider. */
@@ -71,7 +71,7 @@ public enum CredentialsManager {
 
     // Public instance methods
 
-    /** Return credientials for a given User account by email address, null on no account. */
+    /** Return credentials for a given User account by email address, null on no account. */
     public AuthCredential getAuthCredential(final String emailAddress) {
         // Determine if there is no such account.
         Credentials credentials = mCredentialsMap.get(emailAddress);
@@ -92,8 +92,7 @@ public enum CredentialsManager {
     /** Build the object by reading in the saved credentials. */
     public void init(final SharedPreferences prefs) {
         mPrefs = prefs;
-        String key = CREDENTIALS_KEY;
-        Set<String> stringSet = prefs.getStringSet(key, null);
+        Set<String> stringSet = prefs.getStringSet(CREDENTIALS_KEY, null);
         if (stringSet != null) {
             for (String value : stringSet) cacheValue(value);
             cacheValidate();
@@ -108,8 +107,7 @@ public enum CredentialsManager {
 
         // Persist the credentials.
         SharedPreferences.Editor editor = mPrefs.edit();
-        String key = CREDENTIALS_KEY;
-        editor.putStringSet(key, getStringSet());
+        editor.putStringSet(CREDENTIALS_KEY, getStringSet());
         editor.apply();
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -26,7 +26,6 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.firebase.ui.auth.AuthUI;
-import com.google.android.gms.auth.api.credentials.CredentialsApi;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.AuthResult;
@@ -37,11 +36,9 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ValueEventListener;
-import com.pajato.android.gamechat.BuildConfig;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
-import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.handler.AccountChangeHandler;
 import com.pajato.android.gamechat.event.AccountChangeEvent;
@@ -51,7 +48,6 @@ import com.pajato.android.gamechat.event.AuthenticationChangeHandled;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
 import com.pajato.android.gamechat.event.RegistrationChangeEvent;
-import com.pajato.android.gamechat.event.TagClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -63,6 +59,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static android.R.attr.data;
 import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.ME;
 import static com.pajato.android.gamechat.event.RegistrationChangeEvent.REGISTERED;
@@ -86,7 +83,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
      * features.
      *
      * restricted: A restricted User cannot create another restricted User and has limited access
-     * to app features. For example, a restrited User cannot create a group or a room. The notion
+     * to app features. For example, a restricted User cannot create a group or a room. The notion
      * of a restricted/protected User is for use with young children.
      * Every restricted/protected User has a "chaperone", a standard User.  The restricted User can
      * only be a member of a group that the chaperone is a member of.
@@ -111,6 +108,9 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
 
     /** The database path to an invitation.  */
     public static final String INVITE_PATH = "/invites/%s/";
+
+    /** The database path to protected user breadcrumb */
+    public static final String PROTECTED_PATH = "/protectedUsers/%s";
 
     // Private class constants.
 
@@ -153,33 +153,38 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         String roomKey = database.child(path).push().getKey();
 
         // Check for a chaperone account. If one exists, update this account and leave breadcrumbs
-        // for the chaperone.
+        // for the chaperone. Due to the authentication rules, this can't be done until after the
+        // new account is created (as only authorized accounts can access the database).
         if (mChaperone != null && !mChaperone.equals(account.id)) {
-            // Leave the breadcrumbs for the chaperone in the form of an invitation note in the
-            // database.
             account.chaperone = mChaperone;
             account.type = AccountType.restricted.name();
-            Map<String, Object> protectedUsers = new HashMap<>();
-            protectedUsers.put(mChaperone, account.id);
-            String invitePath = String.format(INVITE_PATH, mChaperone);
-            DBUtils.instance.updateChildren(invitePath, protectedUsers);
-            mChaperone = null;
         } else
             // This User has a standard account.
             account.type = AccountType.standard.name();
 
         // Set up and persist the account for the given user.
-        long tstamp = account.createTime;
+        long tStamp = account.createTime;
         account.groupKey = groupKey;
         path = String.format(Locale.US, ACCOUNT_PATH, account.id);
         DBUtils.instance.updateChildren(path, account.toMap());
+
+        // Leave the breadcrumbs for the chaperone in the form of an invitation note in the
+        // database. This must be done after the new account has been added, because the database
+        // authorization rules don't allow non-authorized users to have access.
+        if (mChaperone != null && !mChaperone.equals(account.id)) {
+            Map<String, Object> protectedUsers = new HashMap<>();
+            protectedUsers.put(mChaperone, account.id);
+            String protectedUserPath = String.format(PROTECTED_PATH, mChaperone);
+            DBUtils.instance.updateChildren(protectedUserPath, protectedUsers);
+            mChaperone = null;
+        }
 
         // Update and persist the group profile.
         List<String> rooms = new ArrayList<>();
         rooms.add(roomKey);
         List<String> members = new ArrayList<>();
         members.add(account.id);
-        Group group = new Group(groupKey, account.id, null, tstamp, members, rooms);
+        Group group = new Group(groupKey, account.id, null, tStamp, members, rooms);
         path = String.format(Locale.US, GroupManager.GROUP_PROFILE_PATH, groupKey);
         DBUtils.instance.updateChildren(path, group.toMap());
 
@@ -192,7 +197,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
 
         // Update the "me" room profile on the database.
         String name = account.getDisplayName();
-        Room room = new Room(roomKey, account.id, name, groupKey, tstamp, 0, ME);
+        Room room = new Room(roomKey, account.id, name, groupKey, tStamp, 0, ME);
         path = String.format(Locale.US, RoomManager.ROOM_PROFILE_PATH, groupKey, roomKey);
         DBUtils.instance.updateChildren(path, room.toMap());
 
@@ -278,16 +283,20 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
                     GroupManager.instance.setWatcher(key);
         }
 
-        // Check for protected user invites and update the account if there are any.
+        // Check for protected user data and update the account if there are any.
         if(event.account != null) {
             DatabaseReference invite = FirebaseDatabase.getInstance().getReference()
-                    .child(String.format(AccountManager.INVITE_PATH, mCurrentAccount.id));
+                    .child(String.format(AccountManager.PROTECTED_PATH, mCurrentAccount.id));
 
             invite.addListenerForSingleValueEvent(new ValueEventListener() {
                 @Override public void onDataChange(DataSnapshot dataSnapshot) {
                     // If the snapshot has nothing to offer, move on. Otherwise update the account.
-                    if(!dataSnapshot.hasChildren()) return;
+                    if (!dataSnapshot.hasChildren())
+                        return;
+                    // Update the account.
                     Account account = AccountManager.instance.getCurrentAccount();
+                    if (account == null) // not logged in
+                        return;
                     for (DataSnapshot data : dataSnapshot.getChildren()) {
                         account.protectedUsers.add((String) data.getValue());
                         data.getRef().removeValue();

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static android.R.attr.data;
 import static com.pajato.android.gamechat.chat.model.Message.SYSTEM;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.ME;
 import static com.pajato.android.gamechat.event.RegistrationChangeEvent.REGISTERED;
@@ -106,10 +105,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     /** The sentinel value to use for indicating a signed out experience key. */
     public static final String SIGNED_OUT_EXPERIENCE_KEY = "signedOutExperienceKey";
 
-    /** The database path to an invitation.  */
-    public static final String INVITE_PATH = "/invites/%s/";
-
-    /** The database path to protected user breadcrumb */
+    /** The database path to protected user data */
     public static final String PROTECTED_PATH = "/protectedUsers/%s";
 
     // Private class constants.

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -22,13 +22,8 @@ import android.support.annotation.NonNull;
 
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.FragmentType;
-import com.pajato.android.gamechat.common.InvitationManager;
-import com.pajato.android.gamechat.common.adapter.ListItem;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
@@ -105,10 +105,10 @@ public enum MessageManager {
         String name = type == SYSTEM ? systemName : account.getDisplayName();
         String systemUrl = "android.resource://com.pajato.android.gamechat/drawable/ic_launcher";
         String url = type == SYSTEM ? systemUrl : account.url;
-        long tstamp = new Date().getTime();
+        long tStamp = new Date().getTime();
         List<String> members = new ArrayList<>();
         members.addAll(room.getMemberIdList());
-        Message message = new Message(key, account.id, name, url, tstamp, text, type, members);
+        Message message = new Message(key, account.id, name, url, tStamp, text, type, members);
 
         // Persist the message.
         path = String.format(Locale.US, MESSAGE_PATH, room.groupKey, room.key, key);

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
@@ -23,7 +23,6 @@ import android.util.Log;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
-import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
@@ -137,7 +136,7 @@ public class ExperiencesChangeHandler extends DatabaseEventHandler implements Ch
 
     /** Process the change by updating the database list and notifying the app. */
     private void process(final DataSnapshot snapshot, final int type) {
-        // Validate the snapshot and the experience.  Abort if eitehr is invalid.
+        // Validate the snapshot and the experience.  Abort if either is invalid.
         Experience experience = snapshot.exists() ? getExperience(snapshot) : null;
         Map<String, Experience> expMap = experience != null ? getExpMap(experience) : null;
         if (expMap == null) return;

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java
@@ -125,7 +125,7 @@ public class MessageListChangeHandler extends DatabaseEventHandler implements Ch
         // The room map exists.  Determine if the message map needs to be created.
         messageMap = roomMap.get(mRoomKey);
         if (messageMap == null) {
-            // The m mapessage needs to be created.  Do it now and associate it with the room.
+            // The message map needs to be created.  Do it now and associate it with the room.
             messageMap = new HashMap<>();
             roomMap.put(mRoomKey, messageMap);
         }

--- a/app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java
@@ -28,7 +28,7 @@ public class AccountChangeEvent {
 
     // Public instance variable.
 
-    /** The changed, non-null acount. */
+    /** The changed, non-null account. */
     public Account account;
 
     // Public constructor.

--- a/app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
@@ -1,6 +1,5 @@
 package com.pajato.android.gamechat.event;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/app/src/main/java/com/pajato/android/gamechat/event/InviteEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/InviteEvent.java
@@ -1,7 +1,7 @@
 package com.pajato.android.gamechat.event;
 
 /**
- * Provides an event type indicating that a group invitation should be initiated.
+ * Provides an event type indicating that an invitation should be initiated.
  */
 
 public class InviteEvent {

--- a/app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java
@@ -35,7 +35,7 @@ public class MemberChangeEvent {
     /** The account push key (User id) */
     public String key;
 
-    /** The changed, non-null acount. */
+    /** The changed, non-null account. */
     public Account member;
 
     /** Build the instance with the given account; null indicates a sign out occurred. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java
@@ -18,14 +18,9 @@
 package com.pajato.android.gamechat.exp;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.exp.model.Checkers;
 import com.pajato.android.gamechat.exp.model.Chess;
 import com.pajato.android.gamechat.exp.model.TicTacToe;
-
-import static com.pajato.android.gamechat.common.FragmentType.checkers;
-import static com.pajato.android.gamechat.common.FragmentType.chess;
-import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 
 /**
  * The games enum values associate games, modes, fragments and resources in a very flexible, concise

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessPiece.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessPiece.java
@@ -60,7 +60,7 @@ public class ChessPiece {
     /** Provide a default map for a Firebase create/update. */
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
-        result.put("peiceId", pieceType);
+        result.put("pieceType", pieceType);
         result.put("teamId", teamId);
         return result;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
@@ -13,8 +13,6 @@ import static com.pajato.android.gamechat.exp.ExpType.chessET;
 
 /**
  *  Provide a Firebase model class for a chessET game experience.
- *
- *  Created by sscott on 12/30/16.
  */
 @IgnoreExtraProperties public class Chess implements Experience {
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -68,7 +68,7 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
     /** The experience display name. */
     public String name;
 
-    /** The member account identifer who created the experience. */
+    /** The member account identifier who created the experience. */
     public String owner;
 
     /** The list of players, for tictactoe, two of them. */

--- a/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -77,7 +77,7 @@ public class IntroActivity extends AppCompatActivity {
             finish();
         }
     }
-    /** Create the intro activity to highlight some features and provide a get started opertion. */
+    /** Create the intro activity to highlight some features and provide a get started operation. */
     @Override protected void onCreate(final Bundle savedInstanceState) {
         // Establish the activity state and set up the intro layout enhancing the experience for
         // Lollipop and follow on devices by enabling elevated animation.
@@ -289,7 +289,7 @@ public class IntroActivity extends AppCompatActivity {
         /** The fadein image. */
         private final ImageView mFadeinImage;
 
-        /** The fadout image. */
+        /** The fadeout image. */
         private final ImageView mFadeoutImage;
 
         /** Build the animation handler. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -25,7 +25,6 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.net.Uri;
 import android.support.design.widget.NavigationView;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;


### PR DESCRIPTION
# Rationale

Modifications to improve handling of notifications (correctly hide the 'chat' or 'game' version of the FAB while notification snackbar is present). Change protected user 'breadcrumb' to be under 'protectedUsers' node in the database, rather than under 'invites' so that it's possible to write rational access rules for the database.  Also, fix a bunch of lint complaints.

## Files Changed

#### app/src/androidTest/java/com/pajato/android/gamechat/FABTest.java
* Remove unused imports

#### app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
* Fix lint complaints

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
* extendGroupInvitation(): refactor 'grp' to be 'group'

#### app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
* Remove unused imports

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/SelectableGroupItem.java
* Fix typo

#### app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
* Fix typo

#### app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
* Typos and other lint complaints fixed

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* Remove unused imports
* Put protected user 'breadcrumb' under 'protectedUsers' node in the database
* createAccount(): Move the access to protectedUsers node in the database so it is after the code to create the account. This allows the enforcement of an access rule for the database that ensures that only authenticated access is allowed. This required splitting up the handling of a chaperone value: first, apply the chaperone to the account, then save the account to the database, then write the 'breadcrumb' into the database under 'protectedUsers'.
* onAccountChange(): for listener for single value event, change access to the protected user data to be under the protectedUsers node in the database. Also check for null account value, which can happen while changing accounts

#### app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
* Remove unused imports

#### app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
* Rename tstamp to make lint happy

#### app/src/main/java/com/pajato/android/gamechat/database/handler/ExperiencesChangeHandler.java
* Remove unused import and fix typo

#### app/src/main/java/com/pajato/android/gamechat/database/handler/MessageListChangeHandler.java
* fix typo

#### app/src/main/java/com/pajato/android/gamechat/event/AccountChangeEvent.java
* fix typo

#### app/src/main/java/com/pajato/android/gamechat/event/GroupJoinedEvent.java
* Remove unused imports

#### app/src/main/java/com/pajato/android/gamechat/event/InviteEvent.java
* fix comment

#### app/src/main/java/com/pajato/android/gamechat/event/MemberChangeEvent.java
* fix typo

#### app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java
* Remove unused imports

#### app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
* Add NotifyType enum and use it to distinguish which FAB we want to interact with
* showSnackbar(): add NotifyType parameter and pass to SnackbarChangeHandler
* SnackbarChangeHandler(): add mType member variable; use to determine which FAB to interact with

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessPiece.java
* toMap(): fix erroneous field name

#### app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
* Remove sscott which lint doesn't like!

#### app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
* fix typo

#### app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
* fix typos

#### app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
* Remove unused import
