### PR TITLE
When selecting play-mode 'user', provide a "no users" header when necessary.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.FragmentType.createGroup;
+import static com.pajato.android.gamechat.common.FragmentType.createGroupChat;
 import static com.pajato.android.gamechat.common.FragmentType.joinRoom;
 import static com.pajato.android.gamechat.common.FragmentType.selectChatGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
@@ -80,7 +80,7 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createGroup, null);
+                DispatchManager.instance.chainFragment(getActivity(), createGroupChat, null);
                 break;
             case R.string.JoinRoomsMenuTitle:
                 DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.FragmentType.createGroup;
+import static com.pajato.android.gamechat.common.FragmentType.createGroupChat;
 import static com.pajato.android.gamechat.common.FragmentType.createRoom;
 import static com.pajato.android.gamechat.common.FragmentType.joinRoom;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
@@ -87,7 +87,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createGroup, null);
+                DispatchManager.instance.chainFragment(getActivity(), createGroupChat, null);
                 break;
             case R.string.CreateRoomMenuTitle:
                 DispatchManager.instance.chainFragment(getActivity(), createRoom, mItem);

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -77,7 +77,8 @@ public enum FragmentType {
     chatSignedOut (ChatShowSignedOutFragment.class, chatMain, R.layout.chat_signed_out),
     checkers (CheckersFragment.class, expChain, R.layout.exp_checkers, checkersET),
     chess (ChessFragment.class, expChain, R.layout.exp_checkers, chessET),
-    createGroup (CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
+    createGroupChat(CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
+    createGroupExp (CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
     createRoom (CreateRoomFragment.class, createRoomTT, R.layout.chat_create),
     expEnvelope (ExpEnvelopeFragment.class, none, R.layout.exp_envelope),
     expGroupList (ExpShowGroupsFragment.class, expMain, R.layout.exp_list),
@@ -152,13 +153,14 @@ public enum FragmentType {
             case chatOffline:
             case chatRoomList:
             case chatSignedOut:
-            case createGroup:
+            case createGroupChat:
             case createRoom:
             case joinRoom:
             case messageList:
             case selectChatGroupsRooms:
             case showNoJoinedRooms:
                 return chat;
+            case createGroupExp:
             default:
                 return exp;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -128,12 +128,12 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         Account member = new Account(account);
         member.groupKey = groupKey;
         String path = MemberManager.instance.getMembersPath(groupKey, member.id);
-        DBUtils.instance.updateChildren(path, member.toMap());
+        DBUtils.updateChildren(path, member.toMap());
 
         // Finally add the invited account to the accepting group's profile member list.
         group.memberList.add(member.id);
         path = GroupManager.instance.getGroupProfilePath(groupKey);
-        DBUtils.instance.updateChildren(path, group.toMap());
+        DBUtils.updateChildren(path, group.toMap());
     }
 
     /** Clear the external app invitations map */
@@ -363,7 +363,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
                     if (member != null) {
                         member.joinList.add(event.key);
                         String path = String.format(Locale.US, MemberManager.MEMBERS_PATH, data.groupKey, member.id);
-                        DBUtils.instance.updateChildren(path, member.toMap());
+                        DBUtils.updateChildren(path, member.toMap());
                     }
 
                     // Post a message to the room announcing the user has joined
@@ -387,7 +387,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
         // For the time being, put app invites in their own location in firebase to differentiate
         // them from invites for protected users.
         String invitePath = String.format(APP_INVITE_ID_PATH, id);
-        DBUtils.instance.updateChildren(invitePath, objMap);
+        DBUtils.updateChildren(invitePath, objMap);
         clearInvitationMap();
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
@@ -34,6 +34,8 @@ import com.pajato.android.gamechat.event.PlayModeChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.resourceHeader;
+
 /**
  * Manages the game experience modes: such as playing against a local friend (non-User), the
  * computer or another online User.  Also manages the play mode menu and related events and
@@ -95,12 +97,14 @@ public enum PlayModeManager {
     private List<ListItem> getUserItems() {
         List<ListItem> result = new ArrayList<>();
         Account account = AccountManager.instance.getCurrentAccount();
-        if (account == null || account.joinList.size() == 0)
-            return result;
-        for (String groupKey : account.joinList)
-            for (Account member : MemberManager.instance.getMemberList(groupKey))
-                if (!member.id.equals(account.id))
-                    result.add(new ListItem(new UserItem(groupKey, member)));
+        if (!AccountManager.accountHasFriends(account))
+            // No users exist so create a header stating this.
+            result.add(new ListItem(resourceHeader, R.string.NoFriendsFound));
+        else
+            for (String groupKey : account.joinList)
+                for (Account member : MemberManager.instance.getMemberList(groupKey))
+                    if (!member.id.equals(account.id))
+                        result.add(new ListItem(new UserItem(groupKey, member)));
         return result;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -344,4 +344,5 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             title = (TextView) itemView.findViewById(R.id.header);
         }
     }
+
 }

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -344,5 +344,4 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             title = (TextView) itemView.findViewById(R.id.header);
         }
     }
-
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -97,7 +97,7 @@ public enum JoinManager {
             return;
         member.joinList.add(room.key);
         String path = String.format(Locale.US, MemberManager.MEMBERS_PATH, item.groupKey, member.id);
-        DBUtils.instance.updateChildren(path, member.toMap());
+        DBUtils.updateChildren(path, member.toMap());
 
         // Post a message to the room announcing the user has joined
         String format = mMessageMap.get(R.string.HasJoinedMessage);
@@ -239,12 +239,12 @@ public enum JoinManager {
         room.addMember(account.id);
         room.addMember(memberKey);
         path = String.format(Locale.US, RoomManager.ROOM_PROFILE_PATH, groupKey, roomKey);
-        DBUtils.instance.updateChildren(path, room.toMap());
+        DBUtils.updateChildren(path, room.toMap());
 
         // Update and persist the group profile.
         group.roomList.add(roomKey);
         path = String.format(Locale.US, GroupManager.GROUP_PROFILE_PATH, groupKey);
-        DBUtils.instance.updateChildren(path, group.toMap());
+        DBUtils.updateChildren(path, group.toMap());
 
         // Update the "me" room default message on the database.
         String format = "We have created a room for %s and %s to share private messages.";
@@ -267,7 +267,7 @@ public enum JoinManager {
         room.addMember(id);
         room.modTime = new Date().getTime();
         String path = String.format(Locale.US, RoomManager.ROOM_PROFILE_PATH, groupKey, roomKey);
-        DBUtils.instance.updateChildren(path, room.toMap());
+        DBUtils.updateChildren(path, room.toMap());
         return room;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
@@ -63,7 +63,7 @@ public enum MemberManager {
     public void createMember(final Account member) {
         member.createTime = new Date().getTime();
         String path = String.format(Locale.US, MEMBERS_PATH, member.groupKey, member.id);
-        DBUtils.instance.updateChildren(path, member.toMap());
+        DBUtils.updateChildren(path, member.toMap());
     }
 
     /** Return null or a group member using the current account holder's id and given group key. */
@@ -127,7 +127,7 @@ public enum MemberManager {
         // Obtain a room and set watchers on all the experiences in that room.
         // Determine if a handle already exists. Abort if so.  Register a new handler if not.
         String tag = String.format(Locale.US, "%s,%s", groupKey, memberKey);
-        String name = DBUtils.instance.getHandlerName(MEMBER_CHANGE_HANDLER, tag);
+        String name = DBUtils.getHandlerName(MEMBER_CHANGE_HANDLER, tag);
         if (DatabaseRegistrar.instance.isRegistered(name)) return;
         String path = getMembersPath(groupKey, memberKey);
         DatabaseEventHandler handler;
@@ -139,7 +139,7 @@ public enum MemberManager {
     public void updateMember(final Account member) {
         String path = String.format(Locale.US, MEMBERS_PATH, member.groupKey, member.id);
         member.modTime = new Date().getTime();
-        DBUtils.instance.updateChildren(path, member.toMap());
+        DBUtils.updateChildren(path, member.toMap());
     }
 
     /** Return a possibly empty list of members in the given group. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -25,14 +25,13 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.FragmentType;
+import com.pajato.android.gamechat.common.PlayModeManager;
+import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
-import com.pajato.android.gamechat.common.FragmentType;
-import com.pajato.android.gamechat.common.PlayModeManager;
-import com.pajato.android.gamechat.common.PlayModeManager.PlayModeType;
-import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -54,6 +53,7 @@ import static com.pajato.android.gamechat.common.FragmentType.experienceList;
 import static com.pajato.android.gamechat.common.FragmentType.selectUser;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expList;
+import static com.pajato.android.gamechat.common.PlayModeManager.PlayModeType.user;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_OWNER_ID;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_EXPERIENCE_KEY;
@@ -84,9 +84,6 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     /** The experience being enjoyed. */
     protected Experience mExperience;
-
-    /** The current play mode for the experience being enjoyed. */
-    protected PlayModeType mPlayMode;
 
     // Public constructors.
 
@@ -207,6 +204,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     /** Handle a play mode selection change. */
     @Subscribe void handlePlayModeChange(PlayModeChangeEvent event) {
+        if (mExperience == null)
+            return;
         switch (event.type) {
             case computer:
             case local:
@@ -216,7 +215,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 // Handle selecting another User by chaining to the fragment that will select the
                 // User, copy the experience to a new room, and continue the game in that room with
                 // the current state.
-                ListItem listItem = new ListItem(mExperience, mPlayMode);
+                ListItem listItem = new ListItem(mExperience, user);
                 DispatchManager.instance.chainFragment(this.getActivity(), selectUser, listItem);
                 break;
             default:

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -14,6 +14,7 @@
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyExperiencesToolbarTitle">My Games</string>
     <string name="MyRooms">Go To My Rooms</string>
+    <string name="NoFriendsFound">No Available Users</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="PlayAgain">Play again</string>
@@ -21,7 +22,7 @@
     <string name="PlayChess">Play Chess</string>
     <string name="PlayModeComputerMenuTitle">Play the computer</string>
     <string name="PlayModeLocalMenuTitle">Play a friend</string>
-    <string name="PlayModeUserMenuTitle">Play a User</string>
+    <string name="PlayModeUserMenuTitle">Play another user</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
     <string name="PromotePawnMsg">Promote Your Pawn:</string>
     <string name="SelectRoomToolbarTitle">Select Room</string>


### PR DESCRIPTION
# Rationale
When the current account has not joined any groups with other users and the play-mode "users" choice is selected, provide a header stating there are no users. Also, set the FAM contents when selecting users which provides a short-cut to create a group, create a protected user or invite someone to join.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java

* Reflect name change of createGroup FragmentType to createGroupChat.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

* Reflect name change of createGroup FragmentType to createGroupChat.

#### app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java

* Add new fragment type, createGroupExp, to use from an experience context. Rename createGroup FragmentType to createGroupChat just to more clearly differentiate.
* getKind(): add case for createGroupExp and reflect name change for createGroup.

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
* DBUtils updateChildren method is static, so don't use the 'instance' to reference it.

#### app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
* getUserItems(): if there are no uses to select, add a resourceHeader indicating this is the case.

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* DBUtils updateChildren method is static, so don't use the 'instance' to reference it.
* accountHasFriends(): new method to determine if the specified account belongs to any groups which have members

#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* DBUtils updateChildren method is static, so don't use the 'instance' to reference it.

#### app/src/main/java/com/pajato/android/gamechat/database/MemberManager.java
* DBUtils updateChildren and getHandlerName are static methods, so don't reference them with 'instance'.

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* Remove mPlayMode member variable (not needed)
* handlePlayModeChange(): check for null experience to prevent null-pointer exceptions. Also, use 'user' PlayModeType value rather than possibly stale mPlayMode.

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
* Enable use of FAB/FAM. Add unique value for FAM key.
* onClick(): dispatch click events properly; use base class processClickEvent to handle toggle of FAM
* onClick(): handle TagClickEvents for each FAM item
* onStart(): set up FAM
* getSelectMenu(): set up contents of FAM to allow creating of groups and protected users (if account is not itself a protected user) and always allow sending invitations
* reorder private methods to alphabetize

#### app/src/main/res/values/strings_exp.xml
* Add "no friends" message for resource header
* Change "Play a User" text (nit)
