### PR TITLE
Fix broken FAB menu and broken display content in Join Rooms feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -86,6 +86,10 @@ public class JoinRoomsFragment extends BaseChatFragment {
             case R.id.selector:
                 processSelection(event, (CheckBox) event.view);
                 break;
+            case R.id.chatFab:
+                // It is a chat fab button.  Toggle the state.
+                FabManager.chat.toggle(this);
+                break;
             default:
                 break;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -178,7 +178,8 @@ public enum JoinManager {
                     }
                 }
                 if (!hasMemberRoom)
-                    items.add(new ListItem(selectableMember, groupKey, member.getNickName(),
+                    items.add(new ListItem(selectableMember, groupKey, member.id,
+                            member.getNickName(),
                             GroupManager.instance.getGroupName(groupKey), member.url));
             }
         }


### PR DESCRIPTION
# Rationale
The Join Rooms feature was broken.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
* onClick(): add case to handle FAB button click
#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* getAvailableMembers(): use correct ListItem constructor to utilize account icon URL
