### PR TITLE
Some usability fixes.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -313,7 +313,10 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
             case selectableMember:
                 // For a message, ensure that both the holder and the item have an icon value,
                 // and load the icon or default if not found at the specified URL.
-                if (holder.icon == null || item.iconUrl == null) return;
+                if (holder.icon == null || item.iconUrl == null) {
+                    holder.icon.setImageResource(R.drawable.ic_account_circle_black_24dp);
+                    return;
+                }
                 Uri imageUri = Uri.parse(item.iconUrl);
                 if (imageUri != null) {
                     // There is an image to load.  Use Glide to do the heavy lifting.

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -140,7 +140,7 @@ import java.util.Map;
         if (nickname != null)
             return nickname;
         if (displayName != null)
-            return getPrefix(displayName, " ");
+            return displayName;
         return getPrefix(email, "@");
     }
 

--- a/app/src/main/res/layout/item_contact.xml
+++ b/app/src/main/res/layout/item_contact.xml
@@ -40,8 +40,7 @@ http://www.gnu.org/licenses
         android:orientation="vertical">
         <TextView
             android:id="@+id/contactName"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/ListItemTitle"
             android:textAppearance="?android:attr/textAppearanceListItem"
             android:ellipsize="end"
             android:maxLines="1"

--- a/app/src/main/res/layout/item_protected_user.xml
+++ b/app/src/main/res/layout/item_protected_user.xml
@@ -22,7 +22,6 @@ http://www.gnu.org/licenses
     android:orientation="vertical">
     <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <ImageView style="@style/ListItemImage" android:id="@+id/ListItemIcon"
-            android:tint="@color/colorPrimaryDark"
             android:contentDescription="@string/ListItemIconDesc" />
         <LinearLayout
             android:layout_width="0dp"


### PR DESCRIPTION
# Rationale
When an icon for a user is not available (as is often the case for protected users), use the black "account" icon. Use the full name (not the first token before a space) when a nickname is not available. In the group members display, use the bold blue text (same format as other screens).

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* setIcon(): for selectableMember, message and selectUser, provide a default user icon

#### app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
* getNickName(): don't use the first token (because 'Bobby Sue Jones' might not appreciate being called 'Bobby' and because "Bob Smith" and "Bob Brown" would both appear as "Bob"). Just use the full name if a nickname isn't available.

#### app/src/main/res/layout/item_contact.xml
* Apply ListItemTitle to the user name text view.

#### app/src/main/res/layout/item_protected_user.xml
* Remove the icon tint to insure a black icon is used instead.