### PR TITLE
Fix bug causing the me room to appear twice in the experience display.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -161,8 +161,9 @@ public enum ExperienceManager {
                 String meGroupKey = AccountManager.instance.getMeGroupKey();
                 String meRoomKey = AccountManager.instance.getMeRoomKey();
                 result.addAll(getItemListRooms(roomKey));
-                if (!roomKey.equals(meRoomKey))
-                    result.addAll(getItemListRooms(meGroupKey));
+                if (roomKey.equals(meRoomKey) || roomKey.equals(meGroupKey))
+                    return result;
+                result.addAll(getItemListRooms(meGroupKey));
                 return result;
             default:
                 result.addAll(getItemListGroups());


### PR DESCRIPTION
# Rationale
Fix bug causing the "me" room to appear twice in the experience display.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
* getGroupListItemData(): "roomKey" is actually the me group key in the case of handling the "me" items, so compare it to the "meGroupKey" and the "meRoomKey" values to determine whether to call getItemListRooms().