### PR TITLE
Delete experience feature

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
@@ -102,7 +102,7 @@ public enum PlayModeManager {
         Account account = AccountManager.instance.getCurrentAccount();
         if (!AccountManager.hasSelectableMembers(account))
             // No users exist so create a header stating this.
-            result.add(new ListItem(resourceHeader, R.string.NoFriendsFound));
+            result.add(new ListItem(resourceHeader, R.string.NoUsersFound));
         else
             for (Map.Entry<String, Boolean> entry : account.joinMap.entrySet()) {
                 String groupKey = entry.getKey();

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -237,6 +237,18 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 else
                     holder.optIcon.setImageResource(R.drawable.ic_exit_to_app_black_24dp);
                 break;
+            case expList:
+                Room expRoom = RoomManager.instance.getRoomProfile(item.roomKey);
+                if (expRoom == null) {
+                    String format = "Found null room profile for room %s";
+                    Log.e(TAG, String.format(format, item.roomKey));
+                    break;
+                }
+                if (expRoom.owner.equals(AccountManager.instance.getCurrentAccountId())) {
+                    holder.optIcon.setTag(item);
+                    holder.optIcon.setImageResource(R.drawable.ic_delete_forever_black_24dp);
+                }
+                break;
             default:
                 // ignore other types
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/event/ExperienceDeleteEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ExperienceDeleteEvent.java
@@ -1,0 +1,19 @@
+package com.pajato.android.gamechat.event;
+
+import static android.R.attr.key;
+
+/**
+ * Provides an event class indicating that an experience has been deleted.
+ */
+public class ExperienceDeleteEvent {
+
+    // Public instance variables.
+
+    /** The push key for the experience. */
+    public final String experienceKey;
+
+    /** Build the event */
+    public ExperienceDeleteEvent(final String key) {
+        this.experienceKey = key;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -27,8 +27,6 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.model.Group;
-import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.Dispatcher;
@@ -40,7 +38,6 @@ import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
-import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.PlayModeChangeEvent;
 import com.pajato.android.gamechat.main.NetworkManager;
@@ -62,8 +59,6 @@ import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expLi
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expRoom;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_OWNER_ID;
-import static com.pajato.android.gamechat.event.InviteEvent.ItemType.group;
-import static com.pajato.android.gamechat.event.InviteEvent.ItemType.room;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_OWNER_ID;
 
@@ -345,15 +340,14 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         ListItem item = (ListItem) view.getTag();
         switch (item.type) {
             case expList:
-                handleDeleteExperienceClick(item);
+                verifyDeleteExperience(item);
                 break;
             default:
                 break;
         }
     }
 
-    private void handleDeleteExperienceClick(final ListItem item) {
-        Log.i(TAG, "Got here...");
+    private void verifyDeleteExperience(final ListItem item) {
         final Experience exp = ExperienceManager.instance.experienceMap.get(item.key);
         if (exp == null)
             return;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
@@ -26,11 +26,14 @@ import com.pajato.android.gamechat.common.InvitationManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
+import com.pajato.android.gamechat.event.ExperienceDeleteEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
+
+import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
@@ -63,6 +66,12 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
             default:
                 break;
         }
+    }
+    @Subscribe public void onExperienceDelete(final ExperienceDeleteEvent event) {
+        String format = "onExperienceDelete with event {%s}";
+        logEvent(String.format(Locale.US, format, event));
+        if (mActive)
+            updateAdapterList();
     }
 
     /** Handle a menu item selection. */

--- a/app/src/main/res/layout/item_without_tint.xml
+++ b/app/src/main/res/layout/item_without_tint.xml
@@ -10,16 +10,19 @@
         <ImageView style="@style/ListItemImage" android:id="@+id/ListItemIcon"
             android:contentDescription="@string/ListItemIconDesc" />
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
+            android:layout_weight="1"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_gravity="center_vertical"
             android:orientation="vertical">
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
                 <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     tools:text="Paul &amp; Sandy Group"/>
                 <TextView style="@style/ListItemCount" android:id="@+id/Count"
                     tools:text="3 new"/>
@@ -27,6 +30,9 @@
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="group, Sandy Scott, PT General"/>
         </LinearLayout>
+        <ImageView style="@style/ListItemOptionalImage" android:id="@+id/endIcon"
+            android:tint="@color/colorPrimaryDark"
+            android:contentDescription="@string/ListItemLeaveIconDesc" />
     </LinearLayout>
     <View style="@style/ListItemFooter" />
 </LinearLayout>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -11,12 +11,14 @@
     <string name="ChatSignedOutMessageText">GameChat is much more fun when you can chat with your family and friends.</string>
     <string name="ChatTitle">Chat</string>
     <string name="DefaultRoomName">Common</string>
+    <string name="DeleteConfirmMessage">Do you want to delete %s?</string>
+    <string name="DeleteExperienceTitle">Delete Experience?</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>
     <string name="Group">Group</string>
     <string name="GroupsToolbarTitle">Groups with Messages</string>
     <string name="GroupMeToolbarTitle">My Chat Room</string>
-    <string name="LeaveGroupTitle">Leave Group?</string>
     <string name="LeaveConfirmMessage">Do you want to leave %s?</string>
+    <string name="LeaveGroupTitle">Leave Group?</string>
     <string name="LeaveRoomTitle">Leave Room?</string>
     <string name="ListItemIconDesc">The list icon.</string>
     <string name="ListItemLeaveIconDesc">The leave (exit) icon.</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -13,9 +13,10 @@
     <string name="InviteFriendNav">Invite friends</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyExperiencesToolbarTitle">My Games</string>
-    <string name="NoFriendsFound">No Available Users</string>
+    <string name="NoExperiencesMessage">You have no experiences</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
+    <string name="NoUsersFound">No Available Users</string>
     <string name="PlayAgain">Play again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>


### PR DESCRIPTION
# Rationale

Implement feature to let user delete an experience.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java

* Rename "NoFriendsFound" message to "NoUsersFound"

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java

* setEndIcon(): add case for experience list to show delete icon of the current account owns the experience (otherwise, no icon)

#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

* deleteExperience(): remove experience from Firebase, from the various maps and lists and remove the database watcher. Then post an event indicating that the experience has been deleted.
* getItemListExperience(): if the resulting list is empty, add a header indicating that there are no experiences

#### app/src/main/java/com/pajato/android/gamechat/event/ExperienceDeleteEvent.java

* New class providing an event to indicate that an experience has been deleted

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

* processClickEvent(): add a case for a click on the end icon
* processEndIconClick(): handle end icon click
* verifyDeleteExperience(): raise an AlertDialog to verify with the user that they really want to delete the experience

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java

* onExperienceDelete(): listen for experiences to be deleted and refresh the view by updating the adapter list

#### app/src/main/res/layout/item_without_tint.xml

* Add the end icon to the layout

#### app/src/main/res/values/strings_chat.xml

* new strings

#### app/src/main/res/values/strings_exp.xml

* new strings

