### PR TITLE
Cleanup the Nav Drawer.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -99,6 +99,12 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
             case R.id.inviteFriends:
                 DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
                 break;
+            case R.id.settings:
+                showFutureFeatureMessage(R.string.MenuItemSettings);
+                break;
+            case R.id.helpAndFeedback:
+                showFutureFeatureMessage(R.string.MenuItemHelpAndFeedback);
+                break;
             default:
                 break;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -178,6 +178,12 @@ public class MainActivity extends BaseActivity
                 AppEventManager.instance.post(new NavDrawerOpenEvent(this, null));
                 AccountManager.instance.signOut(this);
                 break;
+            case R.id.switchAccount:
+                // Post a toast message indicating this is a future feature
+                String prefix = getString(R.string.MenuItemSwitchAccount);
+                String suffix = getString(R.string.FutureFeature);
+                CharSequence text = String.format(Locale.getDefault(), "%s %s", prefix, suffix);
+                Toast.makeText(this, text, Toast.LENGTH_LONG).show();
             default:
                 // Ignore everything else.
                 break;

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -75,11 +75,13 @@ http://www.gnu.org/licenses
         android:layout_marginBottom="8dp"
         android:orientation="horizontal">
         <TextView
+            android:id="@+id/switchAccount"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_weight="1.0"
-            android:text="@string/switch_account"/>
+            android:text="@string/switch_account"
+            android:onClick="onClick"/>
         <TextView
             android:id="@+id/signOut"
             android:layout_width="wrap_content"

--- a/app/src/main/res/menu/drawer_body.xml
+++ b/app/src/main/res/menu/drawer_body.xml
@@ -14,28 +14,14 @@
             </group>
         </menu>
     </item>
-    <item android:title="@string/navigation_drawer_account_management">
-        <menu>
-            <group>
-                <item
-                    android:id="@+id/manageProtectedUsers"
-                    android:title="@string/ManageRestrictedUserTitle"
-                    android:icon="@drawable/ic_verified_user_black_24dp" />
-                <item
-                    android:id="@+id/manageAccounts"
-                    android:title="@string/manage_accounts"
-                    android:icon="@drawable/vd_login_2" />
-                <item
-                    android:id="@+id/manageGroups"
-                    android:title="@string/MenuItemManageGroups"
-                    android:icon="@drawable/vd_group_black_24px"/>
-                <item
-                    android:id="@+id/manageRooms"
-                    android:title="@string/MenuItemManageRooms"
-                    android:icon="@drawable/ic_casino_black_24dp"/>
-            </group>
-        </menu>
-    </item>
+    <item
+        android:id="@+id/manageProtectedUsers"
+        android:title="@string/ManageRestrictedUserTitle"
+        android:icon="@drawable/ic_verified_user_black_24dp" />
+    <item
+        android:id="@+id/inviteFriends"
+        android:title="@string/InviteFriendNav"
+        android:icon="@drawable/ic_share_black_24dp"/>
     <group android:orderInCategory="100">
         <item android:title=""/>
         <item android:title=""/>

--- a/app/src/main/res/menu/drawer_footer.xml
+++ b/app/src/main/res/menu/drawer_footer.xml
@@ -8,8 +8,4 @@
         android:id="@+id/helpAndFeedback"
         android:title="@string/MenuItemHelpAndFeedback"
         android:icon="@drawable/vd_help_black_24px"/>
-    <item
-        android:id="@+id/inviteFriends"
-        android:title="@string/InviteFriendNav"
-        android:icon="@drawable/ic_share_black_24dp"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,10 +19,9 @@
     <string name="MenuItemHelpAndFeedback">Help &amp; Feedback</string>
     <string name="MenuItemFeedback">Feedback</string>
     <string name="MenuItemLearnMore">Learn More</string>
-    <string name="MenuItemManageGroups">Manage groups</string>
-    <string name="MenuItemManageRooms">Manage rooms</string>
     <string name="MenuItemSearch">Search</string>
     <string name="MenuItemSettings">Settings</string>
+    <string name="MenuItemSwitchAccount">Switch account</string>
     <string name="SignInMessageText">Use the \u2630 menu in the toolbar to sign in.</string>
     <string name="SignedOutToolbarTitle">Signed Out</string>
     <string name="SwitchToChat">Switch to Chat</string>
@@ -45,7 +44,6 @@
     <string name="intro_levels_message">Relaxed games for teaching and learning as well as competitive levels for serious players</string>
     <string name="intro_levels_title">Levels</string>
     <string name="intro_page_circle">\u25CF</string>
-    <string name="manage_accounts">Manage Accounts</string>
     <string name="nav_header_label_android_studio">Android Studio</string>
     <string name="nav_header_label_android_studio_android_com">android.studio@android.com</string>
     <string name="navigation_drawer_action_close">Close navigation drawer</string>


### PR DESCRIPTION
# Rationale
Many of the nav drawer menu items were not working or defunct. Remove the defunct "manage" entries, add "future feature" toast message to "Settings", "Help & feedback" and "Switch accounts". Move "invite friends" above the footer. Remove the "Account Management" group title.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* onClick(): add cases for "settings" and "help and feedback" items; in both cases, show a "future feature" toast message (which is somewhat circular for "help and feedback" but this should be addressed shortly)

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* onClick(): handle a click on 'switch account' by showing a "future feature" toast message

#### app/src/main/res/layout/nav_header_main.xml
* Add an id and onClick handler for the 'switch account' text view

#### app/src/main/res/menu/drawer_body.xml
* Remove the 'account management' group and the various unused 'manage' entries. Move 'invites friends' here. 

#### app/src/main/res/menu/drawer_footer.xml
* Remove the 'invite friends' item from the footer.

#### app/src/main/res/values/strings.xml
* Remove some now unused strings and add another.