### PR TITLE
Normalize the computation of the checkerboard cell size.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -70,6 +70,8 @@ import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expLi
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.expRoom;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_OWNER_ID;
+import static com.pajato.android.gamechat.exp.ExpType.checkersET;
+import static com.pajato.android.gamechat.exp.ExpType.chessET;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.main.NetworkManager.OFFLINE_OWNER_ID;
 
@@ -97,7 +99,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     // Private instance variables.
 
     /** Visual layout of chess board objects. */
-    protected Checkerboard mBoard = new Checkerboard();
+    protected Checkerboard mBoard;
 
     /** The experience being enjoyed. */
     protected Experience mExperience;
@@ -144,17 +146,26 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     /** Handle an experience fragment setup by establishing the experience to run. */
     @Override public void onSetup(final Context context, final Dispatcher dispatcher) {
         // Ensure that the dispatcher and the dispatcher type exist, and ensure that this setup
-        // is for a true experience fragment.  If not, then abort, otherwise use the dispatcher
-        // to establish the experience to run.
+        // is for a true experience fragment.  If not, abort.
         super.onSetup(context, dispatcher);
         if (dispatcher == null || dispatcher.type == null || dispatcher.type.expType == null)
             return;
+
+        // Use the dispatcher to set up the fragment to run.  If the type is a game type, set up the
+        // checkerboard.
         String groupKey = dispatcher.groupKey;
         String roomKey = dispatcher.roomKey;
         ExpType expType = dispatcher.expType != null ? dispatcher.expType : type.expType;
-        mExperience = ExperienceManager.instance.getExperience(groupKey, roomKey, expType);
-        if (mExperience == null)
-            createExperience(context, getPlayers(dispatcher));
+        if (expType != null && (expType == chessET || expType == checkersET))
+            mBoard = new Checkerboard(context);
+
+        // Determine if an experience of the given type is available in the given room.  Use if
+        // if so, otherwise create one now.
+        if (expType != null) {
+            mExperience = ExperienceManager.instance.getExperience(groupKey, roomKey, expType);
+            if (mExperience == null && dispatcher.expType != null)
+                createExperience(context, getPlayers(dispatcher));
+        }
     }
 
     /** Handle ad setup for experience fragments. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
@@ -54,13 +54,27 @@ public class Checkerboard {
     /** The amount of vertical space allocated for the player controls. */
     private static final int CONTROLS_HEIGHT = 112;
 
-    /** The amount of vertical space allocated to the FAB control. */
-    private static final int FAB_HEIGHT= 88 + 16;
+    /**
+     * The amount of vertical space allocated to the mini FAB control, which consists of three
+     * parts: the (implicit) top margin for the FAB control, the FAB icon size and the bottom
+     * margin.
+     */
+    private static final int FAB_HEIGHT = 48 + 40 + 16;
 
     // Private instance variables.
 
+    /** The size, in pixels, of the checkerboard cells to use on this device. */
+    private int mCellSize;
+
     /** The GridLayout used to build the checkerboard UI. */
     private GridLayout mGrid;
+
+    // Public constructor.
+
+    /** Build an instance to establish the cell size for a given context. */
+    Checkerboard(final Context context) {
+        mCellSize = getCellSize(context);
+    }
 
     // Public instance methods.
 
@@ -82,9 +96,8 @@ public class Checkerboard {
         mGrid.removeAllViews();
         mGrid.setRowCount(8);
         mGrid.setColumnCount(8);
-        int cellSize = getCellSize(fragment);
         for (int i = 0; i < 64; i++) {
-            TextView currentTile = getCellView(fragment.getContext(), i, cellSize);
+            TextView currentTile = getCellView(fragment.getContext(), i, mCellSize);
             currentTile.setOnClickListener(handler);
             mGrid.addView(currentTile);
         }
@@ -140,20 +153,18 @@ public class Checkerboard {
 
     // Private instance methods.
 
-    /** Return the computed cell size based on the device size provided by the given fragment. */
-    private int getCellSize(@NonNull final BaseFragment fragment) {
+    /** Return the computed cell size based on the device size provided by the given context. */
+    private int getCellSize(@NonNull final Context context) {
         // Establish the cell size for the checkerboard.
-        DisplayMetrics metrics = fragment.getContext().getResources().getDisplayMetrics();
-        final float pxHeight = metrics.heightPixels;
-        final float pxWidth = metrics.widthPixels;
-        final int unavailableHeight = CONTROLS_HEIGHT + FAB_HEIGHT +
-                (PaneManager.instance.isTablet() ? TABLET_HEIGHT : SMART_PHONE_HEIGHT);
-        final int unavailableWidth = 32;
-        final int boardHeight = Math.round(pxHeight) - getPixels(metrics, unavailableHeight);
-        final int width = Math.round(pxWidth);
-        final int boardWidth = (PaneManager.instance.isTablet() ? width / 2 : width) -
-                getPixels(metrics, unavailableWidth);
-        return Math.min(boardWidth, boardHeight) / 8;
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        final int dipsHeight = getDips(metrics, metrics.heightPixels);
+        final int dipsWidth = getDips(metrics, metrics.widthPixels);
+        final int toolbarDps = PaneManager.instance.isTablet() ? TABLET_HEIGHT : SMART_PHONE_HEIGHT;
+        final int unavailableHeight = CONTROLS_HEIGHT + FAB_HEIGHT + toolbarDps;
+        final int boardHeight = dipsHeight - unavailableHeight;
+        final int boardWidth = (PaneManager.instance.isTablet() ? dipsWidth / 2 : dipsWidth) - 32;
+        boolean useWidth = boardHeight > boardWidth;
+        return Math.round((useWidth ? boardWidth : boardHeight) / 8) * Math.round(metrics.density);
     }
 
     /** Return a text view representing a cell at a given index of a given size. */
@@ -178,13 +189,14 @@ public class Checkerboard {
         return cellView;
     }
 
-    /** Return the number of physical pixels for a given number of device independent pixels. */
-    private int getPixels(final DisplayMetrics metrics, final int dp) {
-        return Math.round(dp * (metrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
-    }
-
     /** Set the highlight at a given position using a given color resource id. */
     private void setHighlight(Context context, int position, final int colorResId) {
         mGrid.getChildAt(position).setBackgroundColor(ContextCompat.getColor(context, colorResId));
+    }
+
+    private int getDips(final DisplayMetrics metrics, final int px) {
+        // float dp = px / (metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+        return (px * DisplayMetrics.DENSITY_DEFAULT) / metrics.densityDpi;
+
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java
@@ -132,8 +132,8 @@ public enum PaneManager {
             super.setPrimaryItem(container, position, object);
             // Walk the list of child nodes to set the size of the selected page circle icon to
             // be twice the size of an unselected page circle icon.
-            final float LARGE = 30.0f;
-            final float SMALL = 15.0f;
+            final float LARGE = 28.0f;
+            final float SMALL = 14.0f;
             int count = mPageMonitor.getChildCount();
             for (int index = 0; index < count; index++) {
                 TextView child = (TextView) mPageMonitor.getChildAt(index);


### PR DESCRIPTION
<h1>Rationale:</h1>

In the attempt to obtain a decent checkerboard size for the Nexus 7, it was clear that the computation of the basic cell size was lacking in clarity and needed to be updated to reflect the smaller "replay" icon.  This commit addresses those concerns by computing the cell size during the constructor and using a more effective approach to computing the cell size making it very clear how it works.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java

- mBoard: construct the checkerboard duing setup rather than during class loading.
- onSetup(): build the checkerboard as needed; provide safer setting of the experience for the fragment (avoiding NPEs).

modified:   app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java

- FAB_HEIGHT: adjust the size to account for a mini size FAB.
- Checkerboard(): provide a constructor to compute the cell size for a give device context.
- getCellSize(): provide more consistency by using dips throughout (until the last step); add clarity.
- getPixels(): removed: the switch to dips focus made this method obsolete.
- getDisp(); new method to support the dips focus.

modified:   app/src/main/java/com/pajato/android/gamechat/main/PaneManager.java

- Summary: tweak the size of the paging monitor.