### PR TITLE
Fix an IllegalArgumentException (GridLayout) in the Chess fragment.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
@@ -79,8 +79,12 @@ public class Checkerboard {
 
     /** Remove all cells from the board. */
     public void reset() {
+        // There appears to be a bug with GridLayout in that if the row and column counts are not
+        // specified, an illegal argument exception can occur, so explicitly set the row and column
+        // counts.
         mGrid.removeAllViews();
-
+        mGrid.setRowCount(8);
+        mGrid.setColumnCount(8);
     }
 
     /** Set the highlight at a given position using a given color resource id. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -416,8 +416,6 @@ public class ChessFragment extends BaseExperienceFragment {
         param.rightMargin = 0;
         param.topMargin = 0;
         param.setGravity(Gravity.CENTER);
-        param.rowSpec = GridLayout.spec(index / 8);
-        param.columnSpec = GridLayout.spec(index % 8);
 
         // Set up the tile-specific information.
         currentTile.setLayoutParams(param);


### PR DESCRIPTION
<h1>Rationale:</h1>

When starting a chess experience from the TicTacToe FAM, the GridLayout would take an IllegalArgumentException.  The cause is ill understood but debugging reveals that the GridLayout thinks there are 3 columns rather than the 8 specified in the XML.  Programmatically setting the number of rows and columns to 8 combined with not using the GridLayout.Params row and column spec values appears to cure the problem.  This commit provides exactly that cure.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java

- reset(): set the row and column counts programmatically.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java

- makeBoardbutton(): do not use the rowSpec and columnSpec layout params as they are not providing the desired result.