### PR TITLE
Fix an unseen message count bug.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -81,7 +81,6 @@ public abstract class BaseChatFragment extends BaseFragment {
         // Log the event, update the FAB for this fragment, process the ad, determine if a list
         // adapter update needs be processed and set the toolbar titles.
         super.onResume();
-        FabManager.chat.init(this);
         if (mAdView != null)
             mAdView.resume();
         if (type != null)

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.v4.view.ViewPager;
-import android.view.View;
 import android.widget.Toast;
 
 import com.google.firebase.auth.FirebaseAuth;
@@ -133,15 +132,12 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
             updateAdapterList();
     }
 
-    /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
+    /** Deal with the fragment's lifecycle by managing the FAB. */
     @Override public void onResume() {
-        // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
-        // FAM is not and the FAM is set to the home chat menu; initialize the ad view; and set up
-        // the group list display.
+        // Use the super class to set up the list of groups and establish the FAB and it's menu.
         super.onResume();
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
-        FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 
     /** Initialize ... */

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -89,12 +89,6 @@ public enum FabManager {
 
     // Public instance methods
 
-    /** Add the named floating action menu (FAM) to the cache. */
-    public void addMenu(@NonNull final String name, @NonNull final List<MenuEntry> menu) {
-        // Cache the menu, if one is provided.
-        if (name.length() != 0) mMenuMap.put(name, menu);
-    }
-
     /** Dismiss the menu associated with the given FAB button. */
     public void dismissMenu(@NonNull final Fragment fragment) {
         // Determine if the chat fragment is accessible.  If so, dismiss the FAM.
@@ -127,6 +121,7 @@ public enum FabManager {
         // Set the FAB state to closed by assuming an open FAM and dismissing it.
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
+        fab.setVisibility(View.VISIBLE);
         dismissMenu(fragment, layout);
     }
 
@@ -152,7 +147,8 @@ public enum FabManager {
         // error message will have been generated.  If it is accessible, apply the given visibility
         // state.
         View layout = getFragmentLayout(fragment);
-        if (layout == null) return;
+        if (layout == null)
+            return;
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setVisibility(state);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -93,11 +93,10 @@ public enum DBUtils {
         return result;
     }
 
+    /** Return the number of unseen messages and update the given map. */
     public static int getUnseenMessageCount(@NonNull final String groupKey,
                                             @NonNull final Map<String, Integer> map) {
         int result = 0;
-        if (!GroupManager.instance.groupMap.containsKey(groupKey))
-            return result;
         Set<Map.Entry<String, Map<String, Message>>> messageSet =
             MessageManager.instance.messageMap.get(groupKey).entrySet();
         for (Map.Entry<String, Map<String, Message>> roomMap : messageSet) {

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -147,8 +147,6 @@ public enum GroupManager {
         switch (groupMap.size()) {
             case 0:
                 return getNoGroupsItemList();
-            case 1:
-                //return getGroupRoomsItemList();
             default:
                 return getGroupsItemList();
         }
@@ -281,7 +279,7 @@ public enum GroupManager {
         return result;
     }
 
-    /** Return the normal case: more than one group. */
+    /** Return an empty list of items or the items from the me group. */
     private List<ListItem> getNoGroupsItemList() {
         // Determine if the me room exists.  If not, about with an empty list, otherwise return a
         // list of items from the me room.
@@ -294,8 +292,7 @@ public enum GroupManager {
         // Collect and return a list containing a single list item from the me room.
         Map<String, Integer> unseenCountMap = new HashMap<>();
         int count = DBUtils.getUnseenMessageCount(room.groupKey, unseenCountMap);
-        String text = DBUtils.getText(unseenCountMap);
-        result.add(new ListItem(chatRoom, room.groupKey, room.key, room.name, count, text));
+        result.add(new ListItem(chatRoom, room.groupKey, room.key, room.name, count, null));
         return result;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java
@@ -139,8 +139,6 @@ public enum MessageManager {
         // Generate a map of date header types to a list of messages, i.e. a chronological ordering
         // of the messages.
         List<ListItem> result = new ArrayList<>();
-        if (item == null)
-            return result;
         String groupKey = item.groupKey;
         String roomKey = getRoomKey(item);
         if (roomKey == null)

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -98,10 +98,7 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
 
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
     @Override public void onResume() {
-        // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
-        // FAM is not and the FAM is set to the home experience menu; and display a list of groups
-        // with experiences showing the rooms and highlighting new experiences, much like messages
-        // in the chat group display.
+        // Use the super class to set up the list of groups and establish the FAB and it's menu.
         super.onResume();
         FabManager.game.setImage(R.drawable.ic_add_white_24dp);
         FabManager.game.init(this, GAME_HOME_FAM_KEY);
@@ -110,7 +107,6 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
     /** Initialize the fragment by setting up the FAB and toolbar. */
     @Override public void onStart() {
         super.onStart();
-        FabManager.game.init(this);
         int titleResId = getTitleResId();
         ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, invite, settings);
     }


### PR DESCRIPTION
modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onResume(): remove an unnecessary call to intialize the FAB manager as this has already been done in onStart().

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java

- onResume(): remove an unnecessary call to set the FAB visibility as this is now done by the FAB init() method.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- init(): ensure that the FAB is visible.
- addMenu(): remove as AS thinks it is not used.

modified:   app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java

- getUnseenMessageCount(): remove a guard on the existence of the group in the group manager's variables.  This was the source of the problem for the me group.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- getNoGroupsItemList(): ensure that the me group list item text value is null to hide the me group.

modified:   app/src/main/java/com/pajato/android/gamechat/database/MessageManager.java

- Summary: remove an AS warning.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java

- onStart(): remove an unnecessary FAB manager initialization.  This gets done by onResume.