### PR TITLE
Fix a bug in checkers where the no moves case was not checked.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
@@ -29,6 +29,8 @@ import com.pajato.android.gamechat.exp.model.Checkers;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.pajato.android.gamechat.exp.State.primary_wins;
+import static com.pajato.android.gamechat.exp.State.secondary_wins;
 import static com.pajato.android.gamechat.exp.Team.PRIMARY;
 import static com.pajato.android.gamechat.exp.Team.SECONDARY;
 import static com.pajato.android.gamechat.exp.checkers.CheckersPiece.PieceType.KING;
@@ -81,8 +83,8 @@ public enum CheckersEngine implements Engine {
             // If there are no more jumps, change turns. If there is at least one jump left, don't.
             List<Integer> possibleJumps = getPossibleMoves(position);
             for (int possiblePosition: possibleJumps) {
-                if(possiblePosition != -1 && (possiblePosition > 9 + position
-                        || (possiblePosition < position - 9))) {
+                if (possiblePosition != -1 && ((possiblePosition > 9 + position) ||
+                                               (possiblePosition < position - 9))) {
                     finishedJumping = false;
                 }
             }
@@ -94,9 +96,24 @@ public enum CheckersEngine implements Engine {
             mModel.board.clearSelectedPiece();
             mModel.board.getPossibleMoves().clear();
             mModel.toggleTurn();
+            if (noMovesAvailable())
+                mModel.setStateType(mModel.turn ? secondary_wins : primary_wins);
         }
         checkFinished();
         ExperienceManager.instance.updateExperience(mModel);
+    }
+
+    /** Test for the case where a play has been made and the other team has no moves. */
+    private boolean noMovesAvailable() {
+        // Establish the team being scrutinized and check for at least one move from all the players
+        // on that team.
+        Team team = mModel.turn ? PRIMARY : SECONDARY;
+        for (String key : mModel.board.getKeySet()) {
+            int position = mModel.board.getPosition(key);
+            if (mModel.board.getTeam(position) == team && getPossibleMoves(position).size() != 0)
+                return false;
+        }
+        return true;
     }
 
     /** Establish the experience model (chess) and board for this handler. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -54,8 +54,6 @@ import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static com.pajato.android.gamechat.R.color.colorAccent;
 import static com.pajato.android.gamechat.R.color.colorPrimary;
 import static com.pajato.android.gamechat.R.id.player_1_icon;
-import static com.pajato.android.gamechat.common.FragmentType.chess;
-import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -53,8 +53,6 @@ import java.util.Locale;
 import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static com.pajato.android.gamechat.R.color.colorAccent;
 import static com.pajato.android.gamechat.R.color.colorPrimary;
-import static com.pajato.android.gamechat.common.FragmentType.checkers;
-import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -60,8 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.FragmentType.checkers;
-import static com.pajato.android.gamechat.common.FragmentType.chess;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TTTBoard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TTTBoard.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.exp.model;
 
-import com.pajato.android.gamechat.exp.Board;
-
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
<h1>Rationale:</h1>

The Rules for checkers specifies that if no moves are available then the player whose turn it is loses.  This commit adds code to detect that condition.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java

- handleMove(): detect teh no moves available case.
- noMovesAvailable(): new method to detect this case.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/TTTBoard.java

- Summary: silence AS unused import complaints.