### PR TITLE
Make the experience chaining feature work.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -27,11 +27,10 @@ import android.view.View;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
-import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.chat.model.Message;
+import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
-import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -140,46 +139,41 @@ public abstract class BaseChatFragment extends BaseFragment {
     }
 
     /** Return TRUE iff the fragment setup is handled successfully. */
-    @Override protected boolean onDispatch(@NonNull final Context context,
-                                           @NonNull final Dispatcher dispatcher) {
+    @Override protected void onDispatch(@NonNull final Context context) {
         // Ensure that the type is valid.  Signal failure if not, otherwise handle each possible
         // case signalling success.  If there are no valid cases signal failure.
-        if (dispatcher.type == null)
-            return false;
+        if (mDispatcher.type == null)
+            return;
         switch (type) {
-            case createProtectedUser:
-            case groupsForProtectedUser:
-            case chatGroupList: // A group list does not need an item.
-                return true;
             case messageList:   // The messages in a room require both the group and room keys.
-                String groupKey = dispatcher.groupKey;
-                String roomKey = dispatcher.roomKey;
+                String groupKey = mDispatcher.groupKey;
+                String roomKey = mDispatcher.roomKey;
                 String name = RoomManager.instance.getRoomName(roomKey);
                 markMessagesSeen(groupKey, roomKey);
                 mItem = new ListItem(chatRoom, groupKey, roomKey, name, 0, null);
-                return true;
+                break;
             case roomMembersList:
-                if (dispatcher.groupKey == null || dispatcher.roomKey == null)
-                    return false;
-                String roomName = RoomManager.instance.getRoomName(dispatcher.roomKey);
-                mItem = new ListItem(roomList, dispatcher.groupKey, dispatcher.roomKey, roomName);
-                return true;
+                if (mDispatcher.groupKey == null || mDispatcher.roomKey == null)
+                    return;
+                String roomName = RoomManager.instance.getRoomName(mDispatcher.roomKey);
+                mItem = new ListItem(roomList, mDispatcher.groupKey, mDispatcher.roomKey, roomName);
+                break;
             case groupMembersList:
-                if (dispatcher.groupKey == null)
-                    return false;
-                String groupName = GroupManager.instance.getGroupName(dispatcher.groupKey);
-                mItem = new ListItem(groupList, dispatcher.groupKey, groupName);
-                return true;
+                if (mDispatcher.groupKey == null)
+                    return;
+                String groupName = GroupManager.instance.getGroupName(mDispatcher.groupKey);
+                mItem = new ListItem(groupList, mDispatcher.groupKey, groupName);
+                break;
             case createRoom:
             case joinRoom:
             case protectedUsers:
             case chatRoomList:  // The rooms in a group need the group key.
-                if (dispatcher.groupKey == null)
-                    return false;
-                mItem = new ListItem(chatGroup, dispatcher.groupKey, null, null, 0, null);
-                return true;
+                if (mDispatcher.groupKey == null)
+                    return;
+                mItem = new ListItem(chatGroup, mDispatcher.groupKey, null, null, 0, null);
+                break;
             default:
-                return false;
+                break;
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -178,6 +178,8 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         Account account = AccountManager.instance.getCurrentAccount();
         if (account == null)
             return R.string.app_name;
-        return R.string.GroupsToolbarTitle;
+        if (account.joinMap.size() > 0)
+            return R.string.ChatGroupsToolbarTitle;
+        return R.string.GroupMeToolbarTitle;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -133,7 +133,8 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
     /** Deal with the fragment's lifecycle by marking the join inactive. */
     @Override public void onPause() {
         super.onPause();
-        clearJoinState(mItem.groupKey, mItem.roomKey, chat);
+        if (mItem != null)
+            clearJoinState(mItem.groupKey, mItem.roomKey, chat);
     }
 
     /** Deal with the fragment's lifecycle by managing the FAB. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -93,6 +93,9 @@ public abstract class BaseFragment extends Fragment {
     /** An ad view to be conditionally shown at the top of the view. */
     protected AdView mAdView;
 
+    /** The dispatcher information. */
+    protected Dispatcher mDispatcher;
+
     /** The item information passed from the parent fragment. */
     protected ListItem mItem;
 
@@ -179,10 +182,9 @@ public abstract class BaseFragment extends Fragment {
 
     /** Provide a means to setup the fragment once it has been created. */
     public void onSetup(Context context, Dispatcher dispatcher) {
-        if (!onDispatch(context, dispatcher)) {
-            // The dispatch failed. Log it, toast it or some such.
-            Log.d(TAG, "onDispatch failed ...");
-        }
+        // Save the dispatcher information for processing by the started fragment.
+        mDispatcher = dispatcher;
+        onDispatch(context);
     }
 
     /** Log the lifecycle event. */
@@ -235,8 +237,8 @@ public abstract class BaseFragment extends Fragment {
     /** Provide a logger to show the given message. */
     protected abstract void logEvent(String message);
 
-    /** Delegate the setup to the subclasses. */
-    protected abstract boolean onDispatch(Context context, Dispatcher dispatcher);
+    /** Delegate the dispatch setup to the subclasses. */
+    protected abstract void onDispatch(Context context);
 
     /** Provide a way to handle volunteer solicitations for unimplemented functions. */
     protected void showFutureFeatureMessage(final int resourceId) {
@@ -282,13 +284,14 @@ public abstract class BaseFragment extends Fragment {
 
     /** Return null or a list to be displayed by a list adapter for a given fragment type. */
     private List<ListItem> getList(@NonNull final FragmentType type, final ListItem item) {
+        // TODO: this has gotten too ugly.  Fix it!
         switch (type) {
             case chatGroupList: // Get the data to be shown in a list of groups.
                 return GroupManager.instance.getListItemData();
-            case chatRoomList:  // Get the data to be show in a list of rooms.
+            case chatRoomList:    // Get the data to be shown in a list of rooms.
                 return RoomManager.instance.getListItemData(item.groupKey);
-            case expGroupList:  // Get the groups with experiences.
-                return ExperienceManager.instance.getListItemData();
+            case expGroupList:    // Get the groups with experiences.
+            case expRoomList:     // Get the rooms with experiences.
             case experienceList:  // Get the groups with experiences.
                 return ExperienceManager.instance.getListItemData(item);
             case joinRoom:      // Get the candidate list of rooms and members.
@@ -310,7 +313,6 @@ public abstract class BaseFragment extends Fragment {
                 return PlayModeManager.instance.getListItemData(type);
             case selectUser:    // Get all the visible Users for the current account holder.
                 return PlayModeManager.instance.getListItemData(type);
-            case createProtectedUser: // no list data for create protected user
             default:
                 return null;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -18,10 +18,9 @@
 package com.pajato.android.gamechat.common;
 
 import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.exp.Experience;
-
-import java.util.List;
 
 /**
  * The fragment dispatcher provides mediation between the experience or chat managers and the main
@@ -34,14 +33,17 @@ public class Dispatcher {
 
     // Public instance variables.
 
-    /** The experience or message key. */
-    public String key;
+    /** The experience target fragment type. */
+    public FragmentType expFragmentType;
 
     /** The experience payload. */
     public Experience experiencePayload;
 
     /** The group key. */
     public String groupKey;
+
+    /** The experience or message key. */
+    public String key;
 
     /** The room key. */
     public String roomKey;
@@ -55,8 +57,6 @@ public class Dispatcher {
     Dispatcher(final FragmentType type) {
         // Capture the type and handle any of the experience types.
         this.type = type;
-        if (type != null)
-            processType();
     }
 
     /** Build an instance given a list item. */
@@ -89,39 +89,11 @@ public class Dispatcher {
         }
     }
 
-    // Private instance methods.
-
-    /** Handle one of the main experience types. */
-    private void processExperienceType() {
-        // There are three cases to be handled: 1) there are no experiences of the given type;
-        // 2) there is exactly one experience of the given type; or 3) there are multiple
-        // experiences of the given type.
-        List<Experience> experienceList = ExperienceManager.instance.getExperienceList(type);
-        switch (experienceList.size()) {
-            case 0: // There is no experiences of this type.  One will be created shortly.
-                break;
-            case 1: // There is exactly one experience of this type.  Use it.
-                experiencePayload = experienceList.get(0);
-                groupKey = experiencePayload.getGroupKey();
-                roomKey = experiencePayload.getRoomKey();
-                key = experiencePayload.getExperienceKey();
-                break;
-            default: // There are multiple experiences of this type.  Present a list of
-                // them by changing the type to the corresponding list type.
-                type = FragmentType.experienceList;
-                break;
-        }
-    }
-
-    /** Handle the non-null type to refine the choices. */
-    private void processType() {
-        switch (type) {
-            case checkers:
-            case chess:
-            case tictactoe:  // Process one of the game types.
-                processExperienceType();
-                break;
-            default: break;
-        }
+    /** Build an instance providing a fragment type and a target (experience) fragment type. */
+    public Dispatcher(final FragmentType type, final FragmentType expFragmentType) {
+        this.type = type;
+        this.expFragmentType = expFragmentType;
+        groupKey = AccountManager.instance.getMeGroupKey();
+        roomKey = AccountManager.instance.getMeRoomKey();
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -84,7 +84,7 @@ public enum FragmentType {
     expEnvelope (ExpEnvelopeFragment.class, none, R.layout.exp_envelope),
     expGroupList (ExpShowGroupsFragment.class, expMain, R.layout.exp_list),
     expOffline (ExpShowOfflineFragment.class, expMain, R.layout.exp_offline),
-    expRoomList (ExpShowRoomsFragment.class, standardWhite, R.layout.exp_none),
+    expRoomList (ExpShowRoomsFragment.class, standardWhite, R.layout.exp_list),
     expSignedOut (ExpShowSignedOutFragment.class, expMain, R.layout.exp_signed_out),
     experienceList (ShowExperiencesFragment.class, standardWhite, R.layout.exp_list),
     groupMembersList(ChatShowMembersFragment.class, standardBlack, R.layout.chat_members),

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -93,6 +93,7 @@ public enum ToolbarManager {
     public enum ToolbarType {
         chatMain (R.drawable.ic_more_vert_white_24dp),
         expMain (R.drawable.ic_more_vert_white_24dp),
+
         // Define 'standard' toolbar to have the overflow (three vertical dots) and back arrow
         standardBlack (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),
         standardWhite (R.drawable.ic_more_vert_white_24dp, R.drawable.ic_arrow_back_white_24dp),
@@ -243,9 +244,12 @@ public enum ToolbarManager {
         if (item == null)
             return null;
         switch (item.type) {
+            case expGroup:
+                return fragment.getString(R.string.ExpGroupsToolbarTitle);
             case chatGroup:
-                return fragment.getString(R.string.RoomsToolbarTitle);
+                return fragment.getString(R.string.ChatGroupsToolbarTitle);
             case expList:
+            case expRoom:
                 // Determine if the group is the me group and give it special handling.
                 if (AccountManager.instance.isMeGroup(item.groupKey))
                     return fragment.getString(R.string.MyExperiencesToolbarTitle);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -38,7 +38,6 @@ import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 import com.pajato.android.gamechat.exp.ExpHelper;
 import com.pajato.android.gamechat.exp.checkers.CheckersBoard;
-import com.pajato.android.gamechat.exp.checkers.CheckersEngine;
 import com.pajato.android.gamechat.exp.model.Checkers;
 import com.pajato.android.gamechat.exp.model.Player;
 
@@ -94,10 +93,10 @@ public class CheckersFragment extends BaseExperienceFragment {
         processClickEvent(event.view, "checkers");
     }
 
-    /** Handle a FAM or Snackbar Checkers click event. */
+    /** Handle a FAM or Snackbar click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "chess");
+        processTagClickEvent(event, "checkers");
     }
 
     /** Handle an experience posting event to see if this is a checkers experience. */
@@ -115,7 +114,8 @@ public class CheckersFragment extends BaseExperienceFragment {
     /** Deal with the fragment's lifecycle by marking the join inactive. */
     @Override public void onPause() {
         super.onPause();
-        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+        if (mExperience != null)
+            clearJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
     }
 
     /** Handle taking the foreground by updating the UI based on the current experience. */
@@ -127,13 +127,13 @@ public class CheckersFragment extends BaseExperienceFragment {
         if (mExperience == null)
             return;
         setJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
-        CheckersEngine.instance.init(mExperience, mBoard, mTileClickHandler);
-        ExpHelper.updateUiFromExperience(mExperience, mBoard);
+        resumeExperience();
     }
 
     @Override public void onStart() {
         // Setup the FAM, add a new game item to the overflow menu, and obtain the board.
         super.onStart();
+        mDispatcher.expFragmentType = null;
         FabManager.game.setMenu(CHECKERS_FAM_KEY, getCheckersMenu());
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);
         mBoard.init(this, mTileClickHandler); // = (GridLayout) mLayout.findViewById(board);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -39,7 +39,6 @@ import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 import com.pajato.android.gamechat.exp.ExpHelper;
 import com.pajato.android.gamechat.exp.chess.Chess;
 import com.pajato.android.gamechat.exp.chess.ChessBoard;
-import com.pajato.android.gamechat.exp.chess.ChessEngine;
 import com.pajato.android.gamechat.exp.model.Player;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -107,7 +106,8 @@ public class ChessFragment extends BaseExperienceFragment {
     /** Deal with the fragment's lifecycle by marking the join inactive. */
     @Override public void onPause() {
         super.onPause();
-        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+        if (mExperience != null)
+            clearJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
     }
 
     /**
@@ -121,13 +121,13 @@ public class ChessFragment extends BaseExperienceFragment {
         if (mExperience == null)
             return;
         setJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
-        ChessEngine.instance.init(mExperience, mBoard, mTileClickHandler);
-        ExpHelper.updateUiFromExperience(mExperience, mBoard);
+        resumeExperience();
     }
 
     @Override public void onStart() {
         // Setup the FAM, add a new game item to the overflow menu, and obtain the board.
         super.onStart();
+        mDispatcher.expFragmentType = null;
         FabManager.game.setMenu(CHESS_FAM_KEY, getChessMenu());
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);
         mBoard.init(this, mTileClickHandler);
@@ -142,8 +142,7 @@ public class ChessFragment extends BaseExperienceFragment {
     // Protected instance methods.
 
     /** Return a default, partially populated, Chess experience. */
-    @Override
-    protected void createExperience(final Context context, final List<Account> playerAccounts) {
+    @Override protected void createExperience(final Context context, final List<Account> playerAccounts) {
         // Setup the default key, players, creation timestamp and name.
         String key = getExperienceKey();
         List<Player> players = getDefaultPlayers(context, playerAccounts);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -28,12 +28,14 @@ import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
+import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import static com.pajato.android.gamechat.common.FragmentKind.exp;
+import static com.pajato.android.gamechat.common.FragmentType.expRoomList;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
@@ -58,6 +60,12 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
         processClickEvent(event.view, "expShowGroups");
+    }
+
+    /** Handle a FAM or Snackbar click event. */
+    @Subscribe public void onClick(final TagClickEvent event) {
+        // Delegate the event to the base class.
+        processTagClickEvent(event, "chess");
     }
 
     /** Handle an experience list change event by dispatching again. */
@@ -106,9 +114,19 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
 
     /** Initialize the fragment by setting up the FAB and toolbar. */
     @Override public void onStart() {
+        // Ensure that this is not a pass-through to a particular experience fragment.  If not, then
+        // set up the toolbar.
         super.onStart();
-        int titleResId = getTitleResId();
-        ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, invite, settings);
+        if (mDispatcher.expFragmentType == null) {
+            int titleResId = getTitleResId();
+            ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, invite, settings);
+            return;
+        }
+
+        // Handle a pass through by handing off to the experience room list fragment.
+        mDispatcher.type = expRoomList;
+        DispatchManager.instance.chainFragment(getActivity(), mDispatcher);
+        mItem = null;
     }
 
     /** Return the toolbar title resource id to use. */
@@ -117,6 +135,6 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
         // toolbar title, otherwise use a rooms toolbar title.
         if (ExperienceManager.instance.expGroupMap.size() > 1)
             return R.string.ExpGroupsToolbarTitle;
-        return R.string.ExpRoomsToolbarTitle;
+        return R.string.MyGameRoomToolbarTitle;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
@@ -17,11 +17,25 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 
 import org.greenrobot.eventbus.Subscribe;
+
+import static com.pajato.android.gamechat.common.FragmentType.experienceList;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.search;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expRoom;
+import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
 
 public class ExpShowRoomsFragment extends BaseExperienceFragment {
 
@@ -31,9 +45,32 @@ public class ExpShowRoomsFragment extends BaseExperienceFragment {
         processClickEvent(event.view, "expShowRooms");
     }
 
+    /** Handle a FAM or Snackbar click event. */
+    @Subscribe public void onClick(final TagClickEvent event) {
+        // Delegate the event to the base class.
+        processTagClickEvent(event, "chess");
+    }
+
+    @Override public void onResume() {
+        super.onResume();
+        FabManager.game.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.game.init(this, GAME_HOME_FAM_KEY);
+    }
+
     /** Initialize the fragment by setting in the FAB. */
     @Override public void onStart() {
+        // Ensure that this is not a pass-through to a particular experience fragment.  If not, then
+        // initialize the FAM.
         super.onStart();
-        FabManager.game.init(this);
+        if (mDispatcher.expFragmentType == null) {
+            FabManager.game.init(this);
+            ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
+            return;
+        }
+
+        // Handle a pass-through by handing off to the experience list fragment.
+        mDispatcher.type = experienceList;
+        DispatchManager.instance.chainFragment(getActivity(), mDispatcher);
+        mItem = new ListItem(expRoom, mDispatcher.groupKey, null, null, 0, null);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
@@ -55,7 +55,7 @@ public class ShowNoExperiencesFragment extends BaseExperienceFragment {
     /** Handle a FAM or Snackbar Chess click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "chess");
+        processTagClickEvent(event, "no experiences");
     }
 
     /** Handle an experience list change event. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -166,7 +166,8 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     /** Deal with the fragment's lifecycle by marking the join inactive. */
     @Override public void onPause() {
         super.onPause();
-        clearJoinState(mItem.groupKey, mItem.roomKey, exp);
+        if (mExperience != null)
+            clearJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
     }
 
     /** Handle taking the foreground by updating the UI based on the current experience. */
@@ -183,6 +184,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     @Override public void onStart() {
         // Initialize the FAB/FAM and the toolbar.
         super.onStart();
+        mDispatcher.expFragmentType = null;
         FabManager.game.setMenu(TIC_TAC_TOE_FAM_KEY, getTTTMenu());
         FabManager.game.init(this);
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -4,6 +4,7 @@
     <string name="AbortError">Error: %s Aborting</string>
     <string name="ButtonNext">NEXT</string>
     <string name="ButtonFinish">FINISH</string>
+    <string name="ChatGroupsToolbarTitle">Groups with Messages</string>
     <string name="ClearSelectionsMenuTitle">Clear Selections</string>
     <string name="CreateGroupMenuTitle">Create Group</string>
     <string name="CreateGroupNameHint">Type group name</string>Title">
@@ -24,7 +25,6 @@
     <string name="Group">Group</string>
     <string name="GroupExistsMessage">You already have a group named %s. Do you want to continue anyway?</string>
     <string name="GroupExistsTitle">Group %s already exists!</string>
-    <string name="GroupsToolbarTitle">Groups with Messages</string>
     <string name="GroupMeToolbarTitle">My Chat Room</string>
     <string name="LeaveConfirmMessage">Do you want to leave %s?</string>
     <string name="LeaveGroupTitle">Leave Group?</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -14,6 +14,7 @@
     <string name="InviteFriendNav">Invite friends</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyExperiencesToolbarTitle">My Games</string>
+    <string name="MyGameRoomToolbarTitle">My Game Room</string>
     <string name="NoExperiencesMessage">You have no experiences</string>
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

The experience chaining feature was in a sorry state, half implemented, replete with bugs and in dire need of TLC.  This commit is the first dose of that much needed TLC.  It provides the ability to create an initial game and havigate successfully back to the display of groups with experiences, albeit a faulty display, but ... hey, progress.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

- onDispatch(): make void since success result was never used; remove default cases; use the new member dispatcher field.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java

- getTitleResId(): provide a different title based on the number of members.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java

- onPause(): only modify the join state when an item exists.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- mDispatcher: hold onto the dispatcher to use it to support chaining.
- onSetup(): simplify by making onDispatch() void; save the dispatcher for chaining.
- onDispatch(): simplify by using a void return value and not accepting a dispatcher.
- getList(): add the missing case for handling experience rooms; remove default cases.

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java

- chainFragment(), startNextFragment(): provide overloads to take a dispatcher directly.

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- expFragmentType: new field to support chaining.
- processExperienceType(), processType(): remove: stale in the face of chaining.
- Dispatcher(): new constructor to handle chaining.

modified:   app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java

- expRoomList: replace placeholder layout file with the real thing.

modified:   app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java

- getTitle(): flesh out support for list of experience rooms and groups.

modified:   app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

- getExperienceList(): remove: not used.
- getListItemData(): renamed to getGroupListItemData(); this code needs more work as it is likely leading to a dual me group bug.
- getListItemData(): renamed to getRoomListItemData().
- getListItemData(): use to launch the overloads as appropriate.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- onResume(): handle experience chaining.
- onSetup(): enhance comments and simplify establishing the experience member variable value.
- onStart(): conditionally handle the ad view control.
- onDispatch(): overhaul.
- processExperienceChange(): simplify the guard expression; extract common code into a resume() procedural abstraction.
- processFamItem(); initiate experience chaining.
- resumeExperience(): new method handling common code between onResume and onExperienceChange().

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

- onClick(): fix a cosmetic cut/paste error.
- onPause(): wrap a guard around clearing the member join state.
- onResume(), onStart(): support experience chaining.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java

- onClick(): add to fix an oversight.
- onStart(), onResume(): support experience chaining.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java

- onClick(): fix a cut/paste error.

modified:   app/src/main/res/values/strings_chat.xml
modified:   app/src/main/res/values/strings_exp.xml

- Summary: usual localiztion adds/removes.