### PR TITLE
Ensure that there is only one game per type per room.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -184,31 +184,8 @@ public enum DispatchManager {
     private Dispatcher getDispatcher(final FragmentType type, final ListItem item) {
         // Determine if the dispatcher should be generated based on the kind, in which case a
         // suitable dispatcher will be returned, otherwise set up an experience dispatcher based
-        // on the given type.
-        switch (type) {
-            case checkers:
-            case chess:
-            case tictactoe:     // Handle an experience dispatch providing a type.
-                return new Dispatcher(type);
-            case chatRoomList:
-            case createProtectedUser:
-            case createRoom:
-            case experienceList:
-            case groupMembersList:
-            case groupsForProtectedUser:
-            case joinRoom:
-            case protectedUsers:
-            case messageList:
-            case roomMembersList:
-            case selectChatGroupsRooms:
-            case selectExpGroupsRooms:
-            case selectRoom:
-            case selectUser:    // Handle a chat dispatch providing both a type and an item.
-                return new Dispatcher(type, item);
-
-            default:            // Handle all the other types in the normal fashion.
-                return getDispatcher(type.getKind());
-        }
+        // on the given type and item.
+        return item != null ? new Dispatcher(type, item) : getDispatcher(type.getKind());
     }
 
     /** Return a dispatcher object based on the current message list state. */

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -20,6 +20,7 @@ package com.pajato.android.gamechat.common;
 import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
+import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.Experience;
 
 /**
@@ -33,8 +34,8 @@ public class Dispatcher {
 
     // Public instance variables.
 
-    /** The experience target fragment type. */
-    public FragmentType expFragmentType;
+    /** The experience target type. */
+    public ExpType expType;
 
     /** The experience payload. */
     public Experience experiencePayload;
@@ -67,6 +68,13 @@ public class Dispatcher {
         if (type == null || item == null)
             return;
         switch (type) {
+            case checkers:
+            case chess:
+            case tictactoe:
+                groupKey = item.groupKey;
+                roomKey = item.roomKey;
+                key = item.key;
+                break;
             case messageList:
                 groupKey = item.groupKey;
                 roomKey = item.roomKey;
@@ -90,9 +98,9 @@ public class Dispatcher {
     }
 
     /** Build an instance providing a fragment type and a target (experience) fragment type. */
-    public Dispatcher(final FragmentType type, final FragmentType expFragmentType) {
+    public Dispatcher(final FragmentType type, final ExpType expType) {
         this.type = type;
-        this.expFragmentType = expFragmentType;
+        this.expType = expType;
         groupKey = AccountManager.instance.getMeGroupKey();
         roomKey = AccountManager.instance.getMeRoomKey();
     }

--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -143,9 +143,27 @@ public enum ExperienceManager {
 
     }
 
-    /** Return a room push key to use with a subsequent room object persistence. */
+    /** Return an experience push key to use with a subsequent room object persistence. */
     public String getExperienceKey() {
         return FirebaseDatabase.getInstance().getReference().child(EXPERIENCE_PATH).push().getKey();
+    }
+
+    /** Return null or an experience of the given type from the given group and room. */
+    public Experience getExperience(@NonNull final String groupKey, @NonNull final String roomKey,
+                                    @NonNull final ExpType expType) {
+        // Determine if there are any experiences in the given room.  If not, return null.
+        Map<String, Map<String, Experience>> groupMap = expGroupMap.get(groupKey);
+        Map<String, Experience> roomMap;
+        roomMap = groupMap != null ? groupMap.get(roomKey) : null;
+        if (roomMap == null || roomMap.size() == 0)
+            return null;
+
+        // Return the first experience of the given type in the room.  This imposes a one experience
+        // per type per room model which seems reasonable.
+        for (Experience experience : roomMap.values())
+            if (experience.getExperienceType() == expType)
+                return experience;
+        return null;
     }
 
     /** Get the data as a set of list items for all groups. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -28,6 +28,7 @@ import android.util.Log;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.Dispatcher;
@@ -40,15 +41,18 @@ import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
+import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.PlayModeChangeEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
+import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.NetworkManager;
 import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -119,7 +123,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         // Ensure that the type exists and that this is not a pass-through fragment.  In either
         // case abort.
         super.onResume();
-        if (type == null || mDispatcher == null || mDispatcher.expFragmentType != null)
+        if (type == null || mDispatcher == null || mDispatcher.expType != null)
             return;
 
         // Initialize the FAB manager, set up ads and the list adapter.
@@ -142,17 +146,14 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         // Ensure that the dispatcher and the dispatcher type exist, and ensure that this setup
         // is for a true experience fragment.  If not, then abort, otherwise use the dispatcher
         // to establish the experience to run.
-        // TODO: might be better to show a toast or snackbar on error, or even file a bug report!
         super.onSetup(context, dispatcher);
         if (dispatcher == null || dispatcher.type == null || dispatcher.type.expType == null)
             return;
-
-        // Establish the experience for this fragment to manage, creating it if necessary.
-        if (dispatcher.experiencePayload != null)
-            mExperience = dispatcher.experiencePayload;
-        else if (dispatcher.key != null)
-            mExperience = ExperienceManager.instance.experienceMap.get(dispatcher.key);
-        else
+        String groupKey = dispatcher.groupKey;
+        String roomKey = dispatcher.roomKey;
+        ExpType expType = dispatcher.expType;
+        mExperience = ExperienceManager.instance.getExperience(groupKey, roomKey, expType);
+        if (mExperience == null)
             createExperience(context, getPlayers(dispatcher));
     }
 
@@ -166,9 +167,47 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     // Protected instance methods.
 
-    /** Provide a base implementation that will result in no players, i.e. an error. */
+    /** Return a list of default two-player game players. */
+    protected List<Player> getDefaultPlayers(final Context context, final List<Account> players) {
+        // TODO: make this part of an interface implementation.
+        List<Player> result = new ArrayList<>();
+        String name = getPlayerName(getPlayer(players, 0), context.getString(R.string.player1));
+        String team = context.getString(R.string.primaryTeam);
+        result.add(new Player(name, "", team));
+        name = getPlayerName(getPlayer(players, 1), context.getString(R.string.friend));
+        team = context.getString(R.string.secondaryTeam);
+        result.add(new Player(name, "", team));
+        return result;
+    }
+
+    /** Return a possibly empty list of player information for a two-player game experience. */
     protected List<Account> getPlayers(final Dispatcher dispatcher) {
-        return null;
+        // TODO: make this an interface implementation...
+        // Determine if this is an offline experience in which no accounts are provided.
+        Account player1 = AccountManager.instance.getCurrentAccount();
+        if (player1 == null)
+            return null;
+
+        // This is an online experience.  Use the current signed in User as the first player and
+        // determine from the play mode how to get the second player.
+        List<Account> players = new ArrayList<>();
+        players.add(player1);
+        String key = dispatcher.roomKey;
+        Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
+        if (room == null || key.equals(AccountManager.instance.getMeRoomKey()))
+            return players;
+
+        // Obtain the second player from the other room...
+        switch (type) {
+            // TODO: flesh this out...
+            //case MEMBER:
+            // Handle another User by providing their account.
+            //    break;
+            default:
+                // Only one online player.  Just return.
+                break;
+        }
+        return players;
     }
 
     /** Provide a base implementation that does nothing. */
@@ -270,7 +309,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     @Override protected void onDispatch(@NonNull final Context context) {
         // Ensure that the type is valid and that the fragment is not being used as a
         // pass-through.  Abort if either is not the case, otherwise handle each possible case.
-        if (mDispatcher.type == null || mDispatcher.expFragmentType != null)
+        if (mDispatcher.type == null || mDispatcher.expType != null)
             return;
         switch (type) {
             case expRoomList:   // A room list needs an item.
@@ -395,9 +434,15 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 DispatchManager.instance.chainFragment(getActivity(), type, item);
                 break;
             case expRoom: // Show the list of experiences in a room or the one experience.
-                Map<String, Experience> map =
-                        ExperienceManager.instance.expGroupMap.get(item.groupKey).get(item.roomKey);
-                type = map.size() > 1 ? experienceList : getType(map, item);
+                Map<String, Map<String, Experience>> groupMap;
+                Map<String, Experience> roomMap;
+                String key = item.groupKey;
+                groupMap = key != null ? ExperienceManager.instance.expGroupMap.get(key) : null;
+                key = groupMap != null && item.roomKey != null ? item.roomKey : null;
+                roomMap = key != null ? groupMap.get(key) : null;
+                if (roomMap == null || roomMap.size() == 0)
+                    return;
+                type = roomMap.size() > 1 ? experienceList : getType(roomMap, item);
                 DispatchManager.instance.chainFragment(getActivity(), type, item);
                 break;
             default:
@@ -444,7 +489,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 break;
             default: // Dispatch to the game fragment ensuring chaining is coherent.
                 FragmentActivity activity = getActivity();
-                Dispatcher dispatcher = new Dispatcher(expGroupList, entry.fragmentType);
+                Dispatcher dispatcher = new Dispatcher(expGroupList, entry.fragmentType.expType);
                 DispatchManager.instance.startNextFragment(activity, dispatcher);
                 break;
         }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -133,7 +133,7 @@ public class CheckersFragment extends BaseExperienceFragment {
     @Override public void onStart() {
         // Setup the FAM, add a new game item to the overflow menu, and obtain the board.
         super.onStart();
-        mDispatcher.expFragmentType = null;
+        mDispatcher.expType = null;
         FabManager.game.setMenu(CHECKERS_FAM_KEY, getCheckersMenu());
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);
         mBoard.init(this, mTileClickHandler); // = (GridLayout) mLayout.findViewById(board);
@@ -173,45 +173,6 @@ public class CheckersFragment extends BaseExperienceFragment {
             ExperienceManager.instance.createExperience(model);
         else
             ExpHelper.reportError(this, R.string.ErrorCheckersCreation, groupKey, roomKey);
-    }
-
-    /** Return a list of default Checkers players. */
-    protected List<Player> getDefaultPlayers(final Context context, final List<Account> players) {
-        List<Player> result = new ArrayList<>();
-        String name = getPlayerName(getPlayer(players, 0), context.getString(R.string.player1));
-        String team = context.getString(R.string.primaryTeam);
-        result.add(new Player(name, "", team));
-        name = getPlayerName(getPlayer(players, 1), context.getString(R.string.friend));
-        team = context.getString(R.string.secondaryTeam);
-        result.add(new Player(name, "", team));
-        return result;
-    }
-
-    /** Return a possibly null list of player information for a checkers experience. */
-    protected List<Account> getPlayers(final Dispatcher dispatcher) {
-        // Determine if this is an offline experience in which no accounts are provided.
-        Account player1 = AccountManager.instance.getCurrentAccount();
-        if (player1 == null) return null;
-
-        // This is an online experience.  Use the current signed in User as the first player.
-        List<Account> players = new ArrayList<>();
-        players.add(player1);
-
-        // Determine the second account, if any, based on the room.
-        String key = dispatcher.roomKey;
-        Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
-        if (room == null) return players;
-
-        switch (type) {
-            //case MEMBER:
-            // Handle another User by providing their account.
-            //    break;
-            default:
-                // Only one online player.  Just return.
-                break;
-        }
-
-        return players;
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -110,13 +110,11 @@ public class ChessFragment extends BaseExperienceFragment {
             clearJoinState(mExperience.getGroupKey(), mExperience.getRoomKey(), exp);
     }
 
-    /**
-     * Handle taking the foreground by updating the UI based on the current experience.
-     */
+    /** Update the UI for the chess experience while running in the foreground. */
     @Override public void onResume() {
-        // Determine if there is an experience ready to be enjoyed.  If not, hide the layout and
-        // present a spinner.  When an experience is posted by the app event manager, the game can
-        // be shown
+        // Determine if there is an experience ready to be enjoyed.  If not, then chill out.  When
+        // an experience is posted by the app event manager, the game will be shown.  Otherwise mark
+        // the room has having been joined (active join state) and show the game.
         super.onResume();
         if (mExperience == null)
             return;
@@ -127,7 +125,7 @@ public class ChessFragment extends BaseExperienceFragment {
     @Override public void onStart() {
         // Setup the FAM, add a new game item to the overflow menu, and obtain the board.
         super.onStart();
-        mDispatcher.expFragmentType = null;
+        mDispatcher.expType = null;
         FabManager.game.setMenu(CHESS_FAM_KEY, getChessMenu());
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);
         mBoard.init(this, mTileClickHandler);
@@ -166,45 +164,6 @@ public class ChessFragment extends BaseExperienceFragment {
             ExperienceManager.instance.createExperience(model);
         else
             ExpHelper.reportError(this, R.string.ErrorCheckersCreation, groupKey, roomKey);
-    }
-
-    /** Return a list of default Chess players. */
-    protected List<Player> getDefaultPlayers(final Context context, final List<Account> players) {
-        List<Player> result = new ArrayList<>();
-        String name = getPlayerName(getPlayer(players, 0), context.getString(R.string.player1));
-        String team = context.getString(R.string.primaryTeam);
-        result.add(new Player(name, "", team));
-        name = getPlayerName(getPlayer(players, 1), context.getString(R.string.friend));
-        team = context.getString(R.string.secondaryTeam);
-        result.add(new Player(name, "", team));
-        return result;
-    }
-
-    /** Return a possibly null list of chess player information. */
-    @Override protected List<Account> getPlayers(final Dispatcher dispatcher) {
-        // Determine if this is an offline experience in which no accounts are provided.
-        Account player1 = AccountManager.instance.getCurrentAccount();
-        if (player1 == null) return null;
-
-        // This is an online experience.  Use the current signed in User as the first player.
-        List<Account> players = new ArrayList<>();
-        players.add(player1);
-
-        // Determine the second account, if any, based on the room.
-        String key = dispatcher.roomKey;
-        Room room = key != null ? RoomManager.instance.roomMap.get(key) : null;
-        if (room == null)
-            return players;
-
-        switch (type) {
-            //case MEMBER:
-            // Handle another User by providing their account.
-            //    break;
-            default:
-                // Only one online player.  Just return.
-                break;
-        }
-        return players;
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -117,7 +117,7 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
         // Ensure that this is not a pass-through to a particular experience fragment.  If not, then
         // set up the toolbar.
         super.onStart();
-        if (mDispatcher.expFragmentType == null) {
+        if (mDispatcher.expType == null) {
             int titleResId = getTitleResId();
             ToolbarManager.instance.init(this, titleResId, helpAndFeedback, chat, invite, settings);
             return;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
@@ -62,7 +62,7 @@ public class ExpShowRoomsFragment extends BaseExperienceFragment {
         // Ensure that this is not a pass-through to a particular experience fragment.  If not, then
         // initialize the FAM.
         super.onStart();
-        if (mDispatcher.expFragmentType == null) {
+        if (mDispatcher.expType == null) {
             FabManager.game.init(this);
             ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
             return;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
@@ -125,7 +125,7 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
         // Ensure that this is not a pass-through to a particular experience fragment.  If not, then
         // initialize the FAB manager and set up the toolbar.
         super.onStart();
-        if (mDispatcher.expFragmentType == null) {
+        if (mDispatcher.expType == null) {
             FabManager.game.init(this);
             ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
             return;
@@ -133,7 +133,7 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
 
         // Handle a pass through by handing to the target fragment type while leaving an item object
         // in place for a back press or exit from the experience back to the experience list display.
-        mDispatcher.type = mDispatcher.expFragmentType;
+        mDispatcher.type = mDispatcher.expType.getFragmentType();
         DispatchManager.instance.chainFragment(getActivity(), mDispatcher);
         mItem = new ListItem(expList, mDispatcher.groupKey, mDispatcher.roomKey, null, 0, null);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -184,7 +184,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     @Override public void onStart() {
         // Initialize the FAB/FAM and the toolbar.
         super.onStart();
-        mDispatcher.expFragmentType = null;
+        mDispatcher.expType = null;
         FabManager.game.setMenu(TIC_TAC_TOE_FAM_KEY, getTTTMenu());
         FabManager.game.init(this);
         ToolbarManager.instance.init(this, helpAndFeedback, settings, chat, invite);


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit ensures that only one game per type can be created in a room. The commit also fixes one drill down error.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java

- getDispatcher(): simplify one of the abusive switch handlers.

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- expFragmentType: morph to expType.
- Dispatcher(): handle the game cases for the type, item overload.
- Dispatcher(): use expType instead of expFragmentType.

modified:   app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

- getExperience(): new method to provide the first experience of a given type.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- Summary: use expType rather than expFragmentType.
- onSetup(): enforce the one experience per type rule.
- getDefaultPlayers(), getPlayers(): move to the base class as the default 2-player implementatons.
- onDispatch(): overhaul the exp room case.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java

- Summary: move getDefaultPlayers() and getPlayers() to the base class; use expType instead of expFragmentType.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java

- Summary: use expType rather than expFragmentType.