### PR TITLE
Persist chess game board models.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -199,6 +199,15 @@ public abstract class BaseFragment extends Fragment {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId, ordinal));
     }
 
+    /** Return -1 or the integer valud corresponding to the given string. */
+    protected int getInt(final String value) {
+        try {
+            return value != null ? Integer.parseInt(value) : -1;
+        } catch (NumberFormatException exc) {
+            return -1;
+        }
+    }
+
     /** Return a menu entry for with given title and icon resource items. */
     protected MenuEntry getNoTintEntry(final int titleId, final int iconId) {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId));

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -226,6 +226,32 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         }
     }
 
+    /** Handle changing the turn and turn indicator for a given turn state. */
+    protected void handleTurnChangeNew(final boolean switchPlayer) {
+        boolean turn = mExperience.getTurn();
+        if (switchPlayer) {
+            turn = mExperience.toggleTurn();
+        }
+
+        // Handle the TextViews that serve as our turn indicator.
+        TextView playerOneLeft = (TextView) mLayout.findViewById(R.id.leftIndicator1);
+        TextView playerOneRight = (TextView) mLayout.findViewById(R.id.rightIndicator1);
+        TextView playerTwoLeft = (TextView) mLayout.findViewById(R.id.leftIndicator2);
+        TextView playerTwoRight = (TextView) mLayout.findViewById(R.id.rightIndicator2);
+
+        if(turn) {
+            playerOneLeft.setVisibility(View.VISIBLE);
+            playerOneRight.setVisibility(View.VISIBLE);
+            playerTwoLeft.setVisibility(View.INVISIBLE);
+            playerTwoRight.setVisibility(View.INVISIBLE);
+        } else {
+            playerOneLeft.setVisibility(View.INVISIBLE);
+            playerOneRight.setVisibility(View.INVISIBLE);
+            playerTwoLeft.setVisibility(View.VISIBLE);
+            playerTwoRight.setVisibility(View.VISIBLE);
+        }
+    }
+
     /**
      * Return TRUE if this experience is in the "me" group. If either the 'me' group key or the
      * current experience group key is null, return true (assume we're in the 'me' situation).
@@ -332,6 +358,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         if (expFragmentType != null)
             DispatchManager.instance.chainFragment(getActivity(), expFragmentType);
     }
+
+    // Private instance methods.
 
     /** Process the end icon click */
     private void processEndIconClick(final View view) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Board.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Board.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.exp;
+
+import android.support.annotation.NonNull;
+
+import com.pajato.android.gamechat.exp.chess.ChessPiece;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provide an interface for which two-player game experience boards are expected to satisfy. Chess
+ * and Checkers are the first two games to use (implement) this interface.
+ *
+ * @author Paul Michael Reilly
+ */
+
+public interface Board {
+
+    /** Return the default color for the piece at the given position. */
+    int getDefaultColor(int position);
+
+    /** Return the default text value for the piece at the given position. */
+    String getDefaultText(int position);
+
+    /** Return a set of position keys in the board model. */
+    Set<String> getKeySet();
+
+    /** Return -1 or the board position corresponding to a given key. */
+    int getPosition(final String key);
+
+    /** Return null or the unicode text associated with a piece with a given position. */
+    int getTypeface(int position);
+
+    /** Setup the piece at the given position for the start of a game. */
+    void setDefault(int position);
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
@@ -41,6 +41,9 @@ public interface Experience {
     /** Return the experience room push key. */
     String getRoomKey();
 
+    /** Return the current player turn. */
+    boolean getTurn();
+
     /** Return the experience push key. */
     String getExperienceKey();
 
@@ -67,6 +70,9 @@ public interface Experience {
 
     /** Provide a map of experience properties. */
     Map<String, Object> toMap();
+
+    /** Toggle the turn for the players. */
+    boolean toggleTurn();
 
     /** Return the unseen list. */
     List<String> getUnseenList();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Team.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Team.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.exp;
+
+import com.pajato.android.gamechat.R;
+
+/**
+ * The team constants, providing the default text color.
+ *
+ * @author Paul Michael Reilly
+ */
+public enum Team {
+    NONE (R.color.white),
+    PRIMARY (R.color.colorPrimary),
+    SECONDARY (R.color.colorAccent);
+
+    public int color;
+
+    Team(final int color) {
+        this.color = color;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersBoard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersBoard.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.exp.checkers;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.google.firebase.database.Exclude;
+import com.pajato.android.gamechat.exp.Board;
+import com.pajato.android.gamechat.exp.Checkerboard;
+import com.pajato.android.gamechat.exp.Team;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.pajato.android.gamechat.exp.checkers.CheckersPiece.PieceType.PIECE;
+
+/**
+ * Provide a POJO representing a Chess board and methods to modify the board. The basic board is
+ * a HashMap of board cell index (0->63) to ChessPiece (which contains team and piece type).
+ *
+ * Since Firebase has some difficulty with integer-based key values for a HashMap (even if they are
+ * String representations in Java), the key to our HashMap will have "index" prepended to the cell
+ * index value, so that Firebase cannot ever interpret it as an integer.
+ *
+ * So, this class is essentially a wrapper around a HashMap which handles the conversion of an
+ * integer index to a string and provides some convenience methods to determine piece type and team
+ * for a given cell on the board.
+ */
+
+public class CheckersBoard implements Board {
+
+    private static final String CELL_ID = "cell";
+
+    /** logcat TAG */
+    @SuppressWarnings("unused")
+    private static final String TAG = CheckersBoard.class.getSimpleName();
+
+    public Map<String, CheckersPiece> pieceMap;
+
+    private String makeCellId(final int index) {
+        return CELL_ID + String.valueOf(index);
+    }
+
+    // Public constructors.
+
+    /** Provide a no-arg constructor for Firebase. */
+    public CheckersBoard() {}
+
+    /** Build an instance that initializes the underlying board. */
+    public CheckersBoard(@NonNull final Context context, final Checkerboard board) {
+        pieceMap = new HashMap<>();
+
+        // Initialize the text on each piece for the start of a game.
+        for (int index = 0; index < 24; index++)
+            board.initBoardModel(context, index, this);
+        for (int index = 40; index < 64; index++)
+            board.initBoardModel(context, index, this);
+
+    }
+
+    /**
+     * Add a piece to the board
+     * @param index index into the board (valid indices are 0->63).
+     * @param type piece type
+     * @param team the team
+     */
+    public void add(final int index, final CheckersPiece.PieceType type, final Team team) {
+        pieceMap.put(makeCellId(index), new CheckersPiece(type, team));
+    }
+
+    /**
+     * Add the specified piece to the board at the indicated location
+     * @param index board cell index (valid indices are 0->63)
+     * @param p the piece to add
+     */
+    public void add(final int index, final CheckersPiece p) {
+        pieceMap.put(makeCellId(index), p);
+    }
+
+    /**
+     * Convenience method to determine if the primary team's king is at the specified cell location
+     * @return true if the primary king is at the specified index
+     */
+    public boolean containsPrimaryKing() {
+        for (int i = 0; i < 64; i++) {
+            if (cellHasTeamPiece(i, CheckersPiece.PieceType.KING, Team.PRIMARY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Convenience method to determine if the secondary team's king is at the specified cell location
+     * @return true if the secondary king is at the specified index
+     */
+    public boolean containsSecondaryKing() {
+        for (int i = 0; i < 64; i++) {
+            if (cellHasTeamPiece(i, CheckersPiece.PieceType.KING, Team.SECONDARY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Remove a piece from the board at the specified index.
+     * @param index index into the board (valid indices are 0->63).
+     * @return the removed piece
+     */
+    public CheckersPiece delete(final int index) {
+        return pieceMap.remove(makeCellId(index));
+    }
+
+    /** Implement the Board interface to return the default piece text color at a given position. */
+    @Override public int getDefaultColor(final int position) {
+        Team team = getTeam(position);
+        if (team == null)
+            return Team.NONE.color;
+        return team.color;
+    }
+
+    /** Implement the Board interface to return the default piece text value at a given position. */
+    @Override public String getDefaultText(final int position) {
+        CheckersPiece.PieceType type = getPieceType(position);
+        if (type == null)
+            return CheckersPiece.PieceType.NONE.text;
+        return type.text;
+    }
+
+    /** Return a set of position keys representing active pieces on the board. */
+    @Exclude @Override public Set<String> getKeySet() {
+        return pieceMap.keySet();
+    }
+
+    /** Return a checkers piece given a board index. */
+    public CheckersPiece getPiece(final int index) {
+        return pieceMap.get(makeCellId(index));
+    }
+
+    /** Return a checkers piece given a cell key. */
+    public CheckersPiece getPiece(final String key) {
+        return pieceMap.get(key);
+    }
+
+    /**
+     * Return the piece type for the piece at the specified index.
+     * @param index index into the board (valid indices are 0->63).
+     * @return the piece type for the piece at the specified location or empty string ("") if none
+     */
+    public CheckersPiece.PieceType getPieceType(final int index) {
+        CheckersPiece p = pieceMap.get(makeCellId(index));
+        if (p == null) {
+            return CheckersPiece.PieceType.NONE;
+        } else {
+            return p.getPieceType();
+        }
+    }
+
+    /** Implement the interface to return -1 or a position corresponding to a given cell key. */
+    @Override public int getPosition(@NonNull final String key) {
+        try {
+            return Integer.parseInt(key.substring(CELL_ID.length()));
+        } catch (NumberFormatException exc) {
+            return -1;
+        }
+    }
+
+    /**
+     * Return the team id for the piece at the specified index.
+     * TODO: Refactor the ChessFragment, ChessHelper & friends to use the enum value, not an int!!
+     * @param index index into the board (valid indices are 0->63).
+     * @return the team for any piece at the specified location or -1 if none
+     */
+    public Team getTeam(final int index) {
+        CheckersPiece p = pieceMap.get(makeCellId(index));
+        if (p == null) {
+            return Team.NONE;
+        }
+        return p.getTeam();
+    }
+
+    /** Implement the interface to the typeface corresponding to a given cell key. */
+    @Override public int getTypeface(final int position) {
+        CheckersPiece piece = pieceMap.get(CELL_ID + String.valueOf(position));
+        if (piece == null)
+            return CheckersPiece.PieceType.NONE.typeface;
+        return piece.getPieceType().typeface;
+    }
+
+    /**
+     * Determine if specified piece type for the specified team is at the cell location indicates
+     * @return true if the primary king is at the specified index
+     */
+    public boolean cellHasTeamPiece(final int index, CheckersPiece.PieceType type, Team team) {
+        return getPieceType(index).equals(type) && getTeam(index).equals(team);
+    }
+
+    /** Implement the Board interface to setup the default piece at a given position. */
+    @Override public void setDefault(final int position) {
+        String cellId = "cell" + String.valueOf(position);
+        switch (position) {
+            case 0: case 2: case 4: case 6:
+            case 9: case 11: case 13: case 15:
+            case 16: case 18: case 20: case 22:
+                // Handle the secondary team (black) rooks.
+                pieceMap.put(cellId, new CheckersPiece(PIECE, Team.SECONDARY));
+                break;
+            case 40: case 42: case 44: case 46:
+            case 49: case 51: case 53: case 55:
+            case 56: case 58: case 60: case 62:
+                // Handle the primary team (white) pawns.
+                pieceMap.put(cellId, new CheckersPiece(PIECE, Team.PRIMARY));
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** Provide a default map for a Firebase create/update. */
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("board", pieceMap);
+        return result;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersPiece.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersPiece.java
@@ -15,7 +15,7 @@
  * see <http://www.gnu.org/licenses/>.
  */
 
-package com.pajato.android.gamechat.exp.chess;
+package com.pajato.android.gamechat.exp.checkers;
 
 import android.graphics.Typeface;
 
@@ -29,47 +29,43 @@ import java.util.Map;
 /**
  * A simple P.O.J.O. class that keeps track of a chess pieces type and the team it is on.
  */
-@IgnoreExtraProperties public class ChessPiece {
+@IgnoreExtraProperties public class CheckersPiece {
 
     /** Provide constants for chess pieces that use unicode values for the glyph. */
     public enum PieceType {
         NONE (""),
-        KING ("\u2654"),
-        QUEEN ("\u2655"),
-        BISHOP ("\u2657"),
-        KNIGHT ("\u2658"),
-        ROOK ("\u2656"),
-        PAWN ("\u2659");
+        KING ("\u26c1"),
+        PIECE ("\u26c0");
 
         public String text;
         public int typeface;
 
         PieceType(final String text) {
             this.text = text;
-            typeface = Typeface.NORMAL;
+            typeface = Typeface.BOLD;
         }
    }
 
-    /** The chess piece type. */
+    /** The checkers piece type for this piece. */
     private PieceType mPieceType;
 
-    /** The chess team. */
+    /** The checkers team for this piece. */
     private Team mTeam;
 
     // Public constructors.
 
     /** Build an empty args constructor for the database. */
-    @SuppressWarnings("unused") public ChessPiece() {}
+    @SuppressWarnings("unused") public CheckersPiece() {}
 
     /** Constructor requires a piece and team specified, provided as constants in the class. */
-    ChessPiece(final PieceType pieceType, final Team team) {
+    CheckersPiece(final PieceType pieceType, final Team team) {
         mPieceType = pieceType;
         mTeam = team;
     }
 
     // Public instance methods.
 
-    /** Return TRUE iff this piece is of the given type is playing for the given team. */
+    /** ... */
     public boolean isTeamPiece(final PieceType p, final Team t) {
         return (mPieceType.equals(p) && mTeam.equals(t));
     }
@@ -78,11 +74,11 @@ import java.util.Map;
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("pieceType", mPieceType.name());
-        result.put("team", mTeam.name());
+        result.put("teamId", mTeam.name());
         return result;
     }
 
-    public PieceType getPieceType() {
+    PieceType getPieceType() {
         return mPieceType;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
@@ -178,6 +178,9 @@ import static com.pajato.android.gamechat.exp.ExpType.chessET;
     /** Return the room push key. */
     @Exclude @Override public String getRoomKey() { return roomKey; }
 
+    /** Return the room push key. */
+    @Exclude @Override public boolean getTurn() { return turn; }
+
     /** Set the state given a string value. */
     public void setState(final String value) {
         state = value != null ? State.valueOf(value) : null;
@@ -221,7 +224,7 @@ import static com.pajato.android.gamechat.exp.ExpType.chessET;
     }
 
     /** Toggle the turn state. */
-    @Exclude public boolean toggleTurn() {
+    @Exclude @Override public boolean toggleTurn() {
         turn = !turn;
         return turn;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
@@ -17,7 +17,7 @@
 
 package com.pajato.android.gamechat.exp.chess;
 
-import com.pajato.android.gamechat.exp.chess.ChessPiece.ChessTeam;
+import com.pajato.android.gamechat.exp.Team;
 
 import java.util.List;
 
@@ -73,7 +73,7 @@ public class ChessHelper {
         int[] possibleMoves = {left, upLeft, up, upRight, right, downRight, down, downLeft};
         for (int possibleMove : possibleMoves) {
             if(possibleMove > -1 && possibleMove < 64) {
-                if(board.retrieve(possibleMove) == null) {
+                if(board.getPiece(possibleMove) == null) {
                     threatRange.add(possibleMove);
                 } else if (board.getTeam(possibleMove) != board.getTeam(highlightedIndex)) {
                     threatRange.add(possibleMove);
@@ -82,42 +82,42 @@ public class ChessHelper {
         }
 
         // Handle Castling for Blue
-        if(board.getTeam(highlightedIndex).equals(ChessTeam.PRIMARY) && !primaryKingHasMoved) {
+        if(board.getTeam(highlightedIndex).equals(Team.PRIMARY) && !primaryKingHasMoved) {
             // The more common Castling variant, "Queen-Side Castling" or "Short Castling"
             boolean canCastleKingSide = highlightedIndex == 60 && !primaryKingSideRookHasMoved &&
-                    board.retrieve(highlightedIndex + 1) == null &&
-                    board.retrieve(highlightedIndex + 2) == null &&
-                    board.retrieve(highlightedIndex + 3) != null &&
+                    board.getPiece(highlightedIndex + 1) == null &&
+                    board.getPiece(highlightedIndex + 2) == null &&
+                    board.getPiece(highlightedIndex + 3) != null &&
                     board.getPieceType(highlightedIndex + 3).equals(ROOK);
             if(canCastleKingSide) {
                 threatRange.add(highlightedIndex + 2);
             }
             // The less common Castling variant, "Queen-Side Castling" or "Long Castling"
             boolean canCastleQueenSide = highlightedIndex == 60 && !primaryQueenSideRookHasMoved &&
-                    board.retrieve(highlightedIndex - 1) == null &&
-                    board.retrieve(highlightedIndex - 2) == null &&
-                    board.retrieve(highlightedIndex - 3) == null &&
-                    board.retrieve(highlightedIndex - 4) != null &&
+                    board.getPiece(highlightedIndex - 1) == null &&
+                    board.getPiece(highlightedIndex - 2) == null &&
+                    board.getPiece(highlightedIndex - 3) == null &&
+                    board.getPiece(highlightedIndex - 4) != null &&
                     board.getPieceType(highlightedIndex - 4).equals(ROOK);
             if(canCastleQueenSide) {
                 threatRange.add(highlightedIndex - 3);
             }
             // Handle Castling for the other team
-        } else if (board.getTeam(highlightedIndex).equals(ChessTeam.SECONDARY) && !secondaryKingHasMoved) {
+        } else if (board.getTeam(highlightedIndex).equals(Team.SECONDARY) && !secondaryKingHasMoved) {
             boolean canCastleKingSide = highlightedIndex == 4 && !secondaryKingSideRookHasMoved &&
-                    board.retrieve(highlightedIndex + 1) == null &&
-                    board.retrieve(highlightedIndex + 2) == null &&
-                    board.retrieve(highlightedIndex + 3) != null &&
+                    board.getPiece(highlightedIndex + 1) == null &&
+                    board.getPiece(highlightedIndex + 2) == null &&
+                    board.getPiece(highlightedIndex + 3) != null &&
                     board.getPieceType(highlightedIndex + 3).equals(ROOK);
             if (canCastleKingSide) {
                 threatRange.add(highlightedIndex + 2);
             }
             // The less common Castling variant, "Queen-Side Castling" or "Long Castling"
             boolean canCastleQueenSide = highlightedIndex == 4 && !secondaryQueenSideRookHasMoved &&
-                    board.retrieve(highlightedIndex - 1) == null &&
-                    board.retrieve(highlightedIndex - 2) == null &&
-                    board.retrieve(highlightedIndex - 3) == null &&
-                    board.retrieve(highlightedIndex - 4) != null &&
+                    board.getPiece(highlightedIndex - 1) == null &&
+                    board.getPiece(highlightedIndex - 2) == null &&
+                    board.getPiece(highlightedIndex - 3) == null &&
+                    board.getPiece(highlightedIndex - 4) != null &&
                     board.getPieceType(highlightedIndex - 4).equals(ROOK);
             if(canCastleQueenSide) {
                 threatRange.add(highlightedIndex - 3);
@@ -164,7 +164,7 @@ public class ChessHelper {
                 int upLeftIteration = highlightedIndex - (9 * i);
                 if (upLeftIteration % 8 != 7 && upLeftIteration > -1) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(upLeftIteration) == null) {
+                    if (board.getPiece(upLeftIteration) == null) {
                         threatRange.add(upLeftIteration);
                         // If there's an enemy piece, we can go there but no further.
                     } else if (board.getTeam(upLeftIteration) !=  board.getTeam(highlightedIndex)) {
@@ -184,7 +184,7 @@ public class ChessHelper {
                 int upRightIteration = highlightedIndex - (7 * i);
                 if (upRightIteration % 8 != 0 && upRightIteration > -1) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(upRightIteration) == null) {
+                    if (board.getPiece(upRightIteration) == null) {
                         threatRange.add(upRightIteration);
                         // If there's an enemy piece, we can go there but no further.
                     } else if (board.getTeam(upRightIteration) !=  board.getTeam(highlightedIndex)) {
@@ -204,7 +204,7 @@ public class ChessHelper {
                 int downRightIteration = highlightedIndex + (9 * i);
                 if (downRightIteration % 8 != 0 && downRightIteration < 64) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(downRightIteration) == null) {
+                    if (board.getPiece(downRightIteration) == null) {
                         threatRange.add(downRightIteration);
                         // If there's an enemy piece, we can go there but no further.
                     } else if (board.getTeam(downRightIteration) != board.getTeam(highlightedIndex)) {
@@ -224,7 +224,7 @@ public class ChessHelper {
                 int downLeftIteration = highlightedIndex + (7 * i);
                 if (downLeftIteration % 8 != 7 && downLeftIteration < 64) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(downLeftIteration) == null) {
+                    if (board.getPiece(downLeftIteration) == null) {
                         threatRange.add(downLeftIteration);
                         // If there's an enemy piece, we can go there but no further.
                     } else if (board.getTeam(downLeftIteration) != board.getTeam(highlightedIndex)) {
@@ -255,7 +255,7 @@ public class ChessHelper {
                                           final ChessBoard board) {
         // Pawns move differently depending on the team they are on. First, handle the pawns that
         // move "up". These pawns are on the primary team.
-        if (board.getTeam(highlightedIndex).equals(ChessTeam.PRIMARY)) {
+        if (board.getTeam(highlightedIndex).equals(Team.PRIMARY)) {
             int upLeft = highlightedIndex - 9;
             int upRight = highlightedIndex - 7;
             int up = highlightedIndex - 8;
@@ -263,22 +263,22 @@ public class ChessHelper {
             // Pawns can move two squares forward if they are in their starting position.
             if (highlightedIndex > 47 && highlightedIndex < 56) {
                 int upUp = highlightedIndex -  16;
-                if(board.retrieve(upUp) == null && board.retrieve(up) == null) {
+                if(board.getPiece(upUp) == null && board.getPiece(up) == null) {
                     threatRange.add(upUp);
                 }
             }
 
             // Pawns can move diagonally forward only if they are capturing a piece.
-            if (board.retrieve(upLeft) != null && upLeft % 8 != 7 &&
-                    board.getTeam(upLeft).equals(ChessTeam.SECONDARY)) {
+            if (board.getPiece(upLeft) != null && upLeft % 8 != 7 &&
+                    board.getTeam(upLeft).equals(Team.SECONDARY)) {
                 threatRange.add(upLeft);
             }
-            if (board.retrieve(upRight) != null && upRight % 8 != 0 &&
-                    board.getTeam(upRight).equals(ChessTeam.SECONDARY)) {
+            if (board.getPiece(upRight) != null && upRight % 8 != 0 &&
+                    board.getTeam(upRight).equals(Team.SECONDARY)) {
                 threatRange.add(upRight);
             }
             // Pawns can move forward only if they are not being blocked.
-            if (board.retrieve(up) == null && up > -1) {
+            if (board.getPiece(up) == null && up > -1) {
                 threatRange.add(up);
             }
             // We also need to handle the second team, which moves "downward" on the board.
@@ -290,22 +290,22 @@ public class ChessHelper {
             // Pawns can move two squares forward if they are in their starting position.
             if(highlightedIndex > 7 && highlightedIndex < 16) {
                 int downDown = highlightedIndex + 16;
-                if(board.retrieve(downDown) == null && board.retrieve(down) == null) {
+                if(board.getPiece(downDown) == null && board.getPiece(down) == null) {
                     threatRange.add(downDown);
                 }
             }
 
             // Pawns can move diagonally forward only if they are capturing a piece.
-            if (board.retrieve(downRight) !=null && downRight % 8 != 0
-                    && board.getTeam(downRight).equals(ChessTeam.PRIMARY)) {
+            if (board.getPiece(downRight) !=null && downRight % 8 != 0
+                    && board.getTeam(downRight).equals(Team.PRIMARY)) {
                 threatRange.add(downRight);
             }
-            if (board.retrieve(downLeft) != null && downRight % 8 != 7
-                    && board.getTeam(downLeft).equals(ChessTeam.PRIMARY)) {
+            if (board.getPiece(downLeft) != null && downRight % 8 != 7
+                    && board.getTeam(downLeft).equals(Team.PRIMARY)) {
                 threatRange.add(downLeft);
             }
             // Pawns can move forward only if they are not being blocked.
-            if (board.retrieve(down) == null && down < 64) {
+            if (board.getPiece(down) == null && down < 64) {
                 threatRange.add(down);
             }
         }
@@ -347,7 +347,7 @@ public class ChessHelper {
         // Add valid moves to the movement option pool.
         for (int possibleMove : possibleMoves) {
             if (possibleMove > -1 && possibleMove < 64) {
-                if (board.retrieve(possibleMove) == null) {
+                if (board.getPiece(possibleMove) == null) {
                     threatRange.add(possibleMove);
                 } else if (board.getTeam(possibleMove) != board.getTeam(highlightedIndex)) {
                     threatRange.add(possibleMove);
@@ -382,7 +382,7 @@ public class ChessHelper {
                 // Stay within the edges of the board.
                 if (leftIteration % 8 != 7 && leftIteration > -1) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(leftIteration) == null) {
+                    if (board.getPiece(leftIteration) == null) {
                         threatRange.add(leftIteration);
                         // If there's an enemy piece, we can go there but no further.
                     } else if (board.getTeam(leftIteration) != board.getTeam(highlightedIndex)) {
@@ -403,7 +403,7 @@ public class ChessHelper {
                 // Stay within the edges of the board.
                 if (rightIteration % 8 != 0 && rightIteration < 64) {
                     // If there's no piece, a rook can go there and keep going.
-                    if(board.retrieve(rightIteration) == null) {
+                    if(board.getPiece(rightIteration) == null) {
                         threatRange.add(rightIteration);
                         // If there's an enemy piece, a rook can go there but no further.
                     } else if (board.getTeam(rightIteration) != board.getTeam(highlightedIndex)) {
@@ -424,7 +424,7 @@ public class ChessHelper {
                 // Stay within the edges of the board.
                 if (upIteration > -1) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(upIteration) == null) {
+                    if (board.getPiece(upIteration) == null) {
                         threatRange.add(upIteration);
                         // If there's an enemy piece, a rook can go there but no further.
                     } else if (board.getTeam(upIteration) != board.getTeam(highlightedIndex)) {
@@ -445,7 +445,7 @@ public class ChessHelper {
                 // Stay within the edges of the board.
                 if(downIteration < 64) {
                     // If there's no piece, a rook can go there and keep going.
-                    if (board.retrieve(downIteration) == null) {
+                    if (board.getPiece(downIteration) == null) {
                         threatRange.add(downIteration);
                         // If there's an enemy piece, a rook can go there but no further.
                     } else if (board.getTeam(downIteration) != board.getTeam(highlightedIndex)) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -148,6 +148,9 @@ public class Checkers implements Experience {
     /** Return the room push key. */
     @Exclude @Override public String getRoomKey() { return roomKey; }
 
+    /** Return the room push key. */
+    @Exclude @Override public boolean getTurn() { return turn; }
+
     /** Return the unseen list. */
     @Exclude @Override public List<String> getUnseenList() { return unseenList; }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -170,6 +170,9 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
         return roomKey;
     }
 
+    /** Return the room push key. */
+    @Exclude @Override public boolean getTurn() { return turn; }
+
     /** Return the unseen list. */
     @Exclude @Override public List<String> getUnseenList() { return unseenList; }
 
@@ -219,7 +222,7 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
     }
 
     /** Toggle the turn state. */
-    @Exclude public boolean toggleTurn() {
+    @Exclude @Override public boolean toggleTurn() {
         turn = !turn;
         return turn;
     }


### PR DESCRIPTION
<h1>Rationale:</h1>

Chess and checkers games do not persist well across restarts of the app.  The board shows up as a tiny square after a restart.  This commit fixes the problem for chess.  The next will take care of the problem for checkers.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- getInt(): add a utility string to int converter.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- handleTurnChangeNew(): moved to be shared between chess and checkers.  The "New" will be removed when Checkers has the requisite changes.

new file:   app/src/main/java/com/pajato/android/gamechat/exp/Board.java

- Summary: new file to provide a board model abstraction.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java

- getCellView(): remove the chess variant of this overloaded method.
- init(): add an initialization overload for the new chess handling model which checkers will soon use.
- intiBoardModel(): the other part of the two-stage initialization: first part handle blank board setup; second part handle applying the pieces to the board.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/Experience.java

- getTurn(), toggleTurn(): new abstractions used by board handling.

new file:   app/src/main/java/com/pajato/android/gamechat/exp/Team.java

- Summary: use a common team abstracton for chess and checkers (and most likely others in the future.)

new file:   app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersBoard.java
new file:   app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersPiece.java

- Summary: new files greasing the skids to handle better checkers board persistence across restarts.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java

- getTurn(), toggleTurn(): implement the new Experience interfaces.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessBoard.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessPiece.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java

- Summary: major overhaul to provide better peristence across restarts and a solid base for future chess features.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java

- Summary: no functional changes, just renames.