### PR TITLE
Fix dispatching in many uses of chainFragment. Fix regression on experience buttons.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -94,10 +94,10 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                DispatchManager.instance.chainFragment(getActivity(), protectedUsers, null);
+                DispatchManager.instance.chainFragment(getActivity(), protectedUsers);
                 break;
             case R.id.inviteFriends:
-                DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
+                DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms);
                 break;
             case R.id.settings:
                 showFutureFeatureMessage(R.string.MenuItemSettings);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -81,13 +81,13 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createChatGroup, null);
+                DispatchManager.instance.chainFragment(getActivity(), createChatGroup);
                 break;
             case R.string.JoinRoomsMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), joinRoom, null);
+                DispatchManager.instance.chainFragment(getActivity(), joinRoom);
                 break;
             case R.string.InviteFriendFromChat:
-                DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms, null);
+                DispatchManager.instance.chainFragment(getActivity(), selectChatGroupsRooms);
                 break;
             case R.string.ManageRestrictedUserTitle:
                 if (AccountManager.instance.isRestricted()) {
@@ -95,7 +95,7 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                DispatchManager.instance.chainFragment(getActivity(), protectedUsers, null);
+                DispatchManager.instance.chainFragment(getActivity(), protectedUsers);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -91,7 +91,7 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createChatGroup, null);
+                DispatchManager.instance.chainFragment(getActivity(), createChatGroup);
                 break;
             case R.string.CreateRoomMenuTitle:
                 DispatchManager.instance.chainFragment(getActivity(), createRoom, mItem);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -148,7 +148,7 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
                             getUserName(), getPassword(), accountIsKnown);
                     // Dismiss the Keyboard and return to the previous fragment.
                     dismissKeyboard();
-                    DispatchManager.instance.chainFragment(getActivity(), groupsForProtectedUser, null);
+                    DispatchManager.instance.chainFragment(getActivity(), groupsForProtectedUser);
                 }
                 break;
             case email_next_button:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -34,9 +34,6 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.List;
 
-import static com.pajato.android.gamechat.R.id.create_button_finish;
-import static com.pajato.android.gamechat.R.id.emailEditText;
-import static com.pajato.android.gamechat.R.id.email_next_button;
 import static com.pajato.android.gamechat.common.FragmentType.groupsForProtectedUser;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
@@ -137,7 +134,7 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
         if (event == null || event.view == null)
             return;
         switch (event.view.getId()) {
-            case create_button_finish:
+            case R.id.create_button_finish:
             case R.id.pwd_next_button:
                 TextInputLayout mailLayout =
                         (TextInputLayout) activity.findViewById(R.id.email_layout);
@@ -151,9 +148,9 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
                     DispatchManager.instance.chainFragment(getActivity(), groupsForProtectedUser);
                 }
                 break;
-            case email_next_button:
+            case R.id.email_next_button:
                 final TextInputEditText editText =
-                        (TextInputEditText) activity.findViewById(emailEditText);
+                        (TextInputEditText) activity.findViewById(R.id.emailEditText);
                 if (isValidEmailFormat(editText.getText().toString())) {
                     setEmailError(false);
                     checkEmailAccountExists(editText.getText().toString());
@@ -226,7 +223,7 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
         ToolbarManager.instance.init(this, titleResId, helpAndFeedback, settings);
 
         final TextInputEditText editText =
-                (TextInputEditText) getActivity().findViewById(emailEditText);
+                (TextInputEditText) getActivity().findViewById(R.id.emailEditText);
         editText.addTextChangedListener(new EmailTextWatcher());
 
         final TextInputEditText passwordText =

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
@@ -89,7 +89,7 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                DispatchManager.instance.chainFragment(getActivity(), createProtectedUser, null);
+                DispatchManager.instance.chainFragment(getActivity(), createProtectedUser);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -69,7 +69,7 @@ public enum DispatchManager {
      * @param type The type of the fragment to drill into.  One will be created if necessary.
      */
     public void chainFragment(final FragmentActivity context, final FragmentType type) {
-        chainFragment(context, type, null);
+        chainFragment(context, type, new ListItem());
     }
 
     /** Chain to a fragment using the given dispatcher. */
@@ -149,26 +149,6 @@ public enum DispatchManager {
         if (type == null)
             return false;
         Dispatcher dispatcher = getDispatcher(type, null);
-        return dispatcher.type != null && startNextFragment(context, dispatcher);
-    }
-
-    /**
-     * Start the next fragment of a given type as indicated by the current app state.  The fragment
-     * type will determine the dispatch kind.
-     *
-     * @param context The activity that will attach to the next fragment.
-     * @param type The fragment type, which determines the dispatch kind.
-     * @param item A template containing payload data to pass along with the UI views.
-     *
-     * @return TRUE iff the next fragment is started.
-     */
-    public boolean startNextFragment(final FragmentActivity context, final FragmentType type,
-                                     final ListItem item) {
-        // Ensure that the dispatcher has a valid type.  Abort if not. Set up the fragment using the
-        // dispatcher if so.
-        if (type == null)
-            return false;
-        Dispatcher dispatcher = getDispatcher(type, item);
         return dispatcher.type != null && startNextFragment(context, dispatcher);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -168,6 +168,9 @@ public class ListItem {
         this.text = text;
     }
 
+    /** Build an empty list item */
+    public ListItem() {}
+
     /** Build a header instance for a given resource id. */
     public ListItem(final ItemType type, final String groupKey) {
         this.type = type;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -379,15 +379,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
         // Chain to the game experience, if one was found.
         if (expFragmentType != null) {
-            boolean doChain;
-            doChain = type == expGroupList || type == expRoomList || type == experienceList;
-            FragmentType nextType = doChain ? expFragmentType : expGroupList;
-            Dispatcher dispatcher = new Dispatcher(nextType, expFragmentType.expType);
-            if (doChain)
-                DispatchManager.instance.chainFragment(getActivity(), dispatcher);
-            else {
-                DispatchManager.instance.startNextFragment(getActivity(), dispatcher);
-            }
+            dispatchToGame(getActivity(), expFragmentType);
         }
     }
 
@@ -483,6 +475,17 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     // Private instance methods.
 
+    /** Dispatch to the indicated game fragment type */
+    private void dispatchToGame(FragmentActivity activity, FragmentType type) {
+        boolean doChain = type == expGroupList || type == expRoomList || type == experienceList;
+        FragmentType nextType = doChain ? type : expGroupList;
+        Dispatcher dispatcher = new Dispatcher(nextType, type.expType);
+        if (doChain)
+            DispatchManager.instance.chainFragment(activity, dispatcher);
+        else
+            DispatchManager.instance.startNextFragment(activity, dispatcher);
+    }
+
     /** Process the end icon click */
     private void processEndIconClick(final View view) {
         if (!(view.getTag() instanceof ListItem))
@@ -501,20 +504,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     private void processFamItem(final MenuEntry entry) {
         // Dismiss the FAB and dispatch
         FabManager.game.dismissMenu(this);
-        switch(entry.titleResId) {
-            default: // Dispatch to the game fragment ensuring chaining is coherent.
-                FragmentActivity activity = getActivity();
-                boolean doChain;
-                doChain = type == expGroupList || type == expRoomList || type == experienceList;
-                FragmentType nextType = doChain ? entry.fragmentType : expGroupList;
-                Dispatcher dispatcher = new Dispatcher(nextType, entry.fragmentType.expType);
-                if (doChain)
-                    DispatchManager.instance.chainFragment(getActivity(), dispatcher);
-                else {
-                    DispatchManager.instance.startNextFragment(activity, dispatcher);
-                }
-                break;
-        }
+        dispatchToGame(getActivity(), entry.fragmentType);
     }
 
     /** Resume the current fragment experience. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -377,8 +377,18 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 break;
         }
 
-        if (expFragmentType != null)
-            DispatchManager.instance.chainFragment(getActivity(), expFragmentType);
+        // Chain to the game experience, if one was found.
+        if (expFragmentType != null) {
+            boolean doChain;
+            doChain = type == expGroupList || type == expRoomList || type == experienceList;
+            FragmentType nextType = doChain ? expFragmentType : expGroupList;
+            Dispatcher dispatcher = new Dispatcher(nextType, expFragmentType.expType);
+            if (doChain)
+                DispatchManager.instance.chainFragment(getActivity(), dispatcher);
+            else {
+                DispatchManager.instance.startNextFragment(getActivity(), dispatcher);
+            }
+        }
     }
 
     /** Process an experience change event by ... */
@@ -409,7 +419,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             case R.string.InviteFriendsOverflow:
                 String groupKey = mExperience.getGroupKey();
                 if (isInMeGroup())
-                    DispatchManager.instance.chainFragment(activity, selectExpGroupsRooms, null);
+                    DispatchManager.instance.chainFragment(activity, selectExpGroupsRooms);
                 else
                     InvitationManager.instance.extendGroupInvitation(activity, groupKey);
                 break;
@@ -468,7 +478,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             return;
         Object tag = event.view.getTag();
         if (tag instanceof MenuEntry)
-            processFamItem((MenuEntry) tag, name);
+            processFamItem((MenuEntry) tag);
     }
 
     // Private instance methods.
@@ -488,7 +498,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     }
 
     /** Process a FAM menu entry click. */
-    private void processFamItem(final MenuEntry entry, final String name) {
+    private void processFamItem(final MenuEntry entry) {
         // Dismiss the FAB and dispatch
         FabManager.game.dismissMenu(this);
         switch(entry.titleResId) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
@@ -91,10 +91,10 @@ public class SelectUserFragment extends BaseExperienceFragment {
         MenuEntry entry = (MenuEntry) payload;
         switch (entry.titleResId) {
             case R.string.CreateGroupMenuTitle:
-                DispatchManager.instance.chainFragment(getActivity(), createExpGroup, null);
+                DispatchManager.instance.chainFragment(getActivity(), createExpGroup);
                 break;
             case R.string.InviteFriendFromChat:
-                DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms, null);
+                DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
                 break;
             case R.string.ManageRestrictedUserTitle:
                 if (AccountManager.instance.isRestricted()) {
@@ -102,7 +102,7 @@ public class SelectUserFragment extends BaseExperienceFragment {
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
-                DispatchManager.instance.chainFragment(getActivity(), protectedUsers, null);
+                DispatchManager.instance.chainFragment(getActivity(), protectedUsers);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -138,7 +138,7 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
         switch (event.item != null ? event.item.getItemId() : -1) {
             case R.string.InviteFriendsOverflow:
                 if (isInMeGroup())
-                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms, null);
+                    DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
                 else
                     InvitationManager.instance.extendGroupInvitation(getActivity(),
                             mExperience.getGroupKey());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="GridRoomIconGreen">Green room icon</string>
     <string name="HasDepartedMessage">%s has left</string>
     <string name="HasJoinedMessage">%s has joined</string>
-    <string name="InviteTitle">Invite Friends to GameChat</string>
+    <string name="InviteTitle">Invite Friends</string>
     <string name="InviteMessage">You should check out GameChat</string>
     <string name="InviteToGroupFormat">You are invited to join my GameChat group: %s</string>
     <string name="InviteFriendMessage">Invite friends</string>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -16,7 +16,7 @@
     <string name="MyExperiencesToolbarTitle">My Games</string>
     <string name="MyGameRoomToolbarTitle">My Game Room</string>
     <string name="NoExperiencesMessage">You have no experiences</string>
-    <string name="NoGamesMessageText">You have no games to view or play.  Use the button below to create one or join other rooms to play or watch ongoing games.</string>
+    <string name="NoGamesMessageText">You currently have no games. Select a game button to create one, or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="NoUsersFound">No Available Users</string>
     <string name="PlayAgain">Play Again</string>


### PR DESCRIPTION
# Rationale
Fix broken dispatching in many uses of chainFragment which is no longer tolerant of a "null" value for the ListItem parameter. Also, re-enable the click on experience buttons on the "no experience" fragment.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* onClick(): in cases with a call to chainFragment, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
* onClick(): in cases with a call to chainFragment, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
* onClick(): in the create group case, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
* onClick(): in cases with a call to chainFragment, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
* onClick(): in the case of creating a new protected user, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
* chainFragment(): provide a default (empty) ListItem object (rather than passing a null object) to prevent null pointer exception
* startNextFragment(): delete unused variant

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
* Add a default constructor

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* processClickEvent(): if an experience fragment was indicted, call dispatchToGame to handling fragment chaining
* processMenuItemEvent(): for "invite friends", use the chainFragment call that will provide a default ListItem (the 'null' param causes a null pointer exception)
* processFamItem(): Remove unused 'name' param. Refactor and move code to handle dispatch to dispatchToGame method
* dispatchToGame(): dispatch to game after providing appropriate handling of chaining

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
* onClick(): in cases with a call to chainFragment, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
* onClick(): in the 'invite friends' case, refactor to use the chainFragment call that will provide a default ListItem object (the 'null' param causes a null pointer exception)

#### app/src/main/res/values/strings.xml
* change "InviteTitle" so it won't be truncated on smaller devices

#### app/src/main/res/values/strings_exp.xml
* reword the "no games" message
