### PR TITLE
Remove the "Go to My Rooms" menu item on games.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -262,6 +262,17 @@ public class CheckersFragment extends BaseExperienceFragment {
         return result;
     }
 
+    // Private instance methods.
+
+    /** Return the home FAM used in the top level show games and show no games fragments. */
+    private List<MenuEntry> getCheckersMenu() {
+        final List<MenuEntry> menu = new ArrayList<>();
+        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
+        menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
+        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_checkers));
+        return menu;
+    }
+
     /** Return a done message text to show in a snackbar.  The given model provides the state. */
     private String getDoneMessage(final Checkers model) {
         // Determine if there is a winner.  If not, return the "tie" message.
@@ -880,16 +891,6 @@ public class CheckersFragment extends BaseExperienceFragment {
                 // Save any changes that have been made to the database
                 ExperienceManager.instance.updateExperience(mExperience);
         }
-    }
-
-    /** Return the home FAM used in the top level show games and show no games fragments. */
-    private List<MenuEntry> getCheckersMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getTintEntry(R.string.MyRooms, R.drawable.ic_casino_black_24dp));
-        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_checkers));
-        return menu;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -586,6 +586,15 @@ public class ChessFragment extends BaseExperienceFragment {
         return false;
     }
 
+    /** Return the home FAM used in the top level show games and show no games fragments. */
+    private List<MenuEntry> getChessMenu() {
+        final List<MenuEntry> menu = new ArrayList<>();
+        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
+        menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
+        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_chess));
+        return menu;
+    }
+
     /**
      * A utility method that facilitates keeping the board's checker pattern in place throughout the
      * highlighting and de-highlighting process. It accepts a tile and sets its background to white
@@ -921,16 +930,6 @@ public class ChessFragment extends BaseExperienceFragment {
                 ExperienceManager.instance.updateExperience(mExperience);
             }
         }
-    }
-
-    /** Return the home FAM used in the top level show games and show no games fragments. */
-    private List<MenuEntry> getChessMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
-        menu.add(getTintEntry(R.string.MyRooms, R.drawable.ic_casino_black_24dp));
-        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_chess));
-        return menu;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -334,7 +334,6 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         final List<MenuEntry> menu = new ArrayList<>();
         menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getTintEntry(R.string.MyRooms, R.drawable.ic_casino_black_24dp));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_tictactoe_red));
         return menu;
     }

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -13,7 +13,6 @@
     <string name="InviteFriendNav">Invite friends</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyExperiencesToolbarTitle">My Games</string>
-    <string name="MyRooms">Go To My Rooms</string>
     <string name="NoFriendsFound">No Available Users</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

Given that the User can use the back button or the toolbar back icon to easily navigate up an experience hierarchy, the menu item is of questionable value.  This commit removes the menu item.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
modified:   app/src/main/res/values/strings_exp.xml

- Summary: Remove the questionable menu entry and it's localized title string.