### PR TITLE
Warn user before creating group or room with duplicate names.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -70,13 +70,15 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
         switch (event.view.getId()) {
             case R.id.SaveButton: // Validate and persist the group, and be done with the activity.
                 Account account = AccountManager.instance.getCurrentAccount();
-                if (account != null)
-                    save(account);
+                if (account != null) {
+                    if (save(account))
+                        // don't dispatch back to chat unless save was successful
+                        DispatchManager.instance.startNextFragment(getActivity(), chat);
+                }
                 else {
                     dismissKeyboard();
-                    abort("The User account does not exist.  Aborting.");
+                    abort(getString(R.string.InvalidAccountError));
                 }
-                DispatchManager.instance.startNextFragment(getActivity(), chat);
                 break;
 
             case R.id.ClearNameButton: // Clear the group name edit text field.
@@ -121,7 +123,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
 
     /** Log and present a toast message to the User. */
     protected void abort(final String message) {
-        String abortMessage = String.format("Error: (create %s): %s", mCreateType, message);
+        String abortMessage = String.format(getString(R.string.AbortError), message);
         logEvent(abortMessage);
         Toast.makeText(getActivity(), abortMessage, Toast.LENGTH_LONG).show();
     }
@@ -131,8 +133,8 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
         return "";
     }
 
-    /** The save operation for a given account. */
-    abstract protected void save(final Account account);
+    /** The save operation for a given account. Return true if successful. */
+    abstract protected boolean save(final Account account);
 
     /** Set the name of the managed object. */
     abstract protected void setName(final String value);
@@ -171,14 +173,11 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
         /** Make sure that the hint is restored when necessary and that the name is unique. */
         @Override public void afterTextChanged(Editable s) {
             if (mEditText.getText().length() == 0) {
-                // Restore the hint and disable the save button.
-                //restoreHint();
+                // Disable the save button.
                 mSaveButton.setTextColor(mDisabledColor);
                 mSaveButton.setEnabled(false);
             } else {
-                // TODO: determine if the group name is unique.
-                // Render the save button enabled with the primary dark color and update the
-                // group.
+                // Enable the save button and update the group.
                 mSaveButton.setEnabled(true);
                 mSaveButton.setTextColor(mEnabledColor);
                 setName(mEditText.getText().toString());

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -71,11 +71,9 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
             case R.id.SaveButton: // Validate and persist the group, and be done with the activity.
                 Account account = AccountManager.instance.getCurrentAccount();
                 if (account != null) {
-                    if (save(account))
-                        // don't dispatch back to chat unless save was successful
+                    if (save(account, false))
                         DispatchManager.instance.startNextFragment(getActivity(), chat);
-                }
-                else {
+                } else {
                     dismissKeyboard();
                     abort(getString(R.string.InvalidAccountError));
                 }
@@ -134,7 +132,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
     }
 
     /** The save operation for a given account. Return true if successful. */
-    abstract protected boolean save(final Account account);
+    abstract protected boolean save(final Account account, final boolean ignoreDuplicateName);
 
     /** Set the name of the managed object. */
     abstract protected void setName(final String value);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -101,12 +101,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
             new AlertDialog.Builder(getActivity())
                     .setTitle(String.format(getString(R.string.GroupExistsTitle), mGroup.name))
                     .setMessage(String.format(getString(R.string.GroupExistsMessage), mGroup.name))
-                    .setNegativeButton(android.R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                }
-                            })
+                    .setNegativeButton(android.R.string.cancel, null)
                     .setPositiveButton(android.R.string.ok,
                             new DialogInterface.OnClickListener() {
                                 @Override

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -101,12 +101,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
             new AlertDialog.Builder(getActivity())
                     .setTitle(String.format(getString(R.string.RoomExistsTitle), mRoom.name))
                     .setMessage(String.format(getString(R.string.RoomExistsMessage), mRoom.name))
-                    .setNegativeButton(android.R.string.cancel,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                }
-                            })
+                    .setNegativeButton(android.R.string.cancel, null)
                     .setPositiveButton(android.R.string.ok,
                             new DialogInterface.OnClickListener() {
                                 @Override

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -307,6 +307,20 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         MessageManager.instance.createMessage(text, SYSTEM, account, room);
     }
 
+    /** Determine if the current account has a group with the specified name */
+    public boolean hasGroupWithName(String name) {
+        if (mCurrentAccount == null)
+            return false;
+        for (String groupKey : mCurrentAccount.joinMap.keySet()) {
+            Group group = GroupManager.instance.getGroupProfile(groupKey);
+            if (group == null)
+                continue;
+            if (group.name.equals(name))
+                return true;
+        }
+        return false;
+    }
+
     /** Determine if the specified account belongs to any groups which have members */
     public static boolean hasSelectableMembers(Account account) {
         if (account == null)

--- a/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
@@ -141,6 +141,18 @@ public enum GroupManager {
         return result;
     }
 
+    public boolean groupHasRoomName(final String groupKey, final String roomName) {
+        Group group = getGroupProfile(groupKey);
+        if (group == null)
+            return false;
+        for (String roomKey : group.roomList) {
+            Room room = RoomManager.instance.getRoomProfile(roomKey);
+            if (room.name.equals(roomName))
+                return true;
+        }
+        return false;
+    }
+
     /** Get the data as a set of list items for all groups. */
     public List<ListItem> getListItemData() {
         // Determine whether to handle no groups (a set of welcome list items), one group (a set of

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -22,7 +22,8 @@
     <string name="EmailInvalidMessage">Invalid email format</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>
     <string name="Group">Group</string>
-    <string name="GroupExistsMessage">You already have a group named %s.</string>
+    <string name="GroupExistsMessage">You already have a group named %s. Do you want to continue anyway?</string>
+    <string name="GroupExistsTitle">Group %s already exists!</string>
     <string name="GroupsToolbarTitle">Groups with Messages</string>
     <string name="GroupMeToolbarTitle">My Chat Room</string>
     <string name="LeaveConfirmMessage">Do you want to leave %s?</string>
@@ -37,7 +38,6 @@
     <string name="InsertPhoto">Inserting a photo from your device</string>
     <string name="InsertPhotoDesc">Insert photo from file image button.</string>
     <string name="InvalidAccountError">The User account does not exist.</string>
-    <string name="InvalidGroupError">The room is not in a valid group.</string>
     <string name="InviteFriendsOverflow">Invite friends</string>
     <string name="JoinedGroupsMessage">You have joined group %s</string>
     <string name="JoinedOneRoom">You have joined the %1$s room in group %2$s</string>
@@ -59,7 +59,8 @@
     <string name="PromoteUserConfirm">Do you want to promote %s to be a standard (non-protected) user?</string>
     <string name="PromoteUserTitle">Promote Protected User</string>
     <string name="ProtectedUsersTitle">Your Protected Users</string>
-    <string name="RoomExistsMessage">There is already a room named %s.</string>
+    <string name="RoomExistsMessage">There is already a room named %s. Do you want to continue anyway?</string>
+    <string name="RoomExistsTitle">Room %s already exists!</string>
     <string name="RoomListIcon">The room list icon.</string>
     <string name="RoomsAvailableHeaderText">Rooms</string>
     <string name="RoomsToolbarTitle">Rooms with Messages</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="AddGroupDesc">Create Group menu button</string>
     <string name="AddMembers">Invite members</string>
+    <string name="AbortError">Error: %s Aborting</string>
     <string name="ButtonNext">NEXT</string>
     <string name="ButtonFinish">FINISH</string>
     <string name="ClearSelectionsMenuTitle">Clear Selections</string>
@@ -21,6 +22,7 @@
     <string name="EmailInvalidMessage">Invalid email format</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>
     <string name="Group">Group</string>
+    <string name="GroupExistsMessage">You already have a group named %s.</string>
     <string name="GroupsToolbarTitle">Groups with Messages</string>
     <string name="GroupMeToolbarTitle">My Chat Room</string>
     <string name="LeaveConfirmMessage">Do you want to leave %s?</string>
@@ -34,6 +36,8 @@
     <string name="InsertMapDesc">Insert map image button.</string>
     <string name="InsertPhoto">Inserting a photo from your device</string>
     <string name="InsertPhotoDesc">Insert photo from file image button.</string>
+    <string name="InvalidAccountError">The User account does not exist.</string>
+    <string name="InvalidGroupError">The room is not in a valid group.</string>
     <string name="InviteFriendsOverflow">Invite friends</string>
     <string name="JoinedGroupsMessage">You have joined group %s</string>
     <string name="JoinedOneRoom">You have joined the %1$s room in group %2$s</string>
@@ -55,6 +59,7 @@
     <string name="PromoteUserConfirm">Do you want to promote %s to be a standard (non-protected) user?</string>
     <string name="PromoteUserTitle">Promote Protected User</string>
     <string name="ProtectedUsersTitle">Your Protected Users</string>
+    <string name="RoomExistsMessage">There is already a room named %s.</string>
     <string name="RoomListIcon">The room list icon.</string>
     <string name="RoomsAvailableHeaderText">Rooms</string>
     <string name="RoomsToolbarTitle">Rooms with Messages</string>


### PR DESCRIPTION
# Rationale
Ask the user to confirm before creating either a group with a duplicate name or a room within a group that has a duplicate name.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
* onClick(): when handling 'save' case, don't dispatch to next fragment unless save method returns true
* abort(): use string resource
* change save() signature to return boolean and take a second param to indicate ignoring a duplicate name

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
* save(): Return boolean indicating if save completed successfully. Also add param indicating whether to ignore duplicate names. If this is false, and a duplicate name is detected, raise an alert dialog asking user to confirm. If the user gives the go-ahead, call save() again and specify to ignore dups.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* save(): Return boolean indicating if save completed successfully. Also add param indicating whether to ignore duplicate names. If this is false, and a duplicate name is detected, raise an alert dialog asking user to confirm. If the user gives the go-ahead, call save() again and specify to ignore dups.

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* hasGroupWithName(): new convenience method

#### app/src/main/java/com/pajato/android/gamechat/database/GroupManager.java
* groupHasRoomName(): new convenience method

#### app/src/main/res/values/strings_chat.xml
* new strings