### PR TITLE
Fix a bug where new message counts in non-me-groups were not shown.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.v4.view.ViewPager;
-import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
@@ -122,13 +121,6 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         }
     }
 
-    /** Initialize ... */
-    @Override public void onStart() {
-        super.onStart();
-        ToolbarManager.instance.init(this, mItem, game, search);
-        FabManager.chat.setMenu(CHAT_ROOM_FAM_KEY, getRoomMenu());
-    }
-
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */
     @Override public void onResume() {
         // Set the titles in the toolbar to the group name only; ensure that the FAB is visible, the
@@ -137,8 +129,16 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         super.onResume();
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this, CHAT_ROOM_FAM_KEY);
-        FabManager.chat.setVisibility(this, View.VISIBLE);
     }
+
+    /** Initialize ... */
+    @Override public void onStart() {
+        super.onStart();
+        ToolbarManager.instance.init(this, mItem, game, search);
+        FabManager.chat.setMenu(CHAT_ROOM_FAM_KEY, getRoomMenu());
+    }
+
+    // Private instance methods.
 
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getRoomMenu() {

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -245,6 +245,8 @@ public enum ToolbarManager {
         if (item == null)
             return null;
         switch (item.type) {
+            case chatGroup:
+                return fragment.getString(R.string.RoomsToolbarTitle);
             case expList:
                 // Determine if the group is the me group and give it special handling.
                 String meGroupKey = AccountManager.instance.getMeGroupKey();

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -164,7 +164,13 @@ public class ListItem {
     }
 
     /** Build a header instance for a given resource id. */
-    public ListItem(final ItemType type, int resId) {
+    public ListItem(final ItemType type, final String groupKey) {
+        this.type = type;
+        this.groupKey = groupKey;
+    }
+
+    /** Build a header instance for a given resource id. */
+    public ListItem(final ItemType type, final int resId) {
         this.type = type;
         nameResourceId = resId;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -85,7 +85,11 @@ import java.util.Map;
     /** The account identifier, the backend push key. */
     public /*final*/ String id;
 
-    /** A list of group or room push keys (depends on context) the account can join. */
+    /**
+     * In an account context, this is a list of group push keys for which the User is a member.
+     *
+     * In a member context, this is a list of room push keys the User has joined.
+     */
     public final List<String> joinList = new ArrayList<>();
 
     /** The modification timestamp. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -252,23 +252,25 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     /** Return null or the push key for the "me room" associated with the current account. */
     public String getMeRoomKey() {
         // Ensure that there is an account and a me group profile has been registered.  If not
-        // return null, otherwise return the me room push key.
+        // return null, otherwise return the me room push key which will be the only room in the Me
+        // group's room list.
         if (!hasAccount() || mGroup == null)
             return null;
         return mGroup.roomList.get(0);
     }
 
     /** Return TRUE iff there is a signed in User. */
-    public boolean hasAccount() { return mCurrentAccount != null; }
+    public boolean hasAccount() {
+        return mCurrentAccount != null;
+    }
 
     /** Handle initialization by setting up the Firebase required list of registered classes. */
     public void init(final List<String> classNameList) {
         // Setup the class map that drives enabling and disabling Firebase. Each of these classes
         // must be registered with the app event manager before Firebase can be enabled.  If any are
         // deregistered, Firebase will effectively be disabled.
-        for (String name : classNameList) {
+        for (String name : classNameList)
             mRegistrationClassNameMap.put(name, false);
-        }
     }
 
     /** Return true iff the current user is a restricted/protected user. */
@@ -366,7 +368,8 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     /** Handle the me group profile change by obtaining the me room push key. */
     @Subscribe public void onGroupProfileChange(@NonNull final ProfileGroupChangeEvent event) {
         // Ensure that the group profile key and the group exist.  Abort if not, otherwise set
-        // watchers and cache all but the me group.  The me group is handled by the account manager.
+        // watchers and cache all but the me group.  The me group is a read-only group and
+        // maintained in the account manager class.
         if (event.key == null || !event.key.equals(getMeGroupKey()))
             return;
         mGroup = event.group;

--- a/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java
@@ -93,7 +93,7 @@ public enum DBUtils {
         return result;
     }
 
-    /** Return the number of unseen messages and update the given map. */
+    /** Return the number of unseen messages in a given group and update the given map. */
     public static int getUnseenMessageCount(@NonNull final String groupKey,
                                             @NonNull final Map<String, Integer> map) {
         int result = 0;

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -146,7 +146,7 @@ public enum GroupManager {
         // group rooms) or more than one group (a set of groups).
         switch (groupMap.size()) {
             case 0:
-                return getNoGroupsItemList();
+                return getMeGroupItemList();
             default:
                 return getGroupsItemList();
         }
@@ -174,20 +174,19 @@ public enum GroupManager {
 
     /** Handle a joined group profile change by updating the map and ensuring watchers are set. */
     @Subscribe public void onGroupProfileChange(@NonNull final ProfileGroupChangeEvent event) {
-        // Ensure that the group profile key and the group exist.  Abort if not, otherwise set
-        // watchers and cache all but the me group.  The me group is handled by the account manager.
+        // Ensure that the group profile key and the group profile exist.  Abort if neither does,
+        // otherwise set watchers on all the room profiles in the group and cache the group profile
+        // as long as the group is not the me group.  The me group profile is handled by the account
+        // manager.
         String groupKey = event.key;
         if (groupKey == null || event.group == null)
             return;
         for (String key : event.group.memberList)
             MemberManager.instance.setWatcher(groupKey, key);
-        if (!groupKey.equals(AccountManager.instance.getMeGroupKey())) {
+        if (!groupKey.equals(AccountManager.instance.getMeGroupKey()))
             groupMap.put(event.key, event.group);
-            // if this isn't the me group, add watchers for all the rooms
-            for (String roomKey : event.group.roomList) {
-                RoomManager.instance.setWatcher(groupKey, roomKey);
-            }
-        }
+        for (String roomKey : event.group.roomList)
+            RoomManager.instance.setWatcher(groupKey, roomKey);
     }
 
     /** Handle a message change event by adding the message into the correct room list.  */
@@ -226,6 +225,13 @@ public enum GroupManager {
         result.add(new ListItem(chatGroup, groupKey, null, name, count, text));
     }
 
+    /** Add a group list item for the given kind (chat message or game experience) and group. */
+    private void addItem(@NonNull final List<ListItem> result, @NonNull final Room room) {
+        Map<String, Integer> unseenCountMap = new HashMap<>();
+        int count = DBUtils.getUnseenMessageCount(room.groupKey, unseenCountMap);
+        result.add(new ListItem(chatRoom, room.groupKey, room.key, room.name, count, null));
+    }
+
     /** Return a list of chat group or room items. */
     private List<ListItem> getGroupsItemList() {
         // Generate a list of items to render in the chat group list by extracting the items based
@@ -239,6 +245,11 @@ public enum GroupManager {
                 for (String groupKey : groupList)
                     if(!(groupKey.equals(AccountManager.instance.getMeGroupKey())))
                         addItem(result, groupKey);
+                    else {
+                        Room room = RoomManager.instance.getMeRoom();
+                        if (room != null)
+                            addItem(result, room);
+                    }
             }
         }
         return result;
@@ -281,29 +292,19 @@ public enum GroupManager {
     }
 
     /** Return an empty list of items or the items from the me group. */
-    private List<ListItem> getNoGroupsItemList() {
-        // Determine if the me room exists.  If not, about with an empty list, otherwise return a
+    private List<ListItem> getMeGroupItemList() {
+        // Determine if the me room exists.  If not, return with an empty list, otherwise return a
         // list of items from the me room.
         List<ListItem> result = new ArrayList<>();
         result.add(new ListItem(resourceHeader, R.string.NoGroupsHeaderText));
         Room room = RoomManager.instance.getMeRoom();
-        if (room == null)
-            return result;
-
-        // Collect and return a list containing a single list item from the me room.
-        Map<String, Integer> unseenCountMap = new HashMap<>();
-        int count = DBUtils.getUnseenMessageCount(room.groupKey, unseenCountMap);
-        result.add(new ListItem(chatRoom, room.groupKey, room.key, room.name, count, null));
+        if (room != null)
+            addItem(result, room);
         return result;
     }
 
     /** Update the headers used to bracket the messages in the main list. */
     private void updateGroupHeaders(final Message message) {
-        // Filter out me room messages.
-        Account account = AccountManager.instance.getCurrentAccount();
-        if (message.groupKey.equals(account.groupKey))
-            return;
-
         // Add the new message to be the last message emanating from
         // the given group.  Then rebuild the lists of date header type to group list associations.
         mGroupToLastNewMessageMap.put(message.groupKey, message);

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -134,9 +134,9 @@ public enum RoomManager {
                 for (String key : roomMap.keySet()) {
                     Room room = RoomManager.instance.getRoomProfile(key);
                     Map<String, Integer> countMap = new HashMap<>();
-                    int count = DBUtils.getUnseenExperienceCount(key, countMap);
-                    String text = DBUtils.getText(countMap);
-                    result.add(new ListItem(chatRoom, groupKey, room.key, room.name, count, text));
+                    int count = DBUtils.getUnseenMessageCount(room.groupKey, countMap);
+                    count = countMap.containsKey(room.key) ? countMap.get(room.key) : 0;
+                    result.add(new ListItem(chatRoom, groupKey, room.key, room.name, count, null));
                 }
             }
         }
@@ -161,8 +161,7 @@ public enum RoomManager {
     }
 
     /** Handle a account change event by setting up or clearing variables. */
-    @Subscribe
-    public void onAuthenticationChange(@NonNull final AuthenticationChangeEvent event) {
+    @Subscribe public void onAuthenticationChange(@NonNull final AuthenticationChangeEvent event) {
         // Determine if a User has been authenticated.  If so, do nothing, otherwise clear the
         // message list for the logged out User.
         if (event.account != null) return;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -54,6 +54,7 @@ import static com.pajato.android.gamechat.common.FragmentType.selectUser;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.common.PlayModeManager.PlayModeType.user;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expList;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expRoom;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_OWNER_ID;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_EXPERIENCE_KEY;
@@ -268,12 +269,14 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         if (dispatcher.type == null)
             return false;
         switch (type) {
-            case expGroupList:
-            case expRoomList: // A group list does not need an item.
+            case expGroupList:  // A group list does not need an item.
+                return true;
+            case expRoomList:   // A room list needs an item.
+                mItem = new ListItem(expRoom, dispatcher.groupKey);
                 return true;
             case experienceList:
-                // The experiences in a room require both the group and room keys.
-                // Determine if the group is the me group and give it special handling.
+                // The experiences in a room require both the group and room keys.  Determine if the
+                // group is the me group and give it special handling.
                 String groupKey = dispatcher.groupKey;
                 String meGroupKey = AccountManager.instance.getMeGroupKey();
                 String roomKey = meGroupKey != null && meGroupKey.equals(groupKey)

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -187,10 +187,9 @@ public class CheckersFragment extends BaseExperienceFragment {
         List<Player> players = getDefaultPlayers(context, playerAccounts);
         String name1 = players.get(0).name;
         String name2 = players.get(1).name;
-
         long tStamp = new Date().getTime();
-        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2,
-                SimpleDateFormat.getDateTimeInstance().format(tStamp));
+        String date = SimpleDateFormat.getDateTimeInstance().format(tStamp);
+        String name = String.format(Locale.US, "%s vs %s on %s", name1, name2, date);
 
         // Set up the default group (Me Group) and room (Me Room) keys, the owner id and create the
         // object on the database.


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit resolves a problem in handling the unseen message count for groups other than the me group.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java

- onStart(): move per RNF.
- onResume(): remove the stale FAB manager visibility initialization.

modified:   app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java

- setTitle(): deal with showing the rooms in a group.

modified:   app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java

- ListItem(): add a new constructor to just add a group key.

modified:   app/src/main/java/com/pajato/android/gamechat/common/model/Account.java

- Summary: enhance the joinList javadoc.

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/database/DBUtils.java

- Summary: cosmetic and javadoc enhancements.

modified:   app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java

- getNoGroupsItemList(): rename to getMeGroupItemList(); use the new addItem() method.
- onGroupProfileChange(): enhance comments; set a watcher on the me room.
- addItem(): add an overload to deal with the me room.
- getGroupsItemList(): deal with the me room.
- updateGroupHeaders(): do not exclude the me group.

modified:   app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java

- getListItemData(): update the count and text item fields correctly.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- onDispatch(): build a item for a room list.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java

- Summary: cosmetic, non-functional code changes.