### PR TITLE
Change game FABs to only provide game restart

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
@@ -126,7 +126,7 @@ public class JoinRoomsFragment extends BaseChatFragment {
     @Override public void onResume() {
         super.onResume();
         FabManager.chat.setImage(R.drawable.ic_check_white_24dp);
-        FabManager.chat.init(this);
+        FabManager.chat.init(this, CHAT_SELECTION_FAM_KEY);
         FabManager.chat.setVisibility(this, View.VISIBLE);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static android.support.design.widget.FloatingActionButton.SIZE_MINI;
+import static android.support.design.widget.FloatingActionButton.SIZE_NORMAL;
 import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
 import static com.pajato.android.gamechat.common.FabManager.State.opened;
 
@@ -104,8 +106,8 @@ public enum FabManager {
         fab.setVisibility(View.GONE);
     }
 
-    /** Initialize the fab state. */
-    public void init(final Fragment fragment) {
+    /** Initialize the FAB. Set size to small FAB for games to small; all others use normal .*/
+    public void init(@NonNull final BaseFragment fragment) {
         // Ensure that the layout and the recycler views exist. Abort quietly if they do not.
         View layout = getFragmentLayout(fragment);
         RecyclerView recyclerView;
@@ -122,11 +124,21 @@ public enum FabManager {
         FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
         fab.setVisibility(View.VISIBLE);
+        switch (fragment.type) {
+            case chess:
+            case checkers:
+            case tictactoe:
+                setGameFAB(fragment);
+                break;
+            default:
+                setSizeNormal(fragment);
+                break;
+        }
         dismissMenu(fragment, layout);
     }
 
     /** Initialize to use the given fragment and FAM. */
-    public void init(final Fragment fragment, final String name) {
+    public void init(@NonNull final BaseFragment fragment, final String name) {
         this.init(fragment);
         mDefaultMenuName = name;
     }
@@ -139,6 +151,20 @@ public enum FabManager {
         // Cache the menu and make it the default.
         mMenuMap.put(name, menu);
         mDefaultMenuName = name;
+    }
+
+    /** Set FAB to small size */
+    public void setSizeSmall(@NonNull final Fragment fragment) {
+        View layout = getFragmentLayout(fragment);
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setSize(SIZE_MINI);
+    }
+
+    /** Set FAB to normal size */
+    public void setSizeNormal(@NonNull final Fragment fragment) {
+        View layout = getFragmentLayout(fragment);
+        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        fab.setSize(SIZE_NORMAL);
     }
 
     /** Set the FAB state. */
@@ -261,6 +287,12 @@ public enum FabManager {
         Throwable stack = new Throwable();
         Log.e(TAG, String.format(Locale.US, format, fragment), stack);
         return null;
+    }
+
+    /** Convenience method to set the FAB for a game (small size and "reset" icon) */
+    private void setGameFAB(@NonNull final BaseFragment fragment) {
+        setSizeSmall(fragment);
+        setImage(R.drawable.ic_refresh_white_24dp);
     }
 
     /** Set the current FAM using the cached item with the given name. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -32,6 +32,7 @@ import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.ExpListChangeEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.ExperienceDeleteEvent;
+import com.pajato.android.gamechat.event.ExperienceResetEvent;
 import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.Experience;
 
@@ -146,6 +147,17 @@ public enum ExperienceManager {
     /** Return a room push key to use with a subsequent room object persistence. */
     public String getExperienceKey() {
         return FirebaseDatabase.getInstance().getReference().child(EXPERIENCE_PATH).push().getKey();
+    }
+
+    /** Return the experience based on it's push key */
+    public Experience getExperience(String key) {
+        return experienceMap.get(key);
+    }
+
+    /** Update an experience in the database after its model has been reset */
+    @Subscribe void handleExperienceResetEvent(ExperienceResetEvent event) {
+        Experience experience = ExperienceManager.instance.getExperience(event.experienceKey);
+        ExperienceManager.instance.updateExperience(experience);
     }
 
     /** Get the data as a set of list items for all groups. */

--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import static com.pajato.android.gamechat.common.adapter.ListItem.DateHeaderType.old;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.date;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expList;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.experience;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.resourceHeader;
 
 /**
@@ -169,8 +170,9 @@ public enum ExperienceManager {
 
     /** Update an experience in the database after its model has been reset */
     @Subscribe void handleExperienceResetEvent(ExperienceResetEvent event) {
-        Experience experience = ExperienceManager.instance.getExperience(event.experienceKey);
-        ExperienceManager.instance.updateExperience(experience);
+        Experience experience = experienceMap.get(event.experienceKey);
+        if (experience != null)
+            ExperienceManager.instance.updateExperience(experience);
     }
 
     /** Get the data as a set of list items for all groups. */

--- a/app/src/main/java/com/pajato/android/gamechat/event/ExperienceResetEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ExperienceResetEvent.java
@@ -1,9 +1,9 @@
 package com.pajato.android.gamechat.event;
 
 /**
- * Provides an event class indicating that an experience has been deleted.
+ * Provides an event class indicating that an experience model has been reset.
  */
-public class ExperienceDeleteEvent {
+public class ExperienceResetEvent {
 
     // Public instance variables.
 
@@ -11,7 +11,7 @@ public class ExperienceDeleteEvent {
     public final String experienceKey;
 
     /** Build the event */
-    public ExperienceDeleteEvent(final String key) {
+    public ExperienceResetEvent(final String key) {
         this.experienceKey = key;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -315,8 +315,17 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 processEndIconClick(view);
                 break;
             case R.id.gameFab:
-                // If the click is on the fab, we have to handle if it's open or closed.
-                FabManager.game.toggle(this);
+                // Click on the FAB: for games, start a new game. Otherwise, handle open or close.
+                switch (this.type) {
+                    case chess:
+                    case checkers:
+                    case tictactoe:
+                        ExpHelper.handleNewGame(this.type.name(), mExperience);
+                        return; // Return here to avoid the dispatch below...
+                    default:
+                        FabManager.game.toggle(this);
+                        break;
+                }
                 break;
             case R.id.player2Name:
                 logEvent("Got a player 2 control click event.");
@@ -435,13 +444,9 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     /** Process a FAM menu entry click. */
     private void processFamItem(final MenuEntry entry, final String name) {
-        // Dismiss the FAB (assuming it was the source of the click --- being wrong is ok, and
-        // setup a new game or play a different game.
+        // Dismiss the FAB and dispatch
         FabManager.game.dismissMenu(this);
         switch(entry.titleResId) {
-            case R.string.PlayAgain: // Play a new game.
-                ExpHelper.handleNewGame(name, mExperience);
-                break;
             default: // Dispatch to the game fragment ensuring chaining is coherent.
                 FragmentActivity activity = getActivity();
                 Dispatcher dispatcher = new Dispatcher(expGroupList, entry.fragmentType);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
@@ -51,8 +51,8 @@ public class ExpHelper {
             Log.e(TAG, String.format(Locale.US, "Null %s data model.", name));
             return;
         }
-        experience.reset(getBaseFragment(experience));
-        ExperienceManager.instance.updateExperience(experience);
+        if (experience.reset(getBaseFragment(experience)))
+            ExperienceManager.instance.updateExperience(experience);
     }
 
     /** Return TRUE if this experience is in the "me" group. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
@@ -51,7 +51,7 @@ public class ExpHelper {
             Log.e(TAG, String.format(Locale.US, "Null %s data model.", name));
             return;
         }
-        experience.reset();
+        experience.reset(getBaseFragment(experience));
         ExperienceManager.instance.updateExperience(experience);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
@@ -17,6 +17,7 @@
 
 package com.pajato.android.gamechat.exp;
 
+import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.exp.model.Player;
 
 import java.util.List;
@@ -68,7 +69,7 @@ public interface Experience {
     List<String> getUnseenList();
 
     /** Reset an experience. */
-    void reset();
+    boolean reset(BaseFragment fragment);
 
     /** Set the experience push key. */
     void setExperienceKey(String key);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/State.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/State.java
@@ -60,6 +60,11 @@ public enum State {
         }
     }
 
+    /** Return TRUE if the game is "done" - either checkmate, or a winner or a tie is declared */
+    public boolean isDone() {
+        return (isWin() || isTie() || this == checkMate);
+    }
+
     /** Return TRUE iff one of the players wins. */
     public boolean isWin() {
         return this == primary_wins || this == secondary_wins;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
@@ -1,7 +1,14 @@
 package com.pajato.android.gamechat.exp.chess;
 
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.BaseFragment;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ExperienceResetEvent;
 import com.pajato.android.gamechat.exp.Board;
 import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.Experience;
@@ -196,12 +203,28 @@ import static com.pajato.android.gamechat.exp.State.active;
         }
     }
 
-    /** Set the experience key to satisfy the Experience contract. */
-    @Exclude @Override public void reset() {
-        board = new ChessBoard();
-        board.init();
-        state = active;
-        turn = true;
+    /** Reset the game after confirming with the user. */
+    @Exclude @Override public boolean reset(BaseFragment fragment) {
+        if (state.isDone()) {
+            resetModel();
+            return true;
+        }
+        final String key = this.key;
+        new AlertDialog.Builder(fragment.getActivity())
+                .setTitle(fragment.getString(R.string.ResetGameTitle))
+                .setMessage(fragment.getString(R.string.ResetGameMessage))
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface d, int id) {
+                                resetModel();
+                                AppEventManager.instance.post(new ExperienceResetEvent(key));
+                            }
+                        })
+                .create()
+                .show();
+        return false;
     }
 
     /** Set the experience key to satisfy the Experience contract. */
@@ -279,5 +302,15 @@ import static com.pajato.android.gamechat.exp.State.active;
     @Exclude @Override public boolean toggleTurn() {
         turn = !turn;
         return turn;
+    }
+
+    // Private instance methods
+
+    /** Clear the board and reset the state and turn values */
+    private void resetModel() {
+        board = new ChessBoard();
+        board.init();
+        state = active;
+        turn = true;
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -90,13 +90,13 @@ public class CheckersFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        processClickEvent(event.view, "checkers");
+        processClickEvent(event.view, this.type.name());
     }
 
     /** Handle a FAM or Snackbar click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "checkers");
+        processTagClickEvent(event, this.type.name());
     }
 
     /** Handle an experience posting event to see if this is a checkers experience. */
@@ -107,7 +107,7 @@ public class CheckersFragment extends BaseExperienceFragment {
 
     /** Handle a menu item selection. */
     @Subscribe public void onMenuItem(final MenuItemEvent event) {
-        // Delegate to the ?.
+        // Delegate to BaseExperienceFragment (super class)
         processMenuItemEvent(event);
     }
 
@@ -216,12 +216,8 @@ public class CheckersFragment extends BaseExperienceFragment {
 
     // Private instance methods.
 
-    /** Return the home FAM used in the top level show games and show no games fragments. */
+    /** Return the FAM menu (empty) - the FAB operates as a button here. */
     private List<MenuEntry> getCheckersMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        //menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        //menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_checkers));
-        return menu;
+        return new ArrayList<>();
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -82,13 +82,13 @@ public class ChessFragment extends BaseExperienceFragment {
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        processClickEvent(event.view, "chess");
+        processClickEvent(event.view, this.type.name());
     }
 
     /** Handle a FAM or Snackbar Chess click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "chess");
+        processTagClickEvent(event, this.type.name());
     }
 
     /** Handle an experience posting event to see if this is a chess experience. */
@@ -99,7 +99,7 @@ public class ChessFragment extends BaseExperienceFragment {
 
     /** Handle a menu item selection. */
     @Subscribe public void onMenuItem(final MenuItemEvent event) {
-        // Delegate to the ?.
+        // Delegate to BaseExperienceFragment (super class)
         processMenuItemEvent(event);
     }
 
@@ -209,14 +209,8 @@ public class ChessFragment extends BaseExperienceFragment {
 
     // Private instance methods.
 
-    /**
-     * Return the home FAM used in the top level show games and show no games fragments.
-     */
+    /** Return the FAM menu (empty) - the FAB operates as a button here. */
     private List<MenuEntry> getChessMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        //menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
-        //menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
-        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_chess));
-        return menu;
+        return new ArrayList<>();
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -65,7 +65,7 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
     /** Handle a FAM or Snackbar click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "chess");
+        processTagClickEvent(event, "expShowGroups");
     }
 
     /** Handle an experience list change event by dispatching again. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
@@ -48,7 +48,7 @@ public class ExpShowRoomsFragment extends BaseExperienceFragment {
     /** Handle a FAM or Snackbar click event. */
     @Subscribe public void onClick(final TagClickEvent event) {
         // Delegate the event to the base class.
-        processTagClickEvent(event, "chess");
+        processTagClickEvent(event, "expShowRooms");
     }
 
     @Override public void onResume() {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -103,7 +103,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
     /** Process a given button click event looking for one on the game fab button. */
     @Subscribe public void onClick(final ClickEvent event) {
         // Delegate the event to the base class.
-        processClickEvent(event.view, "tictactoe");
+        processClickEvent(event.view, this.type.name());
     }
 
     /** Handle a FAM or Snackbar TicTacToe click event. */
@@ -338,13 +338,9 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         return ACTIVE;
     }
 
-    /** Return the home FAM used in the top level show games and show no games fragments. */
+    /** Return the FAM menu (empty) - the FAB operates as a button here. */
     private List<MenuEntry> getTTTMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        //menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
-        //menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));
-        menu.add(getNoTintEntry(R.string.PlayAgain, R.mipmap.ic_tictactoe_red));
-        return menu;
+        return new ArrayList<>();
     }
 
     /** Handle a click on a given tile by updating the value on the tile and start the next turn. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
@@ -19,6 +19,7 @@ package com.pajato.android.gamechat.exp.model;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
+import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.exp.Board;
 import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.Experience;
@@ -221,8 +222,12 @@ import static com.pajato.android.gamechat.exp.ExpType.tttET;
         return null;
     }
 
-    /** Implement the interface by providing a nop. */
-    @Exclude @Override public void reset() {}
+    /** Always reset the game. Return true to indicate reset completed. */
+    @Exclude @Override public boolean reset(BaseFragment fragment) {
+        board = new TTTBoard();
+        state = ACTIVE;
+        return true;
+    }
 
     /** Set the experience key to satisfy the Experience contract. */
     @Exclude @Override public void setExperienceKey(final String key) {

--- a/app/src/main/res/drawable/ic_refresh_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_refresh_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -19,7 +19,7 @@
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="NoUsersFound">No Available Users</string>
-    <string name="PlayAgain">Play again</string>
+    <string name="PlayAgain">Restart Game</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
     <string name="PlayModeComputerMenuTitle">Play the computer</string>
@@ -27,6 +27,8 @@
     <string name="PlayModeUserMenuTitle">Play another user</string>
     <string name="PlayTicTacToe">Play Tic-Tac-Toe</string>
     <string name="PromotePawnMsg">Promote Your Pawn:</string>
+    <string name="ResetGameTitle">Restart Game?</string>
+    <string name="ResetGameMessage">Restarting this game will clear the board and any previous moves. Do you really want to restart this game?</string>
     <string name="SelectRoomToolbarTitle">Select Room</string>
     <string name="SelectUserToolbarTitle">Select User</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games while signed out but it is way more fun to use GameChat while signed in.</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -19,7 +19,7 @@
     <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="NoUsersFound">No Available Users</string>
-    <string name="PlayAgain">Restart Game</string>
+    <string name="PlayAgain">Play Again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
     <string name="PlayModeComputerMenuTitle">Play the computer</string>


### PR DESCRIPTION
# Rationale
* Change the FAB for games to operation as a button and restart the game.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/JoinRoomsFragment.java
* onResume(): add FAM key constant to FabManager init call for consistency

#### app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
* init(): change param type to BaseFragment so there is access to the fragment type; switch on fragment type to determine how to initialize the FAB. Game FABs use the mini size and "reset" icon.
* setSizeSmall(): convenience method to set the mini size FAB
* setSizeNormal(): convenience method to set the normal size FAB
* setGameFAB(): convenience method to set the game fab to the mini size with the "reset" icon

#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
* handleExperienceResetEvent(): handle experience reset event by updating the experience

#### app/src/main/java/com/pajato/android/gamechat/event/ExperienceDeleteEvent.java
* remove unused import

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* processClickEvent(): when the FAB is clicked, if the experience is a game type there is no menu to show - instead handle a new game. Otherwise, toggle the FAB menu.
* processFamItem(): remove the case for "play again" as this no longer appears in the FAM. Leave the switch in case something is added in the future.

#### app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
* handleNewGame(): add the fragment parameter to the experience.reset call

#### app/src/main/java/com/pajato/android/gamechat/exp/Experience.java
* reset(): change method signature to take a BaseFragment parameter and return a boolean, indicating whether the reset was completed or not.

#### app/src/main/java/com/pajato/android/gamechat/exp/State.java
* isDone(): add convenience method to cover the "done" cases

#### app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
* reset(): if the game is done, proceed with the reset. If not, show an AlertDialog for the user to confirm the reset. If the user does confirm, then reset the model and post an event so that the experience can be updated in the database.
* resetModel(): add private method to reset the values in the model

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
* onClick(): use the fragment type name rather than a hard-coded string when calling processClickEvent
* getCheckersMenu(): return an empty array list for the menu, since the FAB will now operate as a button, not a menu

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
* onClick(): use the fragment type name rather than a hard-coded string when calling processClickEvent
* getChessMenu(): return an empty array list for the menu, since the FAB will now operate as a button, not a menu

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
* onClick(): use correct name for processTagEvent

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
* onClick(): use correct name for processTagEvent

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
* onClick(): use the fragment type name rather than a hard-coded string when calling processClickEvent
* getTTTMenu(): return an empty array list for the menu, since the FAB will now operate as a button, not a menu

#### app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
* reset(): if the game is done, proceed with the reset. If not, show an AlertDialog for the user to confirm the reset. If the user does confirm, then reset the model and post an event so that the experience can be updated in the database.
* resetModel(): add private method to reset the values in the model

#### app/src/main/java/com/pajato/android/gamechat/exp/model/TicTacToe.java
* reset(): always reset the model and return true (no confirmation from user required for tic-tac-toe).

#### app/src/main/res/values/strings_exp.xml
* New strings for "restart game" confirmation dialog

## New Files
#### app/src/main/java/com/pajato/android/gamechat/event/ExperienceResetEvent.java
* Provides an event indicating that an experience has been reset and should be updated in the database

#### app/src/main/res/drawable/ic_refresh_white_24dp.xml
* New icon for the game FAB to indicate restart of the game
