### PR TITLE
Rework create protected user; allow selection of groups to be applied to account.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License along with Gam
 http://www.gnu.org/licenses
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.pajato.android.gamechat">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -27,6 +28,7 @@ http://www.gnu.org/licenses
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        tools:replace="android:supportsRtl"
         android:theme="@style/AppTheme"
         android:name="android.support.multidex.MultiDexApplication">
         <provider

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -92,14 +92,16 @@ public abstract class BaseChatFragment extends BaseFragment {
             mAdView.resume();
         if (type != null)
             switch (type) {
-                case joinRoom:
                 case chatGroupList:
                 case chatRoomList:
+                case createProtectedUser:
+                case groupsForProtectedUser:
+                case joinRoom:
+                case messageList:
+                case protectedUsers:
                 case selectChatGroupsRooms:
                 case selectExpGroupsRooms:
-                case protectedUsers:
-                case messageList:   // Update the state of the list adapter.
-                    updateAdapterList();
+                    updateAdapterList();   // Update the state of the list adapter.
                     break;
                 default:            // Ignore all other fragments.
                     break;
@@ -141,6 +143,8 @@ public abstract class BaseChatFragment extends BaseFragment {
         if (dispatcher.type == null)
             return false;
         switch (type) {
+            case createProtectedUser: // TODO: this may need to be changed!!!
+            case groupsForProtectedUser:
             case chatGroupList: // A group list does not need an item.
                 return true;
             case messageList:   // The messages in a room require both the group and room keys.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -143,7 +143,7 @@ public abstract class BaseChatFragment extends BaseFragment {
         if (dispatcher.type == null)
             return false;
         switch (type) {
-            case createProtectedUser: // TODO: this may need to be changed!!!
+            case createProtectedUser:
             case groupsForProtectedUser:
             case chatGroupList: // A group list does not need an item.
                 return true;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -89,7 +89,7 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
             case R.id.manageProtectedUsers:
                 // Ensure that the current user is not a protected user. Then, start the process of
                 // adding a protected user.
-                if (AccountManager.instance.getCurrentAccount().chaperone != null) {
+                if (AccountManager.instance.isRestricted()) {
                     String protectedWarning = "Protected Users cannot make other Protected Users.";
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.v4.view.ViewPager;
+import android.view.View;
 import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
@@ -89,7 +90,7 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
                 DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
                 break;
             case R.string.ManageRestrictedUserTitle:
-                if (AccountManager.instance.getCurrentAccount().chaperone != null) {
+                if (AccountManager.instance.isRestricted()) {
                     String protectedWarning = "Protected Users cannot make other Protected Users.";
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
@@ -143,6 +144,7 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         super.onResume();
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this, CHAT_GROUP_FAM_KEY);
+        FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 
     /** Initialize ... */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -153,7 +153,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         final List<MenuEntry> menu = new ArrayList<>();
         menu.add(getTintEntry(R.string.JoinRoomsMenuTitle, R.drawable.ic_casino_black_24dp));
         menu.add(getTintEntry(R.string.CreateRoomMenuTitle, R.drawable.ic_casino_black_24dp));
-        if(AccountManager.instance.getCurrentAccount().chaperone == null) {
+        if(!AccountManager.instance.isRestricted()) {
             menu.add(getTintEntry(R.string.CreateGroupMenuTitle, R.drawable.ic_group_add_black_24dp));
         }
         menu.add(getTintEntry(R.string.InviteFriendFromChat, R.drawable.ic_share_black_24dp));

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -34,8 +34,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.R.id.create_button_finish;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -1,0 +1,364 @@
+package com.pajato.android.gamechat.chat.fragment;
+
+import android.support.annotation.NonNull;
+import android.support.design.widget.TextInputEditText;
+import android.support.design.widget.TextInputLayout;
+import android.support.v4.app.FragmentActivity;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import com.firebase.ui.auth.ui.TaskFailureLogger;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.EmailAuthProvider;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.ProviderQueryResult;
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.common.DispatchManager;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.credentials.Credentials;
+import com.pajato.android.gamechat.database.ProtectedUserManager;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static android.content.Context.INPUT_METHOD_SERVICE;
+import static com.pajato.android.gamechat.R.id.create_button_finish;
+import static com.pajato.android.gamechat.R.id.emailEditText;
+import static com.pajato.android.gamechat.R.id.email_next_button;
+import static com.pajato.android.gamechat.common.FragmentType.groupsForProtectedUser;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+
+/**
+ * Provide a fragment to create protected users.
+ */
+
+public class CreateProtectedUsersFragment extends BaseChatFragment {
+
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = CreateProtectedUsersFragment.class.getSimpleName();
+
+    /** Firebase required password to be at least 6 characters */
+    private static final int PASSWORD_MIN = 6;
+
+    /** After testing email address, remember if it is new or already in the auth database */
+    private boolean accountIsKnown = false;
+
+    // Private inner classes
+
+    /** Handle email address provider check */
+    private class EmailOnSuccessListener implements OnSuccessListener<ProviderQueryResult> {
+        @Override
+        public void onSuccess(ProviderQueryResult result) {
+            RelativeLayout layout =
+                    (RelativeLayout) getActivity().
+                            findViewById(R.id.email_next_btn_layout);
+            layout.setVisibility(View.GONE);
+            List<String> providers = result.getProviders();
+            if (providers == null || providers.isEmpty()) {
+                // TODO: Get name and photo URI from SmartLock ??
+                Log.i(TAG, "New user e-mail specified");
+                showPasswordLayout(true, false);
+                showNameLayout(true, true);
+            } else if (EmailAuthProvider.PROVIDER_ID.equalsIgnoreCase(providers.get(0))) {
+                Log.i(TAG, "Existing email user");
+                accountIsKnown = true;
+                showPasswordLayout(true, true);
+                showNameLayout(false, false);
+            } else {
+                // TODO: what to do here?
+                Log.i(TAG, "Existing user (some other provider, not e-mail)...");
+                accountIsKnown = true;
+                showPasswordLayout(true, true);
+                showNameLayout(false, false);
+            }
+        }
+    }
+
+    /** Handle changes in the email text field */
+    private class EmailTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            setEmailError(false);
+            RelativeLayout layout =
+                    (RelativeLayout) getActivity().findViewById(R.id.email_next_btn_layout);
+            layout.setVisibility(View.VISIBLE);
+            enableFinishButton(false);
+            showPasswordLayout(false, false);
+            showNameLayout(false, false);
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {}
+    }
+
+    /** Handle changes in the password text field */
+    private class PasswordTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            if (isValidPasswordFormat(getPassword())) {
+                setPasswordError(false);
+                enableFinishButton(true);
+                Button pwdBtn = (Button) getActivity().findViewById(R.id.pwd_next_button);
+                pwdBtn.setEnabled(true);
+            } else
+                setPasswordError(true);
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {}
+    }
+
+    // Public instance methods.
+
+    /** Handle click events. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        FragmentActivity activity = getActivity();
+        if (event == null || event.view == null)
+            return;
+        switch (event.view.getId()) {
+            case create_button_finish:
+            case R.id.pwd_next_button:
+                TextInputLayout mailLayout =
+                        (TextInputLayout) activity.findViewById(R.id.email_layout);
+                TextInputLayout passwordLayout =
+                        (TextInputLayout) activity.findViewById(R.id.password_layout);
+                if (mailLayout.getError() == null && passwordLayout.getError() == null) {
+                    ProtectedUserManager.instance.setEMailCredentials(getEmailAddress(),
+                            getUserName(), getPassword(), accountIsKnown);
+                    // Dismiss the Keyboard and return to the previous fragment.
+                    dismissKeyboard();
+                    DispatchManager.instance.chainFragment(getActivity(), groupsForProtectedUser, null);
+                }
+                break;
+            case email_next_button:
+                final TextInputEditText editText =
+                        (TextInputEditText) activity.findViewById(emailEditText);
+                if (isValidEmailFormat(editText.getText().toString())) {
+                    setEmailError(false);
+                    checkEmailAccountExists(editText.getText().toString());
+                } else
+                    setEmailError(true);
+
+                break;
+            default:
+                processClickEvent(event.view, "createProtectedUsers");
+                break;
+        }
+    }
+
+    /** When this fragment is no longer visible, make sure to close the keyboard, if necessary */
+    @Override public void onPause() {
+        super.onPause();
+        dismissKeyboard();
+    }
+
+    /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu.
+        super.onResume();
+        FabManager.chat.setVisibility(this, View.INVISIBLE);
+
+        final TextInputEditText emailText =
+                (TextInputEditText) getActivity().findViewById(R.id.emailEditText);
+        final TextInputEditText nameText =
+                (TextInputEditText) getActivity().findViewById(R.id.nameEditText);
+        final TextInputEditText passwordText =
+                (TextInputEditText) getActivity().findViewById(R.id.passwordEditText);
+        Button pwdBtn = (Button) getActivity().findViewById(R.id.pwd_next_button);
+
+        Credentials credentials = ProtectedUserManager.instance.getEMailCredentials();
+        if (credentials != null) {
+            emailText.setText(credentials.email);
+            RelativeLayout layout =
+                    (RelativeLayout) getActivity().findViewById(R.id.email_next_btn_layout);
+            layout.setVisibility(View.GONE);
+            if (!credentials.accountIsKnown) {
+                nameText.setText(credentials.name);
+                showNameLayout(true, false);
+            }
+            showPasswordLayout(true, false);
+            passwordText.setText(credentials.secret);
+            enableFinishButton(true);
+            pwdBtn.setEnabled(true);
+        } else {
+            emailText.setText("");
+            setEmailError(false);
+            passwordText.setText("");
+            setPasswordError(false);
+            nameText.setText("");
+            showNameLayout(false, false);
+            showPasswordLayout(false, false);
+
+            RelativeLayout layout =
+                    (RelativeLayout) getActivity().findViewById(R.id.email_next_btn_layout);
+            layout.setVisibility(View.VISIBLE);
+            enableFinishButton(false);
+            pwdBtn.setEnabled(true);
+        }
+    }
+
+    /** Set up toolbar and FAM */
+    @Override public void onStart() {
+        super.onStart();
+        int titleResId = R.string.CreateRestrictedUserTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
+
+        final TextInputEditText editText =
+                (TextInputEditText) getActivity().findViewById(emailEditText);
+        editText.addTextChangedListener(new EmailTextWatcher());
+
+        final TextInputEditText passwordText =
+                (TextInputEditText) getActivity().findViewById(R.id.passwordEditText);
+        passwordText.addTextChangedListener(new PasswordTextWatcher());
+    }
+
+    // Private instance methods.
+
+    /** Determine if the email specified already exists */
+    private void checkEmailAccountExists(@NonNull final String email) {
+        if (!TextUtils.isEmpty(email)) {
+            accountIsKnown = false;
+            FirebaseAuth.getInstance().fetchProvidersForEmail(email)
+                    .addOnFailureListener(
+                            new TaskFailureLogger(TAG, "Error fetching providers for email"))
+                    .addOnCompleteListener(
+                            getActivity(),
+                            new OnCompleteListener<ProviderQueryResult>() {
+                                @Override
+                                public void onComplete(@NonNull Task<ProviderQueryResult> task) {
+                                    // we need the onSuccess results to continue so this is a no op
+                                }
+                            })
+                    .addOnSuccessListener(getActivity(), new EmailOnSuccessListener());
+        }
+    }
+
+    /** Dismiss the keyboard if necessary */
+    private void dismissKeyboard() {
+        // Dismiss the Keyboard and return to the previous fragment.
+        InputMethodManager manager;
+        manager = (InputMethodManager) getActivity().getSystemService(INPUT_METHOD_SERVICE);
+        if (manager.isAcceptingText() && getActivity().getCurrentFocus() != null)
+            manager.hideSoftInputFromWindow(getActivity().getCurrentFocus().getWindowToken(), 0);
+    }
+
+    /** Enable (or disable) the 'finish' button in the toolbar */
+    private void enableFinishButton(final boolean enable) {
+        final TextView finishButton =
+                (TextView) getActivity().findViewById(R.id.create_button_finish);
+        finishButton.setEnabled(enable);
+    }
+
+    /** Retrieve the email address from the edit text field */
+    private String getEmailAddress() {
+        final TextInputEditText emailText =
+                (TextInputEditText) getActivity().findViewById(R.id.emailEditText);
+        return emailText.getText().toString();
+    }
+
+    /** Retrieve the user name from the edit text field */
+    private String getUserName() {
+        final TextInputEditText nameText =
+                (TextInputEditText) getActivity().findViewById(R.id.nameEditText);
+        return nameText.getText().toString();
+    }
+
+    /** Retrieve the password from the edit text field */
+    private String getPassword() {
+        final TextInputEditText passwordText =
+                (TextInputEditText) getActivity().findViewById(R.id.passwordEditText);
+        return passwordText.getText().toString();
+    }
+
+    /** Determine if value is a valid email format. */
+    private static boolean isValidEmailFormat(String email) {
+        return !TextUtils.isEmpty(email) &&
+                android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches();
+    }
+
+    /** Determine if value is a valid password as per Firebase spec */
+    private static boolean isValidPasswordFormat(String password) {
+        return (password.length() >= PASSWORD_MIN);
+    }
+
+    /** Set or clear error for email layout */
+    private void setEmailError(boolean hasError) {
+        TextInputLayout emailLayout =
+                (TextInputLayout) getActivity().findViewById(R.id.email_layout);
+        if (hasError) {
+            emailLayout.setErrorEnabled(true);
+            emailLayout.setError(getActivity().getString(R.string.EmailInvalidMessage));
+        }
+        else {
+            emailLayout.setError(null);
+            emailLayout.setErrorEnabled(false);
+        }
+    }
+
+    /** Set or clear error for password layout */
+    private void setPasswordError(boolean hasError) {
+        TextInputLayout passwordLayout =
+                (TextInputLayout) getActivity().findViewById(R.id.password_layout);
+        if (hasError) {
+            passwordLayout.setErrorEnabled(true);
+            passwordLayout.setError(getActivity().getString(R.string.PasswordInvalidMessage));
+        }
+        else {
+            passwordLayout.setError(null);
+            passwordLayout.setErrorEnabled(true);
+        }
+    }
+
+    /**
+     * Set visibility of password layout. If it is not visible, also clear the error (if any). If
+     * requested, set focus to EditText field.
+     */
+    private void showPasswordLayout(boolean visible, boolean setFocus) {
+        TextInputLayout layout = (TextInputLayout) getActivity().findViewById(R.id.password_layout);
+        layout.setVisibility(visible ? View.VISIBLE : View.GONE);
+        if (!visible) {
+            layout.setError(null);
+            layout.setErrorEnabled(false);
+        }
+        else if (setFocus) {
+            EditText editText = (EditText) getActivity().findViewById(R.id.passwordEditText);
+            editText.requestFocus();
+        }
+    }
+
+    /** Set visibility of name layout. If requested, set focus to EditText field. */
+    private void showNameLayout(boolean visible, boolean setFocus) {
+        TextInputLayout layout = (TextInputLayout) getActivity().findViewById(R.id.name_layout);
+        layout.setVisibility(visible ? View.VISIBLE : View.GONE);
+        if (setFocus) {
+            EditText editText = (EditText) getActivity().findViewById(R.id.nameEditText);
+            editText.requestFocus();
+        }
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 import com.google.firebase.auth.FirebaseAuth;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
@@ -35,8 +36,8 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
+import static com.pajato.android.gamechat.common.FragmentType.createProtectedUser;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 
@@ -60,7 +61,6 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
      */
     @Subscribe
     public void onClick(final ClickEvent event) {
-        logEvent(String.format(Locale.US, "onClick (join rooms) event: {%s}.", event));
         if (event == null || event.view == null)
             return;
 
@@ -85,19 +85,16 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateRestrictedUserTitle:
-                if (AccountManager.instance.getCurrentAccount().chaperone != null) {
+                if (AccountManager.instance.isRestricted()) {
                     String protectedWarning = "Protected Users cannot make other Protected Users.";
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                AccountManager.instance.mChaperone = AccountManager.instance.getCurrentAccountId();
-                FirebaseAuth.getInstance().signOut();
-                AccountManager.instance.signIn(getContext());
+                DispatchManager.instance.chainFragment(getActivity(), createProtectedUser, null);
                 break;
             default:
                 break;
         }
-
     }
 
     /** Handle protected user deleted events by updating the adapter */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat.fragment;
 import android.view.View;
 import android.widget.Toast;
 
-import com.google.firebase.auth.FirebaseAuth;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.common.DispatchManager;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
@@ -1,6 +1,5 @@
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.support.design.widget.TextInputEditText;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.View;
@@ -22,9 +21,6 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.pajato.android.gamechat.R.id.emailEditText;
-import static com.pajato.android.gamechat.R.id.nameEditText;
-import static com.pajato.android.gamechat.R.id.passwordEditText;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
@@ -1,0 +1,123 @@
+package com.pajato.android.gamechat.chat.fragment;
+
+import android.support.design.widget.TextInputEditText;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.BaseChatFragment;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.common.adapter.ListAdapter;
+import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.credentials.Credentials;
+import com.pajato.android.gamechat.database.AccountManager;
+import com.pajato.android.gamechat.database.ProtectedUserManager;
+import com.pajato.android.gamechat.event.ClickEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.pajato.android.gamechat.R.id.emailEditText;
+import static com.pajato.android.gamechat.R.id.nameEditText;
+import static com.pajato.android.gamechat.R.id.passwordEditText;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+
+/**
+ * Provide a fragment to select groups for creation of protected users.
+ */
+
+public class SelectGroupsFragment extends BaseChatFragment {
+
+    // Private class constants.
+
+    /**
+     * The logcat tag.
+     */
+    private static final String TAG = SelectGroupsFragment.class.getSimpleName();
+
+    /**
+     * Handle click events.
+     */
+    @Subscribe
+    public void onClick(final ClickEvent event) {
+        if (event == null || event.view == null)
+            return;
+        switch (event.view.getId()) {
+            case R.id.button_finish:
+                Credentials credentials = ProtectedUserManager.instance.getEMailCredentials();
+                if (credentials == null) {
+                    Log.e(TAG, "Cannot create protected user: e-mail credentials are not set");
+                    break;
+                }
+                ProtectedUserManager.instance.removeEMailCredentials();
+                AccountManager.instance.createProtectedAccount(credentials.email, credentials.name,
+                        credentials.secret, getGroupSelections());
+                break;
+            case R.id.selector:
+                // Checkbox click, just update the adapter
+                Object payload = event.view.getTag();
+                if (payload == null || !(payload instanceof ListItem))
+                    break;
+                ListItem clickedItem = (ListItem) payload;
+                clickedItem.selected = !clickedItem.selected;
+                RecyclerView recyclerView = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+                ListAdapter adapter = (ListAdapter) recyclerView.getAdapter();
+                List <ListItem> adapterList = adapter.getItems();
+                boolean hasSelection = false;
+                for (ListItem adapterItem : adapterList) {
+                    if (adapterItem.selected)
+                        hasSelection = true;
+                    if (adapterItem.groupKey.equals(clickedItem.groupKey))
+                        adapterItem.selected = clickedItem.selected;
+                }
+                adapter.notifyDataSetChanged();
+                TextView finish = (TextView) getActivity().findViewById(R.id.button_finish);
+                finish.setEnabled(hasSelection);
+                break;
+            default:
+                processClickEvent(event.view, "createProtectedUsers");
+                break;
+        }
+    }
+
+    /** Deal with the fragment's lifecycle by managing the progress bar and the FAB. */
+    @Override public void onResume() {
+        // Set the titles in the toolbar to the app title only; ensure that the FAB is visible, the
+        // FAM is not and the FAM is set to the home chat menu.
+        super.onResume();
+        FabManager.chat.setVisibility(this, View.INVISIBLE);
+
+        TextView finish = (TextView) getActivity().findViewById(R.id.button_finish);
+        finish.setEnabled(false);
+    }
+
+    /** Set up toolbar and FAM */
+    @Override public void onStart() {
+        // Establish the create type, the list type, setup the toolbar and turn off the access
+        // control.
+        super.onStart();
+        int titleResId = R.string.AccessToGroupsTitle;
+        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
+    }
+
+    // Private instance methods.
+
+    /** Get a list of group push keys that have been selected */
+    private List<String> getGroupSelections() {
+        List<String> selections = new ArrayList<>();
+        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        ListAdapter adapter = (ListAdapter) view.getAdapter();
+        // Loop through adapter and find selected groups
+        for (ListItem item : adapter.getItems())
+            if (item.selected)
+                selections.add(item.groupKey);
+        return selections;
+    }
+
+}

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -282,6 +282,8 @@ public abstract class BaseFragment extends Fragment {
                 return ExperienceManager.instance.getListItemData(item);
             case joinRoom:      // Get the candidate list of rooms and members.
                 return JoinManager.instance.getListItemData(item);
+            case groupsForProtectedUser:
+                return GroupManager.instance.getGroupsOnlyListItemData();
             case protectedUsers:
                 return ProtectedUserManager.instance.getProtectedUsersItemData();
             case messageList:   // Get the data to be shown in a room.
@@ -293,6 +295,7 @@ public abstract class BaseFragment extends Fragment {
                 return PlayModeManager.instance.getListItemData(type);
             case selectUser:    // Get all the visible Users for the current account holder.
                 return PlayModeManager.instance.getListItemData(type);
+            case createProtectedUser: // no list data for create protected user
             default:
                 return null;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -103,8 +103,7 @@ public enum DispatchManager {
 
     /** Return null or the fragment associated with the given type, creating it as needed. */
     public BaseFragment getFragment(final FragmentType type) {
-        // Ensure that a fragment is created and cached.  If so, return it, otherwise attempt to do
-        // so.
+        // If a fragment is created, return it.  Otherwise create, cache and return it.
         BaseFragment result = mFragmentMap.get(type);
         return result == null ? getFragmentInstance(type) : result;
     }
@@ -186,8 +185,10 @@ public enum DispatchManager {
                 return new Dispatcher(type);
 
             case chatRoomList:
+            case createProtectedUser:
             case createRoom:
             case experienceList:
+            case groupsForProtectedUser:
             case joinRoom:
             case protectedUsers:
             case messageList:

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -26,10 +26,12 @@ import com.pajato.android.gamechat.chat.fragment.ChatShowOfflineFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ChatShowSignedOutFragment;
 import com.pajato.android.gamechat.chat.fragment.CreateGroupFragment;
+import com.pajato.android.gamechat.chat.fragment.CreateProtectedUsersFragment;
 import com.pajato.android.gamechat.chat.fragment.CreateRoomFragment;
 import com.pajato.android.gamechat.chat.fragment.JoinRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ManageProtectedUsersFragment;
 import com.pajato.android.gamechat.chat.fragment.SelectChatInviteFragment;
+import com.pajato.android.gamechat.chat.fragment.SelectGroupsFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowMessagesFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoJoinedRoomsFragment;
 import com.pajato.android.gamechat.chat.fragment.ShowNoMessagesFragment;
@@ -54,6 +56,7 @@ import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.chatChain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.chatMain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.createGroupTT;
+import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.createPUserTT;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.createRoomTT;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.expChain;
 import static com.pajato.android.gamechat.common.ToolbarManager.ToolbarType.expMain;
@@ -81,6 +84,8 @@ public enum FragmentType {
     chess (ChessFragment.class, expChain, R.layout.exp_checkers, chessET),
     createChatGroup(CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
     createExpGroup(CreateGroupFragment.class, createGroupTT, R.layout.chat_create),
+    createProtectedUser(CreateProtectedUsersFragment.class, createPUserTT,
+            R.layout.chat_create_protected_user),
     createRoom (CreateRoomFragment.class, createRoomTT, R.layout.chat_create),
     expEnvelope (ExpEnvelopeFragment.class, none, R.layout.exp_envelope),
     expGroupList (ExpShowGroupsFragment.class, expMain, R.layout.exp_list),
@@ -88,13 +93,17 @@ public enum FragmentType {
     expRoomList (ExpShowRoomsFragment.class, expChain, R.layout.exp_none),
     expSignedOut (ExpShowSignedOutFragment.class, expMain, R.layout.exp_signed_out),
     experienceList (ShowExperiencesFragment.class, expChain, R.layout.exp_list),
+    groupsForProtectedUser(SelectGroupsFragment.class, createPUserTT, R.layout.chat_select_groups),
     joinRoom (JoinRoomsFragment.class, joinRoomTT, R.layout.chat_join_rooms),
-    protectedUsers (ManageProtectedUsersFragment.class, managePUsersTT, R.layout.chat_protected_users),
+    protectedUsers (ManageProtectedUsersFragment.class, managePUsersTT,
+            R.layout.chat_protected_users),
     messageList (ShowMessagesFragment.class, chatChain, R.layout.chat_messages),
     noExperiences (ShowNoExperiencesFragment.class, expMain, R.layout.exp_none),
     noMessages (ShowNoMessagesFragment.class, chatMain, R.layout.chat_no_messages),
-    selectChatGroupsRooms(SelectChatInviteFragment.class, selectInviteTT, R.layout.select_for_invite),
-    selectExpGroupsRooms (SelectExpInviteFragment.class, selectInviteTT, R.layout.select_for_invite),
+    selectChatGroupsRooms(SelectChatInviteFragment.class,
+            selectInviteTT, R.layout.select_for_invite),
+    selectExpGroupsRooms (SelectExpInviteFragment.class,
+            selectInviteTT, R.layout.select_for_invite),
     selectRoom (SelectRoomFragment.class, expMoveTT, R.layout.exp_select_user),
     selectUser (SelectUserFragment.class, expMoveTT, R.layout.exp_select_user),
     showNoJoinedRooms (ShowNoJoinedRoomsFragment.class, chatChain, R.layout.chat_no_joined_rooms),
@@ -157,10 +166,12 @@ public enum FragmentType {
             case chatRoomList:
             case chatSignedOut:
             case createChatGroup:
+            case createProtectedUser:
             case createRoom:
+            case groupsForProtectedUser:
             case joinRoom:
-            case protectedUsers:
             case messageList:
+            case protectedUsers:
             case selectChatGroupsRooms:
             case showNoJoinedRooms:
                 return chat;

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -90,6 +90,7 @@ public enum ToolbarManager {
         chatChain (R.drawable.ic_more_vert_white_24dp, R.drawable.ic_arrow_back_white_24dp),
         chatMain (R.drawable.ic_more_vert_white_24dp),
         createGroupTT (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),
+        createPUserTT (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),
         createRoomTT (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),
         expMain (R.drawable.ic_more_vert_white_24dp),
         expMoveTT (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -115,6 +115,8 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             case expRoom:
             case chatRoom:
                 return new ItemListViewHolder(getView(parent, R.layout.item_with_tint));
+            case groupList:
+                return new ItemListViewHolder(getView(parent, R.layout.item_select_for_invites));
             case message:
                 return new ItemListViewHolder(getView(parent, R.layout.item_message));
             case selectableMember:
@@ -154,6 +156,7 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 case expGroup:
                 case expList:
                 case expRoom:
+                case groupList:
                 case message:
                 case inviteRoom:
                 case inviteCommonRoom:
@@ -279,6 +282,9 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 break;
             case expList:
                 holder.icon.setImageResource(item.iconResId);
+                break;
+            case groupList:
+                holder.icon.setImageResource(R.drawable.vd_group_black_24px);
                 break;
             case protectedUserList:
                 if (item.iconUrl == null) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -83,6 +83,7 @@ public class ListItem {
         expList ("Exp list item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
         expRoom ("Exp room item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
         experience ("Experience item with group/room/exp keys {%s/%s/%s} and mode {%s}."),
+        groupList ("Group item with name {%s} and key: {%s}"),
         message ("Message item with name {%s}, key: {%s}, count: {%s} and text {%s}."),
         protectedUserList("Protected user list item with name {%s}, e-mail {%s}, iconUrl {%s} and key {%s}."),
         resourceHeader ("Resource header with id: {%d}."),
@@ -262,6 +263,8 @@ public class ListItem {
                 return String.format(Locale.US, type.format, name, groupKey, roomKey, count, text);
             case experience:
                 return String.format(Locale.US, type.format, groupKey, roomKey, key, playMode);
+            case groupList:
+                return String.format(Locale.US, type.format, name, groupKey);
             case message:
                 return String.format(Locale.US, type.format, name, key, count, text);
             case inviteCommonRoom:

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -98,9 +98,6 @@ import java.util.Map;
     /** The account nickname.  Defaults to the first name. */
     public String nickname;
 
-    /** The account provider id, a string like "google.com". */
-    public String providerId;
-
     /** The account type. */
     public String type;
 
@@ -121,7 +118,6 @@ import java.util.Map;
         chaperone = account.chaperone;
         id = account.id;
         modTime = 0;
-        providerId = account.providerId;
         type = account.type;
         url = account.url;
     }
@@ -161,7 +157,6 @@ import java.util.Map;
         result.put("id", id);
         result.put("modTime", modTime);
         result.put("nickname", nickname);
-        result.put("providerId", providerId);
         result.put("type", type);
         result.put("url", url);
 

--- a/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
@@ -29,21 +29,42 @@ public class Credentials {
     /** The User email address. */
     public String email;
 
+    /** The email has been tested and is a known account (so we cannot set a username) */
+    public boolean accountIsKnown;
+
     /** The identity provider. */
     public String provider;
 
     /** The identity secret. */
     public String secret;
 
+    /** The identity token. */
+    public String token;
+
+    /** The user name */
+    public String name;
+
     // Public constructors.
 
     /** Build an empty constructor. */
     public Credentials() {}
 
-    /** Build an instance given a full set of properties. */
-    public Credentials(final String email, final String provider, final String secret) {
+
+    /** Build an instance for e-mail login (used when creating a protected user) */
+    public Credentials(final String email, final String name, final String password, final boolean isKnown) {
+        this.email = email;
+        this.name = name;
+        this.secret = password;
+        this.accountIsKnown = isKnown;
+    }
+
+    /** Build an instance */
+    public Credentials(final String provider, final String email, final String secret,
+                       final String token) {
         this.email = email;
         this.provider = provider;
         this.secret = secret;
+        this.token = token;
     }
+
 }

--- a/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
@@ -69,6 +69,9 @@ public enum CredentialsManager {
     /** The application preferences store. */
     private SharedPreferences mPrefs;
 
+    /** The logcat tag. */
+    private static final String TAG = CredentialsManager.class.getSimpleName();
+
     // Public instance methods
 
     /** Return credentials for a given User account by email address, null on no account. */
@@ -80,7 +83,7 @@ public enum CredentialsManager {
         // Case on the provider type.
         switch (credentials.provider) {
             case GoogleAuthProvider.PROVIDER_ID:
-                return GoogleAuthProvider.getCredential(credentials.secret, null);
+                return GoogleAuthProvider.getCredential(credentials.token, null);
             case FacebookAuthProvider.PROVIDER_ID:
                 return FacebookAuthProvider.getCredential(credentials.secret);
             case TwitterAuthProvider.PROVIDER_ID:
@@ -100,9 +103,10 @@ public enum CredentialsManager {
     }
 
     /** Save a set of credentials to the preferences store. */
-    public void saveCredentials(final String provider, final String email, final String secret) {
+    public void saveCredentials(final String provider, final String email, final String secret,
+                                final String token) {
         // Cache the credentials.
-        Credentials credentials = new Credentials(provider, email, secret);
+        Credentials credentials = new Credentials(provider, email, secret, token);
         mCredentialsMap.put(email, credentials);
 
         // Persist the credentials.

--- a/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
@@ -69,9 +69,6 @@ public enum CredentialsManager {
     /** The application preferences store. */
     private SharedPreferences mPrefs;
 
-    /** The logcat tag. */
-    private static final String TAG = CredentialsManager.class.getSimpleName();
-
     // Public instance methods
 
     /** Return credentials for a given User account by email address, null on no account. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -34,8 +34,6 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
-import com.google.firebase.auth.FirebaseAuthWeakPasswordException;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
 import com.google.firebase.database.DataSnapshot;
@@ -163,6 +161,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
 
     // Public instance methods
 
+    /** Create a new protected user account and automatically join it to the specified groups */
     public void createProtectedAccount(@NonNull final String email, @NonNull final String name,
                                        @NonNull final String password,
                                        @NonNull List<String> groupKeys) {
@@ -216,6 +215,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
                     @Override
                     public void onFailure(@NonNull Exception e) {
                         Log.e(TAG, "Failed to create user " + email + "(" + name + ")");
+                        // TODO: deal with these errors
 //                        if (e instanceof FirebaseAuthWeakPasswordException) {
 //                            // Password too weak
 //                            mPasswordInput.setError(getResources().getQuantityString(

--- a/app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java
@@ -58,7 +58,7 @@ public enum DatabaseRegistrar {
     public void registerHandler(final DatabaseEventHandler handler) {
         // Determine if there is already a listener registered with this name.
         String name = handler.name;
-        Log.d(TAG, String.format(Locale.US, "Registering handler with name {%s].", name));
+        Log.d(TAG, String.format(Locale.US, "Registering handler with name {%s}.", name));
         DatabaseReference database = FirebaseDatabase.getInstance().getReference(handler.path);
         DatabaseEventHandler registeredHandler = mHandlerMap.get(name);
         removeEventListener(database, registeredHandler);

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -47,6 +47,7 @@ import static com.pajato.android.gamechat.common.adapter.ListItem.DateHeaderType
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.chatGroup;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.chatRoom;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.date;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.groupList;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.resourceHeader;
 
 /**
@@ -149,6 +150,16 @@ public enum GroupManager {
                 return getMeGroupItemList();
             default:
                 return getGroupsItemList();
+        }
+    }
+
+    /** Get a list of groups without any headers */
+    public List<ListItem> getGroupsOnlyListItemData() {
+        switch (groupMap.size()) {
+            case 0:
+                return new ArrayList<>();
+            default:
+                return getGroupsOnlyItemList();
         }
     }
 
@@ -276,6 +287,15 @@ public enum GroupManager {
                             addItem(result, room);
                     }
             }
+        }
+        return result;
+    }
+
+    /** Return a list of chat groups only - no rooms and no headers */
+    private List<ListItem> getGroupsOnlyItemList() {
+        List<ListItem> result = new ArrayList<>();
+        for (Group group : groupMap.values()) {
+            result.add(new ListItem(groupList, group.key, group.name));
         }
         return result;
     }

--- a/app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
@@ -21,7 +21,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.util.SparseArray;
 
-import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
@@ -30,7 +29,6 @@ import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.credentials.Credentials;
 import com.pajato.android.gamechat.database.handler.ProtectedUserChangeHandler;
-import com.pajato.android.gamechat.event.AccountChangeEvent;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ProtectedUserChangeEvent;

--- a/app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
@@ -16,18 +16,23 @@
  */
 package com.pajato.android.gamechat.database;
 
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.util.SparseArray;
 
+import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.firebase.database.FirebaseDatabase;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.credentials.Credentials;
 import com.pajato.android.gamechat.database.handler.ProtectedUserChangeHandler;
+import com.pajato.android.gamechat.event.AccountChangeEvent;
 import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ProtectedUserChangeEvent;
 import com.pajato.android.gamechat.event.ProtectedUserDeleteEvent;
 
@@ -48,6 +53,9 @@ public enum ProtectedUserManager {
 
     /** The logcat tag. */
     private static final String TAG = ProtectedUserManager.class.getSimpleName();
+
+    /** Credentials saved while creating a new protected user */
+    private Credentials emailCredentials;
 
     /** The protected users associated with the current account */
     private List<Account> mProtectedUserAccounts = new ArrayList<>();
@@ -143,6 +151,21 @@ public enum ProtectedUserManager {
         }
     }
 
+    /** Set in-flight credentials (saved while creating a new protected user */
+    public void setEMailCredentials(final String email, final String name, final String password,
+                                    final boolean isKnown) {
+        emailCredentials = new Credentials(email, name, password, isKnown);
+    }
+
+    /** Get in-flight credentials (saved while creating a new protected user */
+    public Credentials getEMailCredentials() {
+        return emailCredentials;
+    }
+
+    public void removeEMailCredentials() {
+        emailCredentials = null;
+    }
+
     /** Return a list of protected user account items */
     public List<ListItem> getProtectedUsersItemData() {
         List<ListItem> result = new ArrayList<>();
@@ -158,13 +181,20 @@ public enum ProtectedUserManager {
         return result;
     }
 
+    /** Handle a account change event by clearing the protected user accounts list. */
+    @Subscribe public void onAuthenticationChange(@NonNull final AuthenticationChangeEvent event) {
+        mProtectedUserAccounts.clear();
+    }
+
+
     /** Keep track of protected users that belong to the current account */
     @Subscribe public void onProtectedUserChange(ProtectedUserChangeEvent event) {
         if (!AccountManager.instance.getCurrentAccount().protectedUsers.contains(event.account.id))
             return;
         if (!event.account.chaperone.equals(AccountManager.instance.getCurrentAccountId()))
             return;
-        mProtectedUserAccounts.add(event.account);
+        if (!mProtectedUserAccounts.contains(event.account))
+            mProtectedUserAccounts.add(event.account);
     }
 
     /**

--- a/app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java
@@ -63,7 +63,8 @@ public class AccountChangeHandler extends DatabaseEventHandler implements ValueE
             // The account does not exist.  Create it now, ensuring there really is a User.
             FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
             account = user != null ? getAccount(user) : null;
-            if (account != null) AccountManager.instance.createAccount(account);
+            if (account != null)
+                AccountManager.instance.createAccount(account);
         }
     }
 
@@ -83,7 +84,6 @@ public class AccountChangeHandler extends DatabaseEventHandler implements ValueE
         account.email = user.getEmail();
         account.displayName = user.getDisplayName();
         account.url = getPhotoUrl(user);
-        account.providerId = user.getProviderId();
         account.type = AccountManager.AccountType.standard.name();
         account.createTime = tStamp;
         return account;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
@@ -140,17 +140,19 @@ public enum NotificationManager {
         }
 
         @Override public void onDismissed(final Snackbar snackbar, final int event) {
-            if (mType == chat)
-                FabManager.chat.show(mFragment);
-            else
-                FabManager.game.show(mFragment);
+            if (mType == chat) {
+                FabManager.chat.setVisibility(mFragment, View.VISIBLE);
+            }
+            else {
+                FabManager.game.setVisibility(mFragment, View.VISIBLE);
+             }
         }
 
         @Override public void onShown(final android.support.design.widget.Snackbar snackbar) {
             if (mType == chat)
-                FabManager.chat.hide(mFragment);
+                FabManager.chat.setVisibility(mFragment, View.INVISIBLE);
             else
-                FabManager.game.hide(mFragment);
+                FabManager.game.setVisibility(mFragment, View.INVISIBLE);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
@@ -97,7 +97,7 @@ public class SelectUserFragment extends BaseExperienceFragment {
                 DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms, null);
                 break;
             case R.string.ManageRestrictedUserTitle:
-                if (AccountManager.instance.getCurrentAccount().chaperone != null) {
+                if (AccountManager.instance.isRestricted()) {
                     String protectedWarning = "Protected Users cannot manage other Protected Users.";
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;

--- a/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -44,7 +44,6 @@ import com.pajato.android.gamechat.R;
 
 import java.util.Arrays;
 
-import static android.R.attr.format;
 import static android.view.animation.AnimationUtils.loadAnimation;
 
 /**

--- a/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -29,6 +29,7 @@ import android.os.Parcelable;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,11 +38,13 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.firebase.ui.auth.AuthUI;
+import com.firebase.ui.auth.IdpResponse;
 import com.pajato.android.gamechat.BuildConfig;
 import com.pajato.android.gamechat.R;
 
 import java.util.Arrays;
 
+import static android.R.attr.format;
 import static android.view.animation.AnimationUtils.loadAnimation;
 
 /**
@@ -67,11 +70,25 @@ public class IntroActivity extends AppCompatActivity {
 
     // Protected instance methods.
 
-    /** Handle the sign in activity result, if any. */
+    /**
+     * Handle the sign in activity result. If the sign-in completes with an "OK status, this
+     * intro activity is done so return to the main activity with an "OK" status.
+     */
     @Override protected void onActivityResult(final int requestCode, final int resultCode,
                                               final Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
         if (requestCode == RC_SIGN_IN && resultCode == RESULT_OK) {
+            IdpResponse response = IdpResponse.fromResultIntent(intent);
+            if (response != null) {
+                String format = "Sign in completed with provider type: %s, e-mail: %s, secret: %s, token: %s";
+                Log.i(IntroActivity.class.getSimpleName(),
+                        String.format(format, response.getProviderType(), response.getEmail(),
+                                response.getIdpSecret(), response.getIdpToken()));
+                intent.putExtra("provider", response.getProviderType());
+                intent.putExtra("email", response.getEmail());
+                intent.putExtra("secret", response.getIdpSecret());
+                intent.putExtra("token", response.getIdpToken());
+            }
             // Pass the intent obtained from the sign in activity through to the calling intent.
             setResult(RESULT_OK, intent);
             finish();

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -245,6 +245,10 @@ public class MainActivity extends BaseActivity
             String key = ACCOUNT_AVAILABLE_KEY;
             editor.putBoolean(key, intent.getBooleanExtra(key, uid != null));
             editor.apply();
+            // Look for the login result information and cache it
+            CredentialsManager.instance.saveCredentials(intent.getStringExtra("provider"),
+                    intent.getStringExtra("email"), intent.getStringExtra("secret"),
+                    intent.getStringExtra("token"));
         } else if (requestCode == RC_INVITE) {
             // Hand off to invitation manager as quickly as possible
             Log.d(TAG, "onActivityResult: requestCode=RC_INVITE, resultCode=" + resultCode);
@@ -286,11 +290,6 @@ public class MainActivity extends BaseActivity
         processIntroPage();
         setContentView(R.layout.activity_main);
         init();
-    }
-
-    @Override public void onStop() {
-        super.onStop();
-        AccountManager.instance.stopListeningForAuthChanges();
     }
 
     // Private instance methods.

--- a/app/src/main/res/drawable/ic_smartphone_black_24px.xml
+++ b/app/src/main/res/drawable/ic_smartphone_black_24px.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:pathData="M17,1.01L7,1c-1.1,0 -2,0.9 -2,2v18c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3c0,-1.1 -0.9,-1.99 -2,-1.99zM17,19H7V5h10v14z"
-        android:fillColor="#000000"/>
-</vector>

--- a/app/src/main/res/layout/chat_create_protected_user.xml
+++ b/app/src/main/res/layout/chat_create_protected_user.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@drawable/border">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/create_button_finish"
+            android:layout_gravity="center|end"
+            android:onClick="onClick"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:enabled="false"
+            android:text="@string/ButtonFinish" />
+    </android.support.v7.widget.Toolbar>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/email_layout"
+        style="@style/CreateUserTextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingExtra="4sp"
+        android:paddingTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textSize="12sp"
+        app:errorTextAppearance="@style/CreateUserErrorText">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/emailEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/EmailHint"
+            android:inputType="textEmailAddress" />
+
+        <RelativeLayout
+            android:id="@+id/email_next_btn_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <Button
+                style="@style/IntroTheme.Button"
+                android:id="@+id/email_next_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onClick"
+                android:layout_alignParentEnd="true"
+                android:text="@string/ButtonNext"/>
+        </RelativeLayout>
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/name_layout"
+        android:visibility="invisible"
+        style="@style/CreateUserTextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingExtra="4sp"
+        android:paddingTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textSize="12sp"
+        app:errorTextAppearance="@style/CreateUserErrorText">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/nameEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif"
+            android:hint="@string/UserNameHint"
+            android:inputType="textPersonName"
+            android:textCursorDrawable="@null"
+            android:textSize="16sp" />
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/password_layout"
+        android:visibility="invisible"
+        style="@style/CreateUserTextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingExtra="4sp"
+        android:paddingTop="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:textSize="12sp"
+        app:passwordToggleEnabled="true"
+        app:errorTextAppearance="@style/CreateUserErrorText">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/passwordEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif"
+            android:hint="@string/PasswordHint"
+            android:textSize="16sp"
+            android:inputType="textPassword" />
+
+        <RelativeLayout
+            android:id="@+id/pwd_next_btn_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <Button
+                style="@style/IntroTheme.Button"
+                android:id="@+id/pwd_next_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onClick"
+                android:layout_alignParentEnd="true"
+                android:text="@string/ButtonNext"/>
+        </RelativeLayout>
+
+    </android.support.design.widget.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/chat_select_groups.xml
+++ b/app/src/main/res/layout/chat_select_groups.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2016 Pajato Technologies LLC.
+This file is part of Pajato GameChat.
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<!-- The main content for the fragment to select groups and rooms for invitations -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/emptyListContent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@drawable/border">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/button_finish"
+            android:layout_gravity="center|end"
+            android:enabled="false"
+            android:onClick="onClick"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:text="@string/ButtonFinish"/>
+
+    </android.support.v7.widget.Toolbar>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/ItemList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_protected_user.xml
+++ b/app/src/main/res/layout/item_protected_user.xml
@@ -31,11 +31,12 @@ http://www.gnu.org/licenses
             android:layout_marginStart="16dp"
             android:layout_gravity="center_vertical"
             android:orientation="vertical">
-            <TextView style="@style/ListItemTitle" android:id="@+id/Name"
-                android:layout_weight="1"
+            <TextView
+                android:id="@+id/Name"
+                style="@style/ListItemTitle"
                 android:ellipsize="end"
                 android:maxLines="1"
-                tools:text="Kid One"/>
+                tools:text="Kid One" />
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 tools:text="kid@pajato.com" />
         </LinearLayout>

--- a/app/src/main/res/layout/item_with_tint.xml
+++ b/app/src/main/res/layout/item_with_tint.xml
@@ -14,7 +14,8 @@ Public License for more details.
 
 You should have received a copy of the GNU General Public License along with GameChat.  If not, see
 http://www.gnu.org/licenses
---><LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="AccessToGroupsTitle">Allow Access to Groups</string>
     <string name="CreateRestrictedUserTitle">Create Protected User</string>
     <string name="DeleteGroupMessage">Delete Group</string>
     <string name="DeleteRoomMessage">Delete Room</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="AddGroupDesc">Create Group menu button</string>
     <string name="AddMembers">Invite members</string>
+    <string name="AllowGroupTitle">Allow Access To Groups</string>
+    <string name="ButtonNext">NEXT</string>
+    <string name="ButtonFinish">FINISH</string>
     <string name="ClearSelectionsMenuTitle">Clear Selections</string>
     <string name="CreateGroupMenuTitle">Create Group</string>
     <string name="CreateGroupNameHint">Type group name</string>Title">
@@ -15,6 +18,8 @@
     <string name="DeleteExperienceTitle">Delete Experience?</string>
     <string name="DeleteUserTitle">Delete Protected User</string>
     <string name="DeleteUserConfirm">Are you sure you want to delete %s?</string>
+    <string name="EmailHint">Email (does not need to be a real email account)</string>
+    <string name="EmailInvalidMessage">Invalid email format</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>
     <string name="Group">Group</string>
     <string name="GroupsToolbarTitle">Groups with Messages</string>
@@ -43,6 +48,8 @@
     <string name="NoProtectedUsersHeaderText">You have no protected users.</string>
     <string name="NoRoomsMessageText">You must join a room to see messages.</string>
     <string name="NoSelectableItemsHeaderText">No Groups or Rooms to select</string>
+    <string name="PasswordHint">Password</string>
+    <string name="PasswordInvalidMessage">Password must be more than 6 characters</string>
     <string name="PickForInvitationTitle">Room Invitations</string>
     <string name="PromoteUserConfirm">Do you want to promote %s to be a standard (non-protected) user?</string>
     <string name="PromoteUserTitle">Promote Protected User</string>
@@ -59,6 +66,7 @@
     <string name="TakePictureDesc">Take a camera picture image button.</string>
     <string name="TakeVideo">Inserting a video from your camera</string>
     <string name="TakeVideoDesc">Take a video image button.</string>
+    <string name="UserNameHint">First and Last Name</string>
     <string name="WelcomeMessageText">Welcome to your private messages. Use this space to take notes and stash files. Enjoy!</string>
     <string name="editMessageHint">Type a message</string>
 </resources>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -1,7 +1,6 @@
 <resources>
     <string name="AddGroupDesc">Create Group menu button</string>
     <string name="AddMembers">Invite members</string>
-    <string name="AllowGroupTitle">Allow Access To Groups</string>
     <string name="ButtonNext">NEXT</string>
     <string name="ButtonFinish">FINISH</string>
     <string name="ClearSelectionsMenuTitle">Clear Selections</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -199,4 +199,15 @@ http://www.gnu.org/licenses
         <item name="android:background">@color/colorPrimary</item>
     </style>
 
+    <style name="CreateUserTextInputLayout">
+        <item name="android:paddingTop">8dp</item>
+        <item name="android:textColorHint">@color/colorPrimaryDark</item>
+    </style>
+
+    <style name="CreateUserErrorText">
+        <item name="android:textColor">@color/errorColor</item>
+        <item name="android:paddingTop">4dp</item>
+        <item name="android:paddingBottom">4dp</item>
+    </style>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     // App dependencies
     espressoVersion = '2.2.2'
     facebookSdkVersion = '4.18.0'
-    firebaseAuthUIVersion = '1.0.1'
+    firebaseAuthUIVersion = '1.1.1'
     gmsVersion = '10.2.0'
     hamcrestVersion = '1.3'
     junitVersion = '4.12'


### PR DESCRIPTION
# Rationale
It wasn't useful to create a protected user without also specifying the groups to which the protected user would be a member. Also, we want to limit a protected user to e-mail login only.

## Files Changed

#### app/src/main/AndroidManifest.xml
* The changes here were to fix complaints from Android Studio.

#### app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
* onResume(): add cases for createProtectedUser and groupsForProtectedUser
* onDispatch(): add cases for createProtectedUser and groupsForProtectedUser

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* onClick(): use the "isRestricted" access method for shorter, cleaner code rather than directly touching the 'chaperone' member variable

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
* onClick(): use the "isRestricted" access method for shorter, cleaner code rather than directly touching the 'chaperone' member variable
* onResume(): set FAB visible (fix bug)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
* getRoomMenu(): use the "isRestricted" access method for shorter, cleaner code rather than directly touching the 'chaperone' member variable

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
* onClick(): remove (erroneous) log message
* onClick(): Use the "isRestricted" access method for shorter, cleaner code rather than directly touching the 'chaperone' member variable. Also, dispatch to new protected user fragment rather than launching Firebase signin intent.

#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* getList(): provide cases for groupsForProtectedUser and createProtectedUser (which has no list)

#### app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
* getDispatcher(): provide cases for groupsForProtectedUser and createProtectedUser

#### app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
* Add createProtectedUser and groupsForProtectedUser fragment types.
* getKind(): provide cases for groupsForProtectedUser and createProtectedUser

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* Add createPUserTT toolbar type

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* onCreateViewHolder(): add case for groupList
* onBindViewHolder(): add case for groupList
* setIcon(): add case for groupList to show default group black icon

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
* add new groupList ItemType
* getDescription(): add case for groupList

#### app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
* Remove providerId from account as it was never used

#### app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
* Extend class to be useful for holding credentials for protected user (during creation of new protected user)
* Add token member variable as this is required for Google login

#### app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java
* getAuthCredential(): use credentials token (rather than secret) to create Google provider credentials (fix bug)
* saveCredentials(): add token to saved credentials

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* refactor mChaperone -> currentChaperone
* Add protectedUserName member variable
* Add list of group keys for creation of protected user account
* createProtectedAccount(): create a new protected user account and automatically join it to the specified groups
* createAccount(): Apply saved display name (if necessary) to account in the case of a protected user. Add specified group keys to new account and set a watcher on each of the groups.
* init(): add joined message to saved message list
* onAccountChange(): deal with the case where the account changes without first receiving a sign-out (null account); this happens frequently when a protected user is logged in (even though the sign-out was called first)
* onAuthStateChanged(): Change the database listener to be specific to the user account (not a general listener). This code expected to only deal with one user at a time, but it is possible to receive a signin without receiving a signout when changing users (or logging in the new protected user). By having separate listeners registered, it is possible to manage the listeners specific to the account.
* onGroupProfileChange(): handle the peculiarities of a protected user account with pre-joined groups
* onRoomProfileChange(): for protected users only, make sure to complete the join of rooms within the pre-joined groups
* stopListeningForAuthChanges(): this was added recently and seemed to interfere with the delivery of events

#### app/src/main/java/com/pajato/android/gamechat/database/DatabaseRegistrar.java
* registerHandler(): fix typo in log statement

#### app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
* getGroupsOnlyListItemData(): get a list of groups without any headers (for use when creating a protected user)
* getGroupsOnlyItemList(): get a list of groups without any headers (for use when creating a protected user)

#### app/src/main/java/com/pajato/android/gamechat/database/ProtectedUserManager.java
* add emailCredentials member variable used to save credentials while creating a protected user
* add new methods to get, set and clear email credentials
* listen for authentication changes and at that time, clear the protected user accounts list (prevents duplicating the list every time user logs in)
* onProtectedUserChange(): don't re-add a protected user that is already on the list

#### app/src/main/java/com/pajato/android/gamechat/database/handler/AccountChangeHandler.java
* remove reference to Account providerId which was removed

#### app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
* onDismissed(): use visibility to show FAB (fixes broken behavior)
* onShown(): use visibility to hide FAB (fixes broken behavior)

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
* onClick(): use the "isRestricted" access method for shorter, cleaner code rather than directly touching the 'chaperone' member variable

#### app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
* onActivityResult(): save credentials in intent extras

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* onActivityResult(): fetch credentials from intent extras and save in CredentialsManager
* onStop(): remove call to account manager which seemed to interfere with event receipt

#### app/src/main/res/layout/chat_create_protected_user.xml
* New layout for protected user creation

#### app/src/main/res/layout/chat_select_groups.xml
* New layout for protected user creation and selection of groups

#### app/src/main/res/layout/item_protected_user.xml
* Nits

#### app/src/main/res/layout/item_with_tint.xml
* Nit

#### app/src/main/res/values/strings.xml
* new string

#### app/src/main/res/values/strings_chat.xml
* new strings

#### app/src/main/res/values/styles.xml
* new styles for create user fragment

#### build.gradle
* Update Firebase to 1.1.1 to get some bug fixes

## New Files

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
* Provide a fragment to create protected user and obtain e-mail address, user name and password for protected account

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
* Provide a fragment to select groups for creation of protected users and then to actually create and log in the new user.

## Deleted Files

#### app/src/main/res/drawable/ic_smartphone_black_24px.xml
* Not used
