### PR TITLE
Wrap up the initial stab at a navigation feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -131,7 +131,8 @@ public abstract class BaseChatFragment extends BaseFragment {
                                            @NonNull final Dispatcher dispatcher) {
         // Ensure that the type is valid.  Signal failure if not, otherwise handle each possible
         // case signalling success.  If there are no valid cases signal failure.
-        if (dispatcher.type == null) return false;
+        if (dispatcher.type == null)
+            return false;
         switch (type) {
             case chatGroupList: // A group list does not need an item.
                 return true;

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
 import static com.pajato.android.gamechat.common.FragmentType.messageList;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expList;
 import static com.pajato.android.gamechat.common.adapter.MenuEntry.MENU_ITEM_NO_TINT_TYPE;
 import static com.pajato.android.gamechat.common.adapter.MenuEntry.MENU_ITEM_TINT_TYPE;
 
@@ -278,6 +279,8 @@ public abstract class BaseFragment extends Fragment {
                 return RoomManager.instance.getListItemData(item.groupKey);
             case expGroupList:  // Get the groups with experiences.
                 return ExperienceManager.instance.getListItemData();
+            case experienceList:  // Get the groups with experiences.
+                return ExperienceManager.instance.getListItemData(item);
             case joinRoom:      // Get the candidate list of rooms and members.
                 return JoinManager.instance.getListItemData(item);
             case messageList:   // Get the data to be shown in a room.

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -84,7 +84,7 @@ public enum FragmentType {
     expOffline (ExpShowOfflineFragment.class, expMain, R.layout.exp_offline),
     expRoomList (ExpShowRoomsFragment.class, expChain, R.layout.exp_none),
     expSignedOut (ExpShowSignedOutFragment.class, expMain, R.layout.exp_signed_out),
-    experienceList (ShowExperiencesFragment.class, expMain, R.layout.exp_none),
+    experienceList (ShowExperiencesFragment.class, expChain, R.layout.exp_list),
     joinRoom (JoinRoomsFragment.class, joinRoomTT, R.layout.chat_join_rooms),
     messageList (ShowMessagesFragment.class, chatChain, R.layout.chat_messages),
     noExperiences (ShowNoExperiencesFragment.class, expMain, R.layout.exp_none),

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -27,6 +27,7 @@ import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.AppEventManager;
@@ -155,11 +156,8 @@ public enum ToolbarManager {
     public void init(@NonNull final BaseFragment fragment, ListItem item,
                      final MenuItemType... menuEntries) {
         // Determine if the group name or the room name should be the title.
-        String title = item.key == null
-            ? GroupManager.instance.getGroupName(item.groupKey)
-            : RoomManager.instance.getRoomName(item.key);
-        String subtitle = item.key != null
-            ? GroupManager.instance.getGroupName(item.groupKey) : null;
+        String title = getTitle(fragment, item);
+        String subtitle = getSubtitle(item);
         init(fragment, title, subtitle, menuEntries);
     }
 
@@ -223,6 +221,42 @@ public enum ToolbarManager {
     }
 
     // Private instance methods.
+
+    /** Return a subtitle string for a given list item. */
+    private String getSubtitle(final ListItem item) {
+        // Ensure that the item is not empty.  Abort if so.  Otherwise case on the item type to get
+        // the value to return.
+        if (item == null)
+            return null;
+        switch (item.type) {
+            case expList:
+                return GroupManager.instance.getGroupName(item.groupKey);
+            default:
+                return item.key == null
+                        ? GroupManager.instance.getGroupName(item.groupKey)
+                        : RoomManager.instance.getRoomName(item.key);
+        }
+    }
+
+    /** Return a title string for a given list item. */
+    private String getTitle(@NonNull BaseFragment fragment, final ListItem item) {
+        // Ensure that the item is not empty.  Abort if so.  Otherwise case on the item type to get
+        // the value to return.
+        if (item == null)
+            return null;
+        switch (item.type) {
+            case expList:
+                // Determine if the group is the me group and give it special handling.
+                String meGroupKey = AccountManager.instance.getMeGroupKey();
+                if (meGroupKey != null && meGroupKey.equals(item.groupKey))
+                    return fragment.getString(R.string.MyExperiencesToolbarTitle);
+                return RoomManager.instance.getRoomName(item.roomKey);
+            default:
+                return item.key == null
+                        ? GroupManager.instance.getGroupName(item.groupKey)
+                        : RoomManager.instance.getRoomName(item.key);
+        }
+    }
 
     /** Set the titles in the given toolbar using the given (possibly null) titles. */
     private void setTitles(@NonNull final Toolbar bar, final String title, final String subtitle) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -95,14 +95,16 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             case resourceHeader:
             case roomsHeader:
                 return new HeaderViewHolder(getView(parent, R.layout.item_header));
+            case chatGroup:
+            case expGroup:
+                return new ItemListViewHolder(getView(parent, R.layout.item_with_tint));
             case contact:
                 return new ContactViewHolder(getView(parent, R.layout.item_contact));
-            case expGroup:
-            case chatGroup:
-                return new ItemListViewHolder(getView(parent, R.layout.item_group));
+            case expList:
+                return new ItemListViewHolder(getView(parent, R.layout.item_without_tint));
             case expRoom:
             case chatRoom:
-                return new ItemListViewHolder(getView(parent, R.layout.item_room));
+                return new ItemListViewHolder(getView(parent, R.layout.item_with_tint));
             case message:
                 return new ItemListViewHolder(getView(parent, R.layout.item_message));
             case selectableMember:
@@ -135,18 +137,19 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                     String name = holder.itemView.getContext().getResources().getString(id);
                     ((HeaderViewHolder) holder).title.setText(name);
                     break;
-                case expGroup:
-                case expRoom:
                 case chatGroup:
-                case message:
                 case chatRoom:
+                case expGroup:
+                case expList:
+                case expRoom:
+                case message:
+                case inviteRoom:
+                case inviteCommonRoom:
+                case inviteGroup:
                 case selectRoom:
                 case selectUser:
                 case selectableMember:
                 case selectableRoom:
-                case inviteRoom:
-                case inviteCommonRoom:
-                case inviteGroup:
                     // The group item has to update the group title, the number of new messages,
                     // and the list of rooms with messages (possibly old).
                     updateHolder((ItemListViewHolder) holder, item);
@@ -184,21 +187,32 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
     }
 
     /** Update the chat icon in the given holder based on the given item type. */
-    private void setChatIcon(final ItemListViewHolder holder, final ListItem item) {
+    private void setIcon(final ItemListViewHolder holder, final ListItem item) {
         Context context = holder.icon.getContext();
         switch (item.type) {
+            case expGroup:
+            case chatGroup:
+                holder.icon.setImageResource(R.drawable.vd_group_black_24px);
+                break;
+            case expRoom:
+            case chatRoom:
+                holder.icon.setImageResource(R.drawable.ic_casino_black_24dp);
+                break;
+            case expList:
+                holder.icon.setImageResource(item.iconResId);
+                break;
+            case message:
             case selectUser:
             case selectableMember:
-            case message:
                 // For a message, ensure that both the holder and the item have an icon value,
                 // and load the icon or default if not found at the specified URL.
-                if (holder.icon == null || item.url == null) return;
-                Uri imageUri = Uri.parse(item.url);
+                if (holder.icon == null || item.iconUrl == null) return;
+                Uri imageUri = Uri.parse(item.iconUrl);
                 if (imageUri != null) {
                     // There is an image to load.  Use Glide to do the heavy lifting.
                     holder.icon.setImageURI(imageUri);
                     Glide.with(context)
-                        .load(item.url)
+                        .load(item.iconUrl)
                         .transform(new NavigationManager.CircleTransform(context))
                         .into(holder.icon);
                 } else {
@@ -222,7 +236,7 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             holder.text.setVisibility(View.GONE);
         else
             holder.text.setText(CompatUtils.fromHtml(item.text));
-        setChatIcon(holder, item);
+        setIcon(holder, item);
         holder.itemView.setTag(item);
 
         // Set the new message count field, if necessary.
@@ -276,10 +290,10 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
         /** Build an instance given the item view. */
         ItemListViewHolder(View itemView) {
             super(itemView);
-            name = (TextView) itemView.findViewById(R.id.chatName);
-            count = (TextView) itemView.findViewById(R.id.newCount);
-            text = (TextView) itemView.findViewById(R.id.chatText);
-            icon = (ImageView) itemView.findViewById(R.id.chatIcon);
+            name = (TextView) itemView.findViewById(R.id.Name);
+            count = (TextView) itemView.findViewById(R.id.Count);
+            text = (TextView) itemView.findViewById(R.id.Text);
+            icon = (ImageView) itemView.findViewById(R.id.ListItemIcon);
             setSelectorButton(itemView);
             if (button != null) {
                 button.setOnClickListener(selectorListener);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -84,7 +84,7 @@ public class ListItem {
         contactHeader ("Contact header with resource id: {%d}."),
         date ("Date header with resource id: {%d}."),
         expGroup ("Exp group item with name {%s}, key: {%s}, count: {%s} and text {%s}."),
-        expList ("Exp room item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
+        expList ("Exp list item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
         expRoom ("Exp room item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
         experience ("Experience item with group/room/exp keys {%s/%s/%s} and mode {%s}."),
         message ("Message item with name {%s}, key: {%s}, count: {%s} and text {%s}."),
@@ -122,6 +122,12 @@ public class ListItem {
     /** The group (push) key, possibly null, used for many list items (groups, rooms, messages) */
     public String groupKey;
 
+    /** The item image resource id for dynamic images, as used with experiences. */
+    public int iconResId;
+
+    /** The URL for the item, possibly null, used for icons with contacts and chat list items. */
+    String iconUrl;
+
     /** The item (push) key, possibly null, either a room, member or experience key. */
     public String key;
 
@@ -148,9 +154,6 @@ public class ListItem {
 
     /** The item type, always non-null. */
     public ItemType type;
-
-    /** The URL for the item, possibly null, used for icons with contacts and chat list items. */
-    public String url;
 
     // Private instance variables.
 
@@ -183,7 +186,7 @@ public class ListItem {
         this.name = name;
         this.email = email;
         this.phone = phone;
-        this.url = url;
+        iconUrl = url;
     }
 
     /** Build an instance for a given room list item. */
@@ -197,14 +200,14 @@ public class ListItem {
 
     /** Build an instance for a given room list item. */
     public ListItem(final ItemType type, final String groupKey, final String roomKey,
-                    final String name, final String text, final String url) {
+                    final String name, final String text, final String iconUrl) {
         this.type = type;
         this.groupKey = groupKey;
         key = roomKey;
         this.name = name;
         count = 0;
         this.text = text;
-        this.url = url;
+        this.iconUrl = iconUrl;
     }
 
     /** Build an instance for a given contact list item. */
@@ -214,9 +217,9 @@ public class ListItem {
         key = item.memberKey;
         name = item.name;
         text = item.text;
-        url = item.url;
-        String format = "Member item with name {%s}, email: {%s}, and url {%s}.";
-        mDesc = String.format(Locale.US, format, name, email, url);
+        iconUrl = item.url;
+        String format = "Member item with name {%s}, email: {%s}, and iconUrl {%s}.";
+        mDesc = String.format(Locale.US, format, name, email, iconUrl);
     }
 
     /** Build an instance for a given selectable group. */
@@ -250,9 +253,9 @@ public class ListItem {
         key = item.memberKey;
         name = item.name;
         text = item.text;
-        url = item.url;
-        String format = "Member item with name {%s}, email: {%s}, and url {%s}.";
-        mDesc = String.format(Locale.US, format, name, email, url);
+        iconUrl = item.url;
+        String format = "Member item with name {%s}, email: {%s}, and iconUrl {%s}.";
+        mDesc = String.format(Locale.US, format, name, email, iconUrl);
     }
 
     /** Build an instance for a room or common room invitation. */
@@ -288,7 +291,7 @@ public class ListItem {
             case chatRoom:
                 return String.format(Locale.US, type.format, name, groupKey, roomKey, count, text);
             case contact:
-                return String.format(Locale.US, type.format, name, email, phone, url);
+                return String.format(Locale.US, type.format, name, email, phone, iconUrl);
             case contactHeader:
                 return String.format(Locale.US, type.format, nameResourceId);
             case date:
@@ -296,7 +299,7 @@ public class ListItem {
             case expGroup:
                 return String.format(Locale.US, type.format, name, key, count, text);
             case expList:
-                return String.format(Locale.US, type.format, name, key, count, text);
+                return String.format(Locale.US, type.format, name, groupKey, roomKey, count, text);
             case expRoom:
                 return String.format(Locale.US, type.format, name, groupKey, roomKey, count, text);
             case experience:

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
@@ -17,22 +17,93 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
+import android.support.v4.view.ViewPager;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.InvitationManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.ExperienceChangeEvent;
+import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
+import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import static com.pajato.android.gamechat.common.FragmentKind.exp;
+import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.search;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.event.BaseChangeEvent.CHANGED;
+import static com.pajato.android.gamechat.event.BaseChangeEvent.NEW;
+import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
+
 public class ShowExperiencesFragment extends BaseExperienceFragment {
 
+    // Public instance methods.
+
+    /** Process a given button click event looking for a FAM menu item or a list view click. */
     @Subscribe public void onClick(final ClickEvent event) {
-        // todo add some code here.
-        processClickEvent(event.view, "showExperiences");
+        // Delegate the event to the base class.
+        processClickEvent(event.view, "expShowExperiences");
     }
 
-    /** Initialize the fragment by setting in the FAB. */
+    /** Handle an experience list change event by dispatching again. */
+    @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {
+        switch (event.changeType) {
+            case CHANGED:
+            case NEW:
+                DispatchManager.instance.startNextFragment(getActivity(), exp);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** Handle a menu item selection. */
+    @Subscribe public void onMenuItem(final MenuItemEvent event) {
+        if (!this.mActive)
+            return;
+        // Case on the item resource id if there is one to be had.
+        switch (event.item != null ? event.item.getItemId() : -1) {
+            case R.string.InviteFriendsOverflow:
+                if (isInMeGroup())
+                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
+                else
+                    InvitationManager.instance.extendGroupInvitation(getActivity(),
+                            mExperience.getGroupKey());
+                break;
+            case R.string.SwitchToChat:
+                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
+                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+                if (viewPager != null)
+                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** Deal with the fragment's activity's lifecycle by managing the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home experience menu; and display a list of groups
+        // with experiences showing the rooms and highlighting new experiences, much like messages
+        // in the chat group display.
+        super.onResume();
+        FabManager.game.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.game.init(this, GAME_HOME_FAM_KEY);
+    }
+
+    /** Initialize the fragment by setting up the FAB and toolbar. */
     @Override public void onStart() {
         super.onStart();
         FabManager.game.init(this);
+        ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -83,13 +83,12 @@ public class Checkers implements Experience {
         this.createTime = createTime;
         this.key = key;
         this.groupKey = groupKey;
-        this.modTime = 0;
+        this.modTime = createTime;
         this.level = level;
         this.name = name;
         this.owner = id;
         this.players = players;
         this.roomKey = roomKey;
-        this.unseenList = unseenList;
         state = ACTIVE;
         turn = true;
         type = checkersET.name();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
@@ -102,7 +102,7 @@ import static com.pajato.android.gamechat.exp.ExpType.chessET;
         this.createTime = createTime;
         this.key = key;
         this.groupKey = groupKey;
-        this.modTime = 0;
+        this.modTime = createTime;
         this.level = level;
         this.name = name;
         this.owner = id;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -103,7 +103,7 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
         this.createTime = createTime;
         this.key = key;
         this.groupKey = groupKey;
-        this.modTime = 0;
+        this.modTime = createTime;
         this.name = name;
         this.owner = id;
         this.players = players;

--- a/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
@@ -21,13 +21,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
-import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.database.DatabaseRegistrar;
-import com.pajato.android.gamechat.database.ExperienceManager;
-import com.pajato.android.gamechat.database.GroupManager;
-import com.pajato.android.gamechat.database.MemberManager;
-import com.pajato.android.gamechat.database.MessageManager;
-import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 
 import java.util.Locale;
@@ -96,13 +90,6 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override protected void onResume() {
         super.onResume();
         logEvent("onResume");
-        AppEventManager.instance.register(GroupManager.instance);
-        AppEventManager.instance.register(RoomManager.instance);
-        AppEventManager.instance.register(MessageManager.instance);
-        AppEventManager.instance.register(ExperienceManager.instance);
-        AppEventManager.instance.register(MemberManager.instance);
-        AppEventManager.instance.register(NavigationManager.instance);
-        AppEventManager.instance.register(InvitationManager.instance);
     }
 
     /** Log the lifecycle event. */

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -41,7 +41,12 @@ import com.pajato.android.gamechat.credentials.CredentialsManager;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.DBUtils;
 import com.pajato.android.gamechat.database.DatabaseRegistrar;
+import com.pajato.android.gamechat.database.ExperienceManager;
+import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.JoinManager;
+import com.pajato.android.gamechat.database.MemberManager;
+import com.pajato.android.gamechat.database.MessageManager;
+import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
@@ -264,6 +269,18 @@ public class MainActivity extends BaseActivity
     @Override protected void onCreate(Bundle savedInstanceState) {
         // Deal with sign-in, set up the main layout, and initialize the app.
         super.onCreate(savedInstanceState);
+
+        // Enable the database managers to listen for database activity immediately upon starting
+        // the sign in page.
+        AppEventManager.instance.register(GroupManager.instance);
+        AppEventManager.instance.register(RoomManager.instance);
+        AppEventManager.instance.register(MessageManager.instance);
+        AppEventManager.instance.register(ExperienceManager.instance);
+        AppEventManager.instance.register(MemberManager.instance);
+        AppEventManager.instance.register(NavigationManager.instance);
+        AppEventManager.instance.register(InvitationManager.instance);
+
+        // Deal with initial sign in via the intro activity and normal processing.
         processIntroPage();
         setContentView(R.layout.activity_main);
         init();
@@ -372,7 +389,8 @@ public class MainActivity extends BaseActivity
         boolean skipIntro = intent.hasExtra(SKIP_INTRO_ACTIVITY_KEY);
         SharedPreferences prefs = getSharedPreferences(PREFS, Context.MODE_PRIVATE);
         boolean hasAccount = prefs.getBoolean(ACCOUNT_AVAILABLE_KEY, false);
-        if (skipIntro || hasAccount) return;
+        if (skipIntro || hasAccount)
+            return;
 
         // This is a fresh installation of the app.  Present the intro activity to get
         // things started, which will introduce the user to the app and provide a chance to

--- a/app/src/main/res/layout/exp_none.xml
+++ b/app/src/main/res/layout/exp_none.xml
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License along with Gam
 http://www.gnu.org/licenses
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_join_member.xml
+++ b/app/src/main/res/layout/item_join_member.xml
@@ -4,21 +4,21 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <CheckBox style="@style/ChatListItemSelector" android:id="@+id/selector" />
         <de.hdodenhof.circleimageview.CircleImageView style="@style/ChatListItemSelectorImage"
-            android:id="@+id/chatIcon" />
+            android:id="@+id/ListItemIcon" />
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 tools:text="Fred C. Jones"/>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_join_room.xml
+++ b/app/src/main/res/layout/item_join_room.xml
@@ -5,9 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <CheckBox style="@style/ChatListItemSelector" android:id="@+id/selector" />
-        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/ListItemIcon"
             android:tint="@color/colorPrimaryDark"
             android:contentDescription="@string/RoomListIcon"
             app:srcCompat="@drawable/ic_casino_black_24dp" />
@@ -17,11 +17,11 @@
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 tools:text="Fred C. Jones"/>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -9,7 +9,7 @@
     android:layout_marginBottom="1dp"
     android:orientation="horizontal">
     <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/chatIcon"
+        android:id="@+id/ListItemIcon"
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginStart="4dp"
@@ -22,13 +22,13 @@
         android:gravity="center_vertical"
         android:orientation="vertical">
         <TextView
-            android:id="@+id/chatText"
+            android:id="@+id/Text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceListItem"
             tools:text="A simple sample message that extends over two lines..."/>
         <TextView
-            android:id="@+id/chatName"
+            android:id="@+id/Name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceSmall"/>

--- a/app/src/main/res/layout/item_select_for_invites.xml
+++ b/app/src/main/res/layout/item_select_for_invites.xml
@@ -5,9 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <CheckBox style="@style/ChatListItemSelector" android:id="@+id/selector" />
-        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/ListItemIcon"
             android:tint="@color/colorPrimaryDark"
             android:contentDescription="@string/RoomListIcon"
             app:srcCompat="@drawable/ic_people_black_24dp" />
@@ -17,9 +17,9 @@
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 tools:text="My Group Name"/>
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_select_invites_room.xml
+++ b/app/src/main/res/layout/item_select_invites_room.xml
@@ -5,9 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <CheckBox style="@style/InviteRoomItemSelector" android:id="@+id/selector" />
-        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/ListItemIcon"
             android:tint="@color/colorPrimaryDark"
             android:contentDescription="@string/RoomListIcon"
             app:srcCompat="@drawable/ic_casino_black_24dp" />
@@ -17,11 +17,11 @@
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 tools:text="Fred C. Jones"/>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_select_user.xml
+++ b/app/src/main/res/layout/item_select_user.xml
@@ -5,10 +5,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <RadioButton style="@style/ChatListItemSelector" android:id="@+id/selector" />
         <CheckBox style="@style/ChatListItemSelector" android:id="@+id/altSelector" />
-        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/chatIcon"
+        <ImageView style="@style/ChatListItemSelectorImage" android:id="@+id/ListItemIcon"
             android:tint="@color/colorPrimaryDark"
             android:contentDescription="@string/SelectUserListIcon"
             app:srcCompat="@drawable/ic_account_circle_black_24dp" />
@@ -18,11 +18,11 @@
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 tools:text="Fred C. Jones"/>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="My Group Name"/>
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_with_tint.xml
+++ b/app/src/main/res/layout/item_with_tint.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
-        <ImageView style="@style/ChatListItemImage" android:id="@+id/chatIcon"
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
+        <ImageView style="@style/ListItemImage" android:id="@+id/ListItemIcon"
             android:tint="@color/colorPrimaryDark"
-            android:contentDescription="@string/ListIconDesc"
-            app:srcCompat="@drawable/ic_casino_black_24dp" />
+            android:contentDescription="@string/ListItemIconDesc" />
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -21,14 +18,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
-                <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+                <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                     tools:text="General"/>
-                <TextView style="@style/ChatListItemCount" android:id="@+id/newCount"
+                <TextView style="@style/ListItemCount" android:id="@+id/Count"
                     tools:text="3 new"/>
             </LinearLayout>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="TheShovel, ConnorTheWhiz, GrandPop" />
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_without_tint.xml
+++ b/app/src/main/res/layout/item_without_tint.xml
@@ -6,29 +6,27 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
-    <LinearLayout style="@style/ChatListItemLayout" android:id="@+id/chatListItem">
-        <ImageView style="@style/ChatListItemImage" android:id="@+id/chatIcon"
-            android:tint="@color/colorPrimaryDark"
-            android:contentDescription="@string/ListIconDesc"
-            app:srcCompat="@drawable/vd_group_black_24px"/>
+    <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
+        <ImageView style="@style/ListItemImage" android:id="@+id/ListItemIcon"
+            android:contentDescription="@string/ListItemIconDesc" />
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:gravity="center_vertical"
+            android:layout_gravity="center_vertical"
             android:orientation="vertical">
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
-                <TextView style="@style/ChatListItemTitle" android:id="@+id/chatName"
+                <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                     tools:text="Paul &amp; Sandy Group"/>
-                <TextView style="@style/ChatListItemCount" android:id="@+id/newCount"
+                <TextView style="@style/ListItemCount" android:id="@+id/Count"
                     tools:text="3 new"/>
             </LinearLayout>
-            <TextView style="@style/ChatListItemSubtitle" android:id="@+id/chatText"
+            <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="group, Sandy Scott, PT General"/>
         </LinearLayout>
     </LinearLayout>
-    <View style="@style/ChatListItemFooter" />
+    <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -15,7 +15,7 @@
     <string name="Group">Group</string>
     <string name="GroupsToolbarTitle">Groups with Messages</string>
     <string name="GroupMeToolbarTitle">My Chat Room</string>
-    <string name="ListIconDesc">The list icon.</string>
+    <string name="ListItemIconDesc">The list icon.</string>
     <string name="InsertEmoticon">Inserting an emoticon</string>
     <string name="InsertEmoticonDesc">Insert emoticon image button.</string>
     <string name="InsertMap">Inserting a map based on your location</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -12,6 +12,7 @@
     <string name="InviteFriendFromChat">Invite friends</string>
     <string name="InviteFriendNav">Invite friends</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
+    <string name="MyExperiencesToolbarTitle">My Games</string>
     <string name="MyRooms">Go To My Rooms</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,19 +25,19 @@ http://www.gnu.org/licenses
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="ChatListItemLayout">
+    <style name="ListItemLayout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:orientation">horizontal</item>
     </style>
 
-    <style name="ChatListItemImage">
+    <style name="ListItemImage">
         <item name="android:layout_width">36dp</item>
         <item name="android:layout_height">36dp</item>
         <item name="android:layout_marginStart">16dp</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:contentDescription">@string/ListIconDesc</item>
+        <item name="android:contentDescription">@string/ListItemIconDesc</item>
     </style>
 
     <style name="ChatListItemSelector">
@@ -45,7 +45,7 @@ http://www.gnu.org/licenses
         <item name="android:layout_height">36dp</item>
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:contentDescription">@string/ListIconDesc</item>
+        <item name="android:contentDescription">@string/ListItemIconDesc</item>
     </style>
 
     <style name="InviteRoomItemSelector">
@@ -53,7 +53,7 @@ http://www.gnu.org/licenses
         <item name="android:layout_height">36dp</item>
         <item name="android:layout_marginStart">36dp</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:contentDescription">@string/ListIconDesc</item>
+        <item name="android:contentDescription">@string/ListItemIconDesc</item>
     </style>
 
     <style name="ChatListItemSelectorImage">
@@ -61,10 +61,10 @@ http://www.gnu.org/licenses
         <item name="android:layout_height">36dp</item>
         <item name="android:layout_marginStart">4dp</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:contentDescription">@string/ListIconDesc</item>
+        <item name="android:contentDescription">@string/ListItemIconDesc</item>
     </style>
 
-    <style name="ChatListItemCount">
+    <style name="ListItemCount">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginStart">8dp</item>
@@ -76,7 +76,7 @@ http://www.gnu.org/licenses
         <item name="android:paddingEnd">4dp</item>
     </style>
 
-    <style name="ChatListItemFooter">
+    <style name="ListItemFooter">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">1dp</item>
         <item name="android:layout_marginTop">8dp</item>
@@ -84,13 +84,13 @@ http://www.gnu.org/licenses
         <item name="android:background">@android:color/darker_gray</item>
     </style>
 
-    <style name="ChatListItemSubtitle">
+    <style name="ListItemSubtitle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
     </style>
 
-    <style name="ChatListItemTitle">
+    <style name="ListItemTitle">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAppearance">?android:attr/textAppearanceListItem</item>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit wraps up the main aspects of navigating experiences, from a list of groups drilling down into playing a particular game.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- Summary: cosmetic for debugging.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- getList(): add an entry to handle an experience list.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java

- experienceList: chain to the fragment (this looks suspicious in 20/20 hindsight); use the real layout file.

modified:   app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java

- init(): case on the item type to set the title and subtitle from a given item.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java

- Summary: add support for navigating experiences (new cases to handle); normalize the names used with resource ids; apply RNF to switch statements; remove stale artifacts.

modified:   app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

- Summary: add support for navigating experiences; apply RNF.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- onResume(): fix a cut/paste error in selecting the FAB constant.
- onSetup(): call the super class.
- onDispatch(): handle the experience navigation cases.
- processPayload(): handle an experience list.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java

- Summary: replace the placeholder code with a correct, initial take at showing a list of groups with experiences.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Chess.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java

- Summary: set the inital modification timestamp to be the creation timestamp.

modified:   app/src/main/java/com/pajato/android/gamechat/main/BaseActivity.java
modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- Summary: after observing that database handling is taking place even before a user logs in, it was clear that the database managers should be registered with the app event mamnager asap so the registration code has been moved from onResume to onCreate.

modified:   app/src/main/res/layout/exp_none.xml

- Summary: fix an AS warning.

modified:   app/src/main/res/layout/item_join_member.xml
modified:   app/src/main/res/layout/item_join_room.xml
modified:   app/src/main/res/layout/item_message.xml
modified:   app/src/main/res/layout/item_select_for_invites.xml
modified:   app/src/main/res/layout/item_select_invites_room.xml
modified:   app/src/main/res/layout/item_select_user.xml
modified:   app/src/main/res/values/styles.xml

- Summary: normalize names across item layouts.

renamed:    app/src/main/res/layout/item_room.xml -> app/src/main/res/layout/item_with_tint.xml
renamed:    app/src/main/res/layout/item_group.xml -> app/src/main/res/layout/item_without_tint.xml

- Summary: canonicalize the item layouts to have one with tinting of icons and one without tinting.

modified:   app/src/main/res/values/strings_chat.xml
modified:   app/src/main/res/values/strings_exp.xml

- Summary: remove stale resources and add new ones.