### PR TITLE
Fix "no experiences" fragment so it doesn't show a hamburger menu.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -87,7 +87,7 @@ public enum FragmentType {
     experienceList (ShowExperiencesFragment.class, expMain, R.layout.exp_none),
     joinRoom (JoinRoomsFragment.class, joinRoomTT, R.layout.chat_join_rooms),
     messageList (ShowMessagesFragment.class, chatChain, R.layout.chat_messages),
-    noExperiences (ShowNoExperiencesFragment.class, chatMain, R.layout.exp_none),
+    noExperiences (ShowNoExperiencesFragment.class, expMain, R.layout.exp_none),
     noMessages (ShowNoMessagesFragment.class, chatMain, R.layout.chat_no_messages),
     selectChatGroupsRooms(SelectChatInviteFragment.class, selectInviteTT, R.layout.select_for_invite),
     selectExpGroupsRooms (SelectExpInviteFragment.class, selectInviteTT, R.layout.select_for_invite),


### PR DESCRIPTION
# Rationale
The "no experiences" fragment had a hamburger menu. This is a bug.

## Files Changed
* app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
For 'noExperiences' type, change toolbar type to 'expMain' (it was 'chatMain' which causes the addition of the hamburger menu).
