### PR TITLE
Implement a toast message to eliminate a TODO. Consolidate the keyboard dismissal code.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -24,6 +24,7 @@ import android.text.TextWatcher;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
@@ -71,8 +72,10 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
                 Account account = AccountManager.instance.getCurrentAccount();
                 if (account != null)
                     save(account);
-                else
+                else {
+                    dismissKeyboard();
                     abort("The User account does not exist.  Aborting.");
+                }
                 DispatchManager.instance.startNextFragment(getActivity(), chat);
                 break;
 
@@ -118,8 +121,9 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
     /** Log and present a toast message to the User. */
     protected void abort(final String message) {
-        logEvent(String.format(Locale.US, "Error: (create %s): %s.", mCreateType, message));
-        // TODO: throw up a toast or snackbar.
+        String abortMessage = String.format("Error: (create %s): %s", mCreateType, message);
+        logEvent(abortMessage);
+        Toast.makeText(getActivity(), abortMessage, Toast.LENGTH_LONG).show();
     }
 
     /** Return a default name. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -17,10 +17,8 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.RadioGroup;
 
@@ -42,7 +40,6 @@ import com.pajato.android.gamechat.exp.NotificationManager;
 import java.util.ArrayList;
 import java.util.Locale;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.COMMON;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
@@ -127,11 +124,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
         MessageManager.instance.createMessage(text, STANDARD, account, room);
 
         // Dismiss the Keyboard and return to the previous fragment.
-        Activity activity = getActivity();
-        InputMethodManager manager;
-        manager = (InputMethodManager) activity.getSystemService(INPUT_METHOD_SERVICE);
-        if (manager.isAcceptingText() && activity.getCurrentFocus() != null)
-            manager.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        dismissKeyboard();
 
         // Give the user a snackbar message offering to join friends to the group.
         NotificationManager.instance.notifyGroupCreate(this, mGroup.key, mGroup.name);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
@@ -35,7 +34,6 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.List;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.R.id.create_button_finish;
 import static com.pajato.android.gamechat.R.id.emailEditText;
 import static com.pajato.android.gamechat.R.id.email_next_button;
@@ -255,15 +253,6 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
                             })
                     .addOnSuccessListener(getActivity(), new EmailOnSuccessListener());
         }
-    }
-
-    /** Dismiss the keyboard if necessary */
-    private void dismissKeyboard() {
-        // Dismiss the Keyboard and return to the previous fragment.
-        InputMethodManager manager;
-        manager = (InputMethodManager) getActivity().getSystemService(INPUT_METHOD_SERVICE);
-        if (manager.isAcceptingText() && getActivity().getCurrentFocus() != null)
-            manager.hideSoftInputFromWindow(getActivity().getCurrentFocus().getWindowToken(), 0);
     }
 
     /** Enable (or disable) the 'finish' button in the toolbar */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -17,9 +17,7 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.app.Activity;
 import android.support.annotation.NonNull;
-import android.view.inputmethod.InputMethodManager;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
@@ -36,7 +34,6 @@ import com.pajato.android.gamechat.database.MessageManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.exp.NotificationManager;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
@@ -111,11 +108,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
         MessageManager.instance.createMessage(text, STANDARD, account, mRoom);
 
         // Dismiss the Keyboard and return to the previous fragment.
-        Activity activity = getActivity();
-        InputMethodManager manager;
-        manager = (InputMethodManager) activity.getSystemService(INPUT_METHOD_SERVICE);
-        if (manager.isAcceptingText() && activity.getCurrentFocus() != null)
-            manager.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        dismissKeyboard();
 
         // Give the user a snackbar message offering to join friends to the room.
         NotificationManager.instance.notifyRoomCreate(this, mRoom.key, mRoom.name);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -17,7 +17,6 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -25,7 +24,6 @@ import android.support.v4.view.ViewPager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import com.pajato.android.gamechat.R;
@@ -154,17 +152,6 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
 
     // Private instance methods.
 
-    /** Dismiss the virtual keyboard in response to a click on the given view. */
-    private void hideSoftKeyBoard(final View view) {
-        // Determine if the keyboard is active before dismissing it.
-        final String SERVICE = Context.INPUT_METHOD_SERVICE;
-        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(SERVICE);
-        if(imm.isAcceptingText()) {
-            // The virtual keyboard is active.  Dismiss it.
-            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-        }
-    }
-
     /** Initialize the edit text field. */
     private void initEditText(@NonNull final View layout) {
         // Set up the edit text field and the send button.
@@ -184,7 +171,7 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         if (account == null || editText == null) {
             // Something is wrong.  Log it and tell the User.
             Snackbar.make(view, "Software error: could not send message!", Snackbar.LENGTH_LONG);
-            hideSoftKeyBoard(view);
+            dismissKeyboard();
             return;
         }
 
@@ -196,7 +183,7 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         MessageManager.instance.createMessage(text, STANDARD, account, room);
         editText.setText("");
         Snackbar.make(layout, "Message sent.", Snackbar.LENGTH_SHORT);
-        hideSoftKeyBoard(view);
+        dismissKeyboard();
     }
 
     // Private inner classes.

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
 import com.google.android.gms.ads.AdRequest;
@@ -54,6 +55,7 @@ import com.pajato.android.gamechat.event.AppEventManager;
 import java.util.List;
 import java.util.Locale;
 
+import static android.content.Context.INPUT_METHOD_SERVICE;
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
 import static com.pajato.android.gamechat.common.FragmentType.messageList;
 import static com.pajato.android.gamechat.common.adapter.MenuEntry.MENU_ITEM_NO_TINT_TYPE;
@@ -334,6 +336,15 @@ public abstract class BaseFragment extends Fragment {
         else
             state.setType(inactive);
         MemberManager.instance.updateMember(member);
+    }
+
+    /** Dismiss the keyboard if necessary */
+    protected void dismissKeyboard() {
+        // Determine if the keyboard is active before dismissing it.
+        InputMethodManager manager;
+        manager = (InputMethodManager) getActivity().getSystemService(INPUT_METHOD_SERVICE);
+        if (manager.isAcceptingText() && getActivity().getCurrentFocus() != null)
+            manager.hideSoftInputFromWindow(getActivity().getCurrentFocus().getWindowToken(), 0);
     }
 
     /** Set the join state using the given value which must be one of 'chat' or 'exp'. */


### PR DESCRIPTION
# Rationale
Remove a "TODO" which wanted a toast message. Meanwhile, consolidate keyboard dismissal code to a method in BaseFragment where everyone can share.

## Files Changed 
#### app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
* abort(): add the toast method and remove the "TODO". Be sure that the keyboard is dismissed first or else the toast message may not be visible.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
* remove keyboard dismissal code and use new method in BaseFragment instead

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
* remove keyboard dismissal code and use new method in BaseFragment instead

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* remove keyboard dismissal code and use new method in BaseFragment instead

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
* remove keyboard dismissal code and use new method in BaseFragment instead

#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* dismissKeyboard(): move keyboard dismissal function to base class so it isn't duplicated in other fragments