### PR TITLE
Fix numerous problems with delete of protected user.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ProtectedUserChangeEvent;
+import com.pajato.android.gamechat.event.ProtectedUserDeleteEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -97,6 +98,13 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
                 break;
         }
 
+    }
+
+    /** Handle protected user deleted events by updating the adapter */
+    @Subscribe public void onProtectedUserDeleted(ProtectedUserDeleteEvent event) {
+        if (!mActive)
+            return;
+        updateAdapterList();
     }
 
     /** Handle protected user changed events by updating the adapter */

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -119,7 +119,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
     private static final String ACCOUNT_CHANGE_HANDLER = "accountChangeHandler";
 
     /** The database path to an account profile. */
-    private static final String ACCOUNT_PATH = "/accounts/%s/";
+    public static final String ACCOUNT_PATH = "/accounts/%s/";
 
     /** The logcat tag. */
     private static final String TAG = AccountManager.class.getSimpleName();
@@ -366,8 +366,9 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         }
 
         // Set watchers on any existing protected user accounts
-        for (String pUserId : mCurrentAccount.protectedUsers)
-            ProtectedUserManager.instance.setWatcher(pUserId);
+        if (mCurrentAccount != null)
+            for (String pUserId : mCurrentAccount.protectedUsers)
+                ProtectedUserManager.instance.setWatcher(pUserId);
 
         // Check for protected user data and update the account if there are any.
         if (event.account != null) {

--- a/app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserDeleteEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserDeleteEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+package com.pajato.android.gamechat.event;
+
+import com.pajato.android.gamechat.common.model.Account;
+
+/**
+ * Provides a protected user account deleted event.
+ */
+public class ProtectedUserDeleteEvent {
+
+    // Public instance variable.
+
+    /** The changed, non-null account. */
+    public Account account;
+
+    // Public constructor.
+
+    /** Build the instance with the given account; should represent a protected user! */
+    public ProtectedUserDeleteEvent(final Account account) {
+        this.account = account;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext {
     espressoVersion = '2.2.2'
     facebookSdkVersion = '4.18.0'
     firebaseAuthUIVersion = '1.0.1'
-    gmsVersion = '10.0.1'
+    gmsVersion = '10.2.0'
     hamcrestVersion = '1.3'
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'


### PR DESCRIPTION
# Rationale
Deleting a protected user was half-baked.

Upgrade gms version to pick up a fix for a Firebase bug causing protected user account display name to be null.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
* onProtectedUserDeleted(): handle deleted protected user by refreshing the adapter list

####  app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* make ACCOUNT_PATH public so it can be used in the protected user code
* onAccountChange(): check for mCurrentAccount null to prevent null pointer exception

####  app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
* deleteProtectedUser(): Delete the protected user's me group. Remove the account database. Post an event indicating the account was deleted.

####  app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserDeleteEvent.java
* New event indicating that a protected user account was deleted.

####  build.gradle
* bump gms version to 10.2.0