### PR TITLE
Support long names

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -200,15 +200,6 @@ public abstract class BaseFragment extends Fragment {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId, ordinal));
     }
 
-    /** Return -1 or the integer valud corresponding to the given string. */
-    protected int getInt(final String value) {
-        try {
-            return value != null ? Integer.parseInt(value) : -1;
-        } catch (NumberFormatException exc) {
-            return -1;
-        }
-    }
-
     /** Return a menu entry for with given title and icon resource items. */
     protected MenuEntry getNoTintEntry(final int titleId, final int iconId) {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId));

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -479,8 +479,11 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
      */
     private void startInvitationIntent(final FragmentActivity activity, final String groupName) {
         String msgText;
+        // invitation text is limited to 100 characters or less
         if (groupName != null) {
             msgText = String.format(activity.getString(R.string.InviteToGroupFormat), groupName);
+            if (msgText.length() > 100)
+                msgText = msgText.substring(0, 96) + "...";
         } else {
             msgText = activity.getString(R.string.InviteMessage);
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -479,11 +479,12 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
      */
     private void startInvitationIntent(final FragmentActivity activity, final String groupName) {
         String msgText;
-        // invitation text is limited to 100 characters or less
+        int max = AppInviteInvitation.IntentBuilder.MAX_MESSAGE_LENGTH;
+        // invitation text is limited max size
         if (groupName != null) {
             msgText = String.format(activity.getString(R.string.InviteToGroupFormat), groupName);
-            if (msgText.length() > 100)
-                msgText = msgText.substring(0, 96) + "...";
+            if (msgText.length() > max)
+                msgText = msgText.substring(0, max-4) + "...";
         } else {
             msgText = activity.getString(R.string.InviteMessage);
         }

--- a/app/src/main/res/layout/item_join_member.xml
+++ b/app/src/main/res/layout/item_join_member.xml
@@ -15,8 +15,12 @@
             android:gravity="center_vertical"
             android:orientation="vertical">
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="Fred C. Jones"/>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_join_room.xml
+++ b/app/src/main/res/layout/item_join_room.xml
@@ -18,8 +18,12 @@
             android:gravity="center_vertical"
             android:orientation="vertical">
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="Fred C. Jones"/>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_select_for_invites.xml
+++ b/app/src/main/res/layout/item_select_for_invites.xml
@@ -18,6 +18,8 @@
             android:gravity="center_vertical"
             android:orientation="vertical">
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="My Group Name"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_select_invites_room.xml
+++ b/app/src/main/res/layout/item_select_invites_room.xml
@@ -18,8 +18,12 @@
             android:gravity="center_vertical"
             android:orientation="vertical">
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="Fred C. Jones"/>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="The Jones Boys Group" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_select_user.xml
+++ b/app/src/main/res/layout/item_select_user.xml
@@ -19,8 +19,12 @@
             android:gravity="center_vertical"
             android:orientation="vertical">
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="Fred C. Jones"/>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="My Group Name"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_with_tint.xml
+++ b/app/src/main/res/layout/item_with_tint.xml
@@ -36,11 +36,15 @@ http://www.gnu.org/licenses
                 android:orientation="horizontal">
                 <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                     android:layout_weight="1"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     tools:text="General"/>
                 <TextView style="@style/ListItemCount" android:id="@+id/Count"
                     tools:text="3 new"/>
             </LinearLayout>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="TheShovel, ConnorTheWhiz, GrandPop" />
         </LinearLayout>
         <ImageView style="@style/ListItemOptionalImage" android:id="@+id/endIcon"

--- a/app/src/main/res/layout/item_without_tint.xml
+++ b/app/src/main/res/layout/item_without_tint.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -28,6 +27,8 @@
                     tools:text="3 new"/>
             </LinearLayout>
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
+                android:ellipsize="end"
+                android:maxLines="1"
                 tools:text="group, Sandy Scott, PT General"/>
         </LinearLayout>
         <ImageView style="@style/ListItemOptionalImage" android:id="@+id/endIcon"


### PR DESCRIPTION
# Rationale
Support long names by ellipsizing and enforcing a single-line max for group, room and user names in item layouts.
Also, the invitation intent has a max message size, so if the group name is included and is large, ellpisize it.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* remove getInt() which was unused

#### app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
* startInvitationIntent(): enforce max message length and ellpisize if necessary

#### app/src/main/res/layout/item_join_member.xml
* for name and text items, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_join_room.xml
* for name and text items, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_select_for_invites.xml
* for name item, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_select_invites_room.xml
* for name and text items, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_select_user.xml
* for name and text items, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_with_tint.xml
* for name and text items, enforce max 1 line and ellipsize if necessary

#### app/src/main/res/layout/item_without_tint.xml
* remove unused app namespace
* for text item, enforce max 1 line and ellipsize if necessary (name already had these characteristics)

