### PR TITLE
Player menu

### DIFF
--- a/app/src/main/res/drawable/ic_menu_black_24px.xml
+++ b/app/src/main/res/drawable/ic_menu_black_24px.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:pathData="M3,18h18v-2L3,16v2zM3,13h18v-2L3,11v2zM3,6v2h18L21,6L3,6z"
-        android:fillColor="#000000"/>
-</vector>

--- a/app/src/main/res/layout/chat_signed_out.xml
+++ b/app/src/main/res/layout/chat_signed_out.xml
@@ -17,7 +17,6 @@ http://www.gnu.org/licenses
 -->
 <!-- The main content for the no sign in fragment is a message imploring the User to sign in. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -31,29 +30,12 @@ http://www.gnu.org/licenses
         android:text="@string/ChatSignedOutMessageText"
         android:textAlignment="center"
         android:textSize="24sp" />
-    <LinearLayout
-        android:layout_width="wrap_content"
+    <TextView
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:orientation="horizontal">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/SignInPrefixMessageText"
-            android:textAlignment="center"
-            android:textSize="24sp"/>
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="2dp"
-            android:layout_marginEnd="2dp"
-            android:contentDescription="@string/HamburgerMenuDesc"
-            app:srcCompat="@drawable/ic_menu_black_24px"/>
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/SignInSuffixMessageText"
-            android:textAlignment="center"
-            android:textSize="24sp"/>
-    </LinearLayout>
+        android:id="@+id/emptyListMessage2"
+        android:text="@string/SignInMessageText"
+        android:padding="24dp"
+        android:textAlignment="center"
+        android:textSize="24sp" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,7 @@
     <string name="MenuItemManageRooms">Manage rooms</string>
     <string name="MenuItemSearch">Search</string>
     <string name="MenuItemSettings">Settings</string>
-    <string name="SignInPrefixMessageText">Use the</string>
-    <string name="SignInSuffixMessageText">menu in the toolbar to sign in.</string>
+    <string name="SignInMessageText">Use the \u2630 menu in the toolbar to sign in.</string>
     <string name="SignedOutToolbarTitle">Signed Out</string>
     <string name="SwitchToChat">Switch to Chat</string>
     <string name="SwitchToExp">Switch to Game</string>


### PR DESCRIPTION
# Rationale
The not-signed-in message the font wasn't consistent and the spacing of the message was erratic.  Use unicode for the hamburger menu icon which solves the layout ugliness and makes the font look consistent.

## Files Changed
#### app/src/main/res/drawable/ic_menu_black_24px.xml
* Delete as this is no longer used.
#### app/src/main/res/layout/chat_signed_out.xml
* Replace the LinearLayout with a single TextView for the second message.
#### app/src/main/res/values/strings.xml
* Replace the prefix and suffix message with a single message which contains the appropriate unicode value for the hamburger menu.