### PR TITLE
Fix bug when creating a private chat room with another member.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -237,6 +237,8 @@ public enum JoinManager {
             return room;
         String path = String.format(Locale.US, RoomManager.ROOMS_PATH, groupKey);
         String roomKey = FirebaseDatabase.getInstance().getReference().child(path).push().getKey();
+        member.joinMap.put(roomKey, true);
+        MemberManager.instance.updateMember(member);
 
         // Build, update and persist a room object adding the two principals as members.
         long tStamp = new Date().getTime();


### PR DESCRIPTION
# Rationale
The join room function didn't add a new private chat room to the 'other' members join map, so the other person never knew about it.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* joinMember(): add room key to 'other' member's join map and save updated member to database
