### PR TITLE
Experience navigation feature, drill into an experience.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java
@@ -18,9 +18,14 @@
 package com.pajato.android.gamechat.exp;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.exp.model.Checkers;
 import com.pajato.android.gamechat.exp.model.Chess;
 import com.pajato.android.gamechat.exp.model.TicTacToe;
+
+import static com.pajato.android.gamechat.common.FragmentType.checkers;
+import static com.pajato.android.gamechat.common.FragmentType.chess;
+import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 
 /**
  * The games enum values associate games, modes, fragments and resources in a very flexible, concise
@@ -60,5 +65,18 @@ public enum ExpType {
         mTitleResId = titleId;
         mPrimaryIndex = primary;
         mSecondaryIndex = secondary;
+    }
+
+    /** Return the fragment type associated with this experience type. */
+    public FragmentType getFragmentType() {
+        switch (this) {
+            case checkersET:
+                return checkers;
+            case chessET:
+                return chess;
+            case tttET:
+                return tictactoe;
+        }
+        return null;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -17,7 +17,6 @@ import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
@@ -98,8 +97,7 @@ public class CheckersFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        logEvent("onClick (tictactoe)");
-        processClickEvent(event.view);
+        processClickEvent(event.view, "tictactoe");
     }
 
     /** Handle a FAM or Snackbar Checkers click event. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -87,8 +87,7 @@ public class ChessFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        logEvent("onClick (chess)");
-        processClickEvent(event.view);
+        processClickEvent(event.view, "chess");
     }
 
     /** Handle a FAM or Snackbar Chess click event. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -57,8 +57,7 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        logEvent("onClick (expShowGroups)");
-        processClickEvent(event.view);
+        processClickEvent(event.view, "expShowGroups");
     }
 
     /** Handle an experience list change event by dispatching again. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
@@ -28,8 +28,7 @@ public class ExpShowRoomsFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        logEvent("onClick (expShowRooms)");
-        processClickEvent(event.view);
+        processClickEvent(event.view, "expShowRooms");
     }
 
     /** Initialize the fragment by setting in the FAB. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
@@ -27,8 +27,7 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
 
     @Subscribe public void onClick(final ClickEvent event) {
         // todo add some code here.
-        logEvent("onClick (showExperiences)");
-        processClickEvent(event.view);
+        processClickEvent(event.view, "showExperiences");
     }
 
     /** Initialize the fragment by setting in the FAB. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
@@ -24,6 +24,7 @@ import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
@@ -43,6 +44,12 @@ import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_
 public class ShowNoExperiencesFragment extends BaseExperienceFragment {
 
     // Public instance methods.
+
+    /** Process a given button click event looking for one on the game fab button. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        // Delegate the event to the base class.
+        processClickEvent(event.view, "showNoExperiences");
+    }
 
     /** Handle an experience list change event. */
     @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -103,7 +103,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        processClickEvent(event.view);
+        processClickEvent(event.view, "tictactoe");
     }
 
     /** Handle a FAM or Snackbar TicTacToe click event. */


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit is the next step in providing an experience navigation drill-down.  It allows for a single existing database experience to be played in two taps from startup.

The commit also addresses a but in the no experiences fragment that prevented the FAB button from working.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- processClickEvent(): Make the interface be consistent with the chat version.
- expType: rename to expFragmentType for clarity.
- processPayload(): provide an optimization for a single experience in a room.
- getType(): procedural abstraction helper for processPayload().

modified:   app/src/main/java/com/pajato/android/gamechat/exp/ExpType.java

- getFragmentType(): new method to convert from an experience type to a fragment type.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java

- onClick(): use the new processClickEvent() interface.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java

- onClick(): need to handle click events here as well.