### PR TITLE
Fix broken FAB menus.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
@@ -72,6 +72,10 @@ public class SelectChatInviteFragment extends BaseChatFragment {
                 InvitationManager.instance.extendInvitation(getActivity(), getSelections());
                 DispatchManager.instance.startNextFragment(getActivity(), chat);
                 break;
+            case R.id.chatFab:
+                // It is a chat fab button.  Toggle the state.
+                FabManager.chat.toggle(this);
+                break;
             default:
                 processSelection(event.view);
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
@@ -72,6 +72,10 @@ public class SelectExpInviteFragment extends BaseChatFragment {
                 InvitationManager.instance.extendInvitation(getActivity(), getSelections());
                 DispatchManager.instance.startNextFragment(getActivity(), exp);
                 break;
+            case R.id.gameFab:
+                // It is a chat fab button.  Toggle the state.
+                FabManager.game.toggle(this);
+                break;
             default:
                 processSelection(event.view);
                 break;


### PR DESCRIPTION
# Rationale

The FAB menus in the Room Invitations screen (both chat and experience) were not working. Reconnect the click handler.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectChatInviteFragment.java
* onClick(): add case for chat FAB click

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectExpInviteFragment.java
* onClick(): add case for game FAB click
