### PR TITLE
Fix a bug encountered posting a message to the Me room.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -179,7 +179,7 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         // The account and the edit text field exist.  Persist the message to the database and
         // inform the User that the message has been sent.
         String text = editText.getText().toString();
-        String roomKey = mItem.key;
+        String roomKey = mItem.roomKey;
         Room room = RoomManager.instance.getRoomProfile(roomKey);
         MessageManager.instance.createMessage(text, STANDARD, account, room);
         editText.setText("");


### PR DESCRIPTION
<h1>Rationale:</h1>

At some point, breakage was introduced that made posting a message to oneself take an NPE.  This commit fixes that breakage.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java

- postMessage(): at some point recently, the use of "key" for the leaf in a database access was deprecated over the more corrent leaf name (room in this case.)