### PR TITLE
Fix bug causing crash when trying to show rooms.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -132,7 +132,7 @@ public enum RoomManager {
                 result.add(new ListItem(date, dht.resId));
                 roomMap = MessageManager.instance.messageMap.get(groupKey);
                 for (String key : roomMap.keySet()) {
-                    Room room = RoomManager.instance.getRoomProfile(groupKey);
+                    Room room = RoomManager.instance.getRoomProfile(key);
                     Map<String, Integer> countMap = new HashMap<>();
                     int count = DBUtils.getUnseenExperienceCount(key, countMap);
                     String text = DBUtils.getText(countMap);


### PR DESCRIPTION
# Rationale
Bug cases crash when trying to view rooms.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
* getListItemData(): pass room key to RoomManager to get room profile (not group key)