### PR TITLE
Provide a feature to indicate if a member is in a room.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,9 @@ http://www.gnu.org/licenses
         <activity
             android:name=".intro.IntroActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
+        <service android:name=".main.MainService"
+            android:exported="false">
+        </service>
         <service
             android:name=".main.GameChatMessagingService"
             android:exported="false">

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -31,6 +31,7 @@ import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.common.model.JoinState;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.MemberManager;
@@ -113,12 +114,12 @@ public class CreateGroupFragment extends BaseCreateFragment {
 
         // Create and persist a member object to the database joined to the default room.
         Account member = new Account(account);
-        member.joinMap.put(roomKey, true);
+        member.joinMap.put(roomKey, new JoinState());
         member.groupKey = groupKey;
         MemberManager.instance.createMember(member);
 
         // Update and persist the User account with the new joined list entry.
-        account.joinMap.put(groupKey, true);
+        account.joinMap.put(groupKey, new JoinState());
         AccountManager.instance.updateAccount(account);
 
         // Post a welcome message to the default room from the owner.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.common.model.JoinState;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.MemberManager;
@@ -102,7 +103,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
         GroupManager.instance.updateGroupProfile(mGroup);
 
         // Update and persist the member adding the new room to it's join list.
-        mMember.joinMap.put(mRoom.key, true);
+        mMember.joinMap.put(mRoom.key, new JoinState());
         MemberManager.instance.updateMember(mMember);
 
         // Post a welcome message to the new room from the owner.

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -52,6 +52,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.hel
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.search;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.chat;
 
 /**
  * Display the chat associated with the room selected by the current logged in User.
@@ -125,11 +126,18 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         }
     }
 
+    /** Deal with the fragment's lifecycle by marking the join inactive. */
+    @Override public void onPause() {
+        super.onPause();
+        clearJoinState(mItem.groupKey, mItem.roomKey, chat);
+    }
+
     /** Deal with the fragment's lifecycle by managing the FAB. */
     @Override public void onResume() {
         super.onResume();        // Turn off the FAB and force a recycler view update.
         initEditText(mLayout);
         FabManager.chat.setVisibility(this, View.GONE);
+        setJoinState(mItem.groupKey, mItem.roomKey, chat);
     }
 
     /** Setup the toolbar. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -43,6 +43,7 @@ import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.common.model.GroupInviteData;
+import com.pajato.android.gamechat.common.model.JoinState;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.DBUtils;
 import com.pajato.android.gamechat.database.GroupManager;
@@ -122,7 +123,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
 
         // The account holder has been invited to join the given group.  Do so by adding the group
         // key to the account join list and create a copy of the account as a member of the group.
-        account.joinMap.put(groupKey, true);
+        account.joinMap.put(groupKey, new JoinState());
         AccountManager.instance.updateAccount(account);
         Account member = new Account(account);
         member.groupKey = groupKey;
@@ -270,11 +271,11 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
 
             // Create and persist a member object to the database and join to the specified rooms
             Account member = new Account(currAccount);
-            member.joinMap.put(data.commonRoomKey, true);
+            member.joinMap.put(data.commonRoomKey, new JoinState());
             if (data.rooms == null)
                 data.rooms = new ArrayList<>();
             for (String roomKey : data.rooms) {
-                member.joinMap.put(roomKey, true);
+                member.joinMap.put(roomKey, new JoinState());
             }
             member.groupKey = changedGroup.key;
             MemberManager.instance.createMember(member);
@@ -338,7 +339,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
                     // Update the member within the group to include this room
                     Account member = MemberManager.instance.getMember(data.groupKey);
                     if (member != null) {
-                        member.joinMap.put(event.key, true);
+                        member.joinMap.put(event.key, new JoinState());
                         String path = String.format(Locale.US, MemberManager.MEMBERS_PATH, data.groupKey, member.id);
                         DBUtils.updateChildren(path, member.toMap());
                     }
@@ -508,7 +509,7 @@ public enum InvitationManager implements ResultCallback<AppInviteInvitationResul
                 mInviteMap.get(key).addedToCommRoomMemberList = true;
                 mInviteMap.get(key).addedToGroupMemberList = true;
             } else {
-                account.joinMap.put(key, true);
+                account.joinMap.put(key, new JoinState());
                 accountChanged = true;
                 mInviteMap.get(key).addedToAccountJoinList = true;
             }

--- a/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
@@ -25,6 +25,7 @@ import android.view.View;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.common.model.JoinState;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.database.MemberManager;
@@ -104,7 +105,7 @@ public enum PlayModeManager {
             // No users exist so create a header stating this.
             result.add(new ListItem(resourceHeader, R.string.NoUsersFound));
         else
-            for (Map.Entry<String, Boolean> entry : account.joinMap.entrySet()) {
+            for (Map.Entry<String, JoinState> entry : account.joinMap.entrySet()) {
                 String groupKey = entry.getKey();
                 for (Account member : MemberManager.instance.getMemberList(groupKey))
                     if (!member.id.equals(account.id)) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
@@ -86,11 +86,15 @@ import java.util.Map;
     public /*final*/ String id;
 
     /**
-     * In an account context, this is a map of group push keys for which the User is a member.
-     * In a member context, this is a map of room push keys the User has joined. The value is
-     * always 'true' for now (this is a placeholder to help avoid use of lists in Firebase.
+     * In an account context, this is a map of group push keys for which the User is a member.  In a
+     * member context, this is a map of room push keys the User has joined. The value is one of:
+     * "inactive", "chat", "experience", "active" where "inactive" means the app is not in the
+     * foreground or the User is not in the room at all; the other three choices indicated that the
+     * app is running in the foreground, "chat" indicates presence in the chat room, "exp" indicates
+     * presence with a game, and "active" indicates presence in both the chat room and with an
+     * experience.
      */
-    public final Map<String, Boolean> joinMap = new HashMap<>();
+    public final Map<String, JoinState> joinMap = new HashMap<>();
 
     /** The modification timestamp. */
     public long modTime;

--- a/app/src/main/java/com/pajato/android/gamechat/common/model/JoinState.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/model/JoinState.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.common.model;
+
+import com.google.firebase.database.Exclude;
+
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.active;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.chat;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.exp;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.inactive;
+
+/**
+ * Defines a Firebase suitable POJO for maintaining the join state for a given User.
+ *
+ * @author Paul Michael Reilly on 2/26/17
+ */
+public class JoinState {
+
+    /** Provide a set of values to define the User join state for a given room or group. */
+    public enum JoinType {
+        active,                     // The User is "joined" to both the group and room.
+        chat,                       // The User is "joined" only to the group and room chat.
+        exp,                        // The User is "joined" only to the group and room experience.
+        inactive                   // The User is not joined to either the group or room.
+    }
+
+    // Private instance variables.
+
+    /** The current join type. */
+    private JoinType mType = inactive;
+
+    // Public instance methods.
+
+    /** Provide a getter for Firebase. */
+    @SuppressWarnings("unused")
+    public String getJoinState() {
+        return mType.name();
+    }
+
+    /** Return the current state a a JoinType. */
+    @Exclude public JoinType getType() {
+        return mType != null ? mType : inactive;
+    }
+
+    /** Provide a setter for Firebase. */
+    @SuppressWarnings("unused")
+    public void setJoinState(final String value) {
+        mType = getType(value);
+    }
+
+    /** Set the join type to the given value. */
+    @Exclude public void setType(final JoinType value) {
+        mType = value;
+    }
+
+    // Private instance methods.
+
+    /** Return 'inactive' or the state type corresponding to the given value. */
+    private JoinType getType(String value) {
+        if (value == null || value.isEmpty())
+            return inactive;
+
+        switch (value) {
+            case "active":
+                return active;
+            case "chat":
+                return chat;
+            case "exp":
+                return exp;
+            default:
+                return inactive;
+        }
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -45,6 +45,7 @@ import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.common.model.JoinState;
 import com.pajato.android.gamechat.database.handler.AccountChangeHandler;
 import com.pajato.android.gamechat.event.AccountChangeEvent;
 import com.pajato.android.gamechat.event.AppEventManager;
@@ -253,7 +254,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
             }
             account.type = AccountType.restricted.name();
             for (String key : protectedUserGroupKeys)
-                account.joinMap.put(key, true);
+                account.joinMap.put(key, new JoinState());
         } else
             // This User has a standard account.
             account.type = AccountType.standard.name();
@@ -290,7 +291,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
 
         // Update the member entry in the default group.
         Account member = new Account(account);
-        member.joinMap.put(roomKey, true);
+        member.joinMap.put(roomKey, new JoinState());
         member.groupKey = groupKey;
         path = String.format(Locale.US, MemberManager.MEMBERS_PATH, groupKey, account.id);
         DBUtils.updateChildren(path, member.toMap());
@@ -576,7 +577,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
                 event.group.roomList = new ArrayList<>();
             for (String roomKey : event.group.roomList) {
                 Room room = RoomManager.instance.getRoomProfile(roomKey);
-                member.joinMap.put(roomKey, true);
+                member.joinMap.put(roomKey, new JoinState());
                 if (room != null) {
                     List<String> roomMembers = room.getMemberIdList();
                     roomMembers.add(getCurrentAccountId());

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -28,6 +28,7 @@ import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
+import com.pajato.android.gamechat.common.model.JoinState;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -95,7 +96,7 @@ public enum JoinManager {
         // update and persist the member join list.
         if (room == null || member.joinMap.keySet().contains(room.key))
             return;
-        member.joinMap.put(room.key, true);
+        member.joinMap.put(room.key, new JoinState());
         String path = String.format(Locale.US, MemberManager.MEMBERS_PATH, item.groupKey, member.id);
         DBUtils.updateChildren(path, member.toMap());
 
@@ -237,7 +238,7 @@ public enum JoinManager {
             return room;
         String path = String.format(Locale.US, RoomManager.ROOMS_PATH, groupKey);
         String roomKey = FirebaseDatabase.getInstance().getReference().child(path).push().getKey();
-        member.joinMap.put(roomKey, true);
+        member.joinMap.put(roomKey, new JoinState());
         MemberManager.instance.updateMember(member);
 
         // Build, update and persist a room object adding the two principals as members.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -58,6 +58,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.cha
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.exp;
 
 /**
  * A simple Checkers game for use in GameChat.
@@ -111,6 +112,12 @@ public class CheckersFragment extends BaseExperienceFragment {
         processMenuItemEvent(event);
     }
 
+    /** Deal with the fragment's lifecycle by marking the join inactive. */
+    @Override public void onPause() {
+        super.onPause();
+        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+    }
+
     /** Handle taking the foreground by updating the UI based on the current experience. */
     @Override public void onResume() {
         // Determine if there is an experience ready to be enjoyed.  If not, hide the layout and
@@ -119,6 +126,7 @@ public class CheckersFragment extends BaseExperienceFragment {
         super.onResume();
         if (mExperience == null)
             return;
+        setJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
         CheckersEngine.instance.init(mExperience, mBoard, mTileClickHandler);
         ExpHelper.updateUiFromExperience(mExperience, mBoard);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -57,6 +57,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.cha
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.exp;
 
 /**
  * A simple Chess game for use in GameChat.
@@ -103,6 +104,12 @@ public class ChessFragment extends BaseExperienceFragment {
         processMenuItemEvent(event);
     }
 
+    /** Deal with the fragment's lifecycle by marking the join inactive. */
+    @Override public void onPause() {
+        super.onPause();
+        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+    }
+
     /**
      * Handle taking the foreground by updating the UI based on the current experience.
      */
@@ -113,6 +120,7 @@ public class ChessFragment extends BaseExperienceFragment {
         super.onResume();
         if (mExperience == null)
             return;
+        setJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
         ChessEngine.instance.init(mExperience, mBoard, mTileClickHandler);
         ExpHelper.updateUiFromExperience(mExperience, mBoard);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -65,6 +65,7 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.cha
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.common.model.JoinState.JoinType.exp;
 import static com.pajato.android.gamechat.exp.ExpType.tttET;
 import static com.pajato.android.gamechat.exp.model.TTTBoard.BEG_COL;
 import static com.pajato.android.gamechat.exp.model.TTTBoard.BOT_ROW;
@@ -162,12 +163,19 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         resume();
     }
 
+    /** Deal with the fragment's lifecycle by marking the join inactive. */
+    @Override public void onPause() {
+        super.onPause();
+        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+    }
+
     /** Handle taking the foreground by updating the UI based on the current experience. */
     @Override public void onResume() {
         // Determine if there is an experience ready to be enjoyed.  If not, hide the layout and
         // present a spinner.  When an experience is posted by the app event manager, the game can
         // be shown
         super.onResume();
+        setJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
         resume();
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainService.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.main;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+import java.util.Locale;
+
+/**
+ * Provide a service to monitor the message and experience changes in rooms on behalf of registered
+ * Users. Changes to rooms in which a current User is "in" (see below) are ignored.  All other
+ * changes (for each User registered wih the service) generate or modify a status bar notification.
+ * GameChat app settings will allow configuration of notification filtering for each User.  There
+ * will only be a single app icon providing notification details per the Android notifications spec
+ * fount at: https://developer.android.com/guide/topics/ui/notifiers/notifications.html
+ *
+ * The service will buffer all database accesses on behalf of registered...
+ *
+ * A User is currently "in" a room iff GameChat is running in the foreground.  This implies that
+ * the service has been informed of the current User (via an account change event).
+ *
+ * @author Paul Michael Reilly on 2/25/17
+ */
+public class MainService extends Service {
+
+    // Private class constants.
+
+    /** The logcat tag. */
+    private static final String TAG = "MainService";
+
+    // Public instance methods.
+
+    /** Implement the Service interface by providing a null operation (no binding is done). */
+    @Override public IBinder onBind(final Intent intent) {
+        logEvent("bind", "not used");
+        return null;
+    }
+
+    /** Implement the Service interface by initializing the service on startup. */
+    @Override public void onCreate() {
+        // TODO: figure this out
+        logEvent("create", "Creating the main service");
+    }
+
+    /** Implement the Service interface by handing the death of the service. */
+    @Override public void onDestroy() {
+        logEvent("create", "Creating the main service");
+        // TODO: figure this out
+    }
+
+    /** Implement the Service interface to handle a command. */
+    @Override public int onStartCommand(final Intent intent, final int flags, final int startId) {
+        String name = intent.getStringExtra("nameKey");
+        String message = name != null
+            ? String.format(Locale.US, "executing command {%s}.", name)
+            : "executing un-named command.";
+        logEvent("startCommand", message);
+        return START_REDELIVER_INTENT;
+    }
+
+    // Private instance methods.
+
+    /** Log an event. */
+    private void logEvent(final String name, final String message) {
+        Log.d(TAG, String.format(Locale.US, "event {%s}, with message: {%s}.", name, message));
+    }
+}


### PR DESCRIPTION
<h1>Rationale:</h1>

Notifications and member list displays both need to know if a member is in a particular room.  This commit provides that feature.

<h1>File changes:</h1>

modified:   app/src/main/AndroidManifest.xml

- Summary: add the main service to the application element.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/model/Account.java
modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java

- Summary: convert the join map value to a join state object.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

- Summary: add support in onPause() and onResume() for updating the member join state.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- Summary: add support for setting (setJoinState()) and clearing (clearJoinState()) state values.

new file:   app/src/main/java/com/pajato/android/gamechat/common/model/JoinState.java

- Summary: new file (POJO) to support the join state feature.

new file:   app/src/main/java/com/pajato/android/gamechat/main/MainService.java

- Summary: add the skeleton for the main service.  It is non-functional at this point.