### PR TITLE
Fix a bug when creating a new game.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -25,7 +25,6 @@ import com.pajato.android.gamechat.common.adapter.ListItem;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
-import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.main.NetworkManager;
 
 import java.util.HashMap;

--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -37,9 +37,6 @@ public class Dispatcher {
     /** The experience target type. */
     public ExpType expType;
 
-    /** The experience payload. */
-    public Experience experiencePayload;
-
     /** The group key. */
     public String groupKey;
 
@@ -81,8 +78,8 @@ public class Dispatcher {
                 break;
             case selectUser:
                 if (item.key != null) {
-                    experiencePayload = ExperienceManager.instance.experienceMap.get(item.key);
-                    this.type.expType = experiencePayload.getExperienceType();
+                    Experience exp = ExperienceManager.instance.experienceMap.get(item.key);
+                    this.type.expType = exp.getExperienceType();
                 }
                 break;
             case roomMembersList:

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -151,7 +151,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             return;
         String groupKey = dispatcher.groupKey;
         String roomKey = dispatcher.roomKey;
-        ExpType expType = dispatcher.expType;
+        ExpType expType = dispatcher.expType != null ? dispatcher.expType : type.expType;
         mExperience = ExperienceManager.instance.getExperience(groupKey, roomKey, expType);
         if (mExperience == null)
             createExperience(context, getPlayers(dispatcher));
@@ -494,8 +494,15 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         switch(entry.titleResId) {
             default: // Dispatch to the game fragment ensuring chaining is coherent.
                 FragmentActivity activity = getActivity();
-                Dispatcher dispatcher = new Dispatcher(expGroupList, entry.fragmentType.expType);
-                DispatchManager.instance.startNextFragment(activity, dispatcher);
+                boolean doChain;
+                doChain = type == expGroupList || type == expRoomList || type == experienceList;
+                FragmentType nextType = doChain ? entry.fragmentType : expGroupList;
+                Dispatcher dispatcher = new Dispatcher(nextType, entry.fragmentType.expType);
+                if (doChain)
+                    DispatchManager.instance.chainFragment(getActivity(), dispatcher);
+                else {
+                    DispatchManager.instance.startNextFragment(activity, dispatcher);
+                }
                 break;
         }
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -22,15 +22,12 @@ import android.support.v4.content.ContextCompat;
 import android.widget.ImageView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.model.Room;
-import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
-import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -22,15 +22,12 @@ import android.support.v4.content.ContextCompat;
 import android.widget.ImageView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.chat.model.Room;
-import com.pajato.android.gamechat.common.Dispatcher;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.database.ExperienceManager;
-import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug whereby an existing fragment was not reused.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java

- Summary: fix some AS unused import warnings.

modified:   app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java

- experiencePayload: remove: not used outside class.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- onSetup(): get the right experience type value to use to cover all cases.
- processFamItem(): redo the dispatching taking into account the fragment source.