### PR TITLE
Provide a workaround for the play different game feature.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
@@ -20,6 +20,7 @@ package com.pajato.android.gamechat.exp.checkers;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.exp.Checkerboard;
 import com.pajato.android.gamechat.exp.Engine;
+import com.pajato.android.gamechat.exp.ExpHelper;
 import com.pajato.android.gamechat.exp.Experience;
 import com.pajato.android.gamechat.exp.Team;
 import com.pajato.android.gamechat.exp.TileClickHandler;
@@ -105,6 +106,7 @@ public enum CheckersEngine implements Engine {
             return;
         mModel = (Checkers) model;
         mBoard = board;
+        board.init(ExpHelper.getBaseFragment(model), handler);
         handler.setModel(model);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessEngine.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessEngine.java
@@ -114,6 +114,7 @@ public enum ChessEngine implements Engine {
             return;
         mModel = (Chess) model;
         mBoard = board;
+        board.init(ExpHelper.getBaseFragment(model), handler);
         handler.setModel(model);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -213,8 +213,8 @@ public class CheckersFragment extends BaseExperienceFragment {
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getCheckersMenu() {
         final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
+        //menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
+        //menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_checkers));
         return menu;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -209,8 +209,8 @@ public class ChessFragment extends BaseExperienceFragment {
      */
     private List<MenuEntry> getChessMenu() {
         final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
+        //menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
+        //menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_chess));
         return menu;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -333,8 +333,8 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getTTTMenu() {
         final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
-        menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
+        //menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
+        //menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
         menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_tictactoe_red));
         return menu;
     }


### PR DESCRIPTION
<h1>Rationale:</h1>

The task list identifies a scenario where using the FAM to play a different game does not work and has an ugly manifestation (tiny grid).  This commit provides a workaround to avoid the problem by not offering the FAM items to play a different game.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessEngine.java

- init(): initialize the checkerboard to remedy an oversight.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

- getMenu(): do not add the different game choices.