### PR TITLE
Add help and feedback feature. Some usability cleanup and bug fixes.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,11 @@ http://www.gnu.org/licenses
         <service android:name=".main.MainService"
             android:exported="false">
         </service>
+
+        <activity android:name=".help.HelpActivity"
+            android:theme="@style/AppTheme.NoActionBar" >
+        </activity>
+
         <service
             android:name=".main.GameChatMessagingService"
             android:exported="false">

--- a/app/src/main/assets/article_list.json
+++ b/app/src/main/assets/article_list.json
@@ -1,0 +1,16 @@
+{
+  "articles": [
+    {
+      "name": "Using Protected Users",
+      "path": "file:///android_asset/misc/protectedUsers.html"
+    },
+    {
+      "name": "Creating Groups",
+      "path": "file:///android_asset/misc/creatingGroups.html"
+    },
+    {
+      "name": "Invitations",
+      "path": "file:///android_asset/misc/invitations.html"
+    }
+  ]
+}

--- a/app/src/main/assets/misc/creatingGroups.html
+++ b/app/src/main/assets/misc/creatingGroups.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>Creating Groups</title>
+</head>
+<body style="background-color:#FFFFFF">
+<center>
+    <img src="file:///android_res/drawable/ic_launcher.png" align="BOTTOM" style="width:48px;height:48px;">
+    <h1>Creating Groups</h1>
+</center>
+<hr>
+<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
+<p>
+September 12, 1962
+<p>
+No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
+half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
+animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
+learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
+during this whole 50-year span of human history, the steam engine provided a new source of power.
+<p>
+Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
+penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
+midnight tonight.
+<p>
+This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
+vistas of space promise high costs and hardships, as well as high reward.
+<p>
+Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
+<hr>
+</body>
+</html>

--- a/app/src/main/assets/misc/invitations.html
+++ b/app/src/main/assets/misc/invitations.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>Invitations</title>
+</head>
+<body style="background-color:#FFFFFF">
+<center>
+    <img src="file:///android_res/drawable/ic_launcher.png" align="BOTTOM" style="width:48px;height:48px;">
+    <h1>Invitations</h1>
+</center>
+<hr>
+<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
+<p>
+    September 12, 1962
+<p>
+    No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
+    half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
+    animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
+    learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
+    during this whole 50-year span of human history, the steam engine provided a new source of power.
+<p>
+    Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
+    penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
+    midnight tonight.
+<p>
+    This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
+    vistas of space promise high costs and hardships, as well as high reward.
+<p>
+    Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
+<hr>
+</body>
+</html>

--- a/app/src/main/assets/misc/protectedUsers.html
+++ b/app/src/main/assets/misc/protectedUsers.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>Protected Users</title>
+</head>
+<body style="background-color:#FFFFFF">
+<center>
+    <img src="file:///android_res/drawable/ic_launcher.png" align="BOTTOM" style="width:48px;height:48px;">
+    <h1>Protected Users</h1>
+</center>
+<hr>
+<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
+<p>
+    September 12, 1962
+<p>
+    No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
+    half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
+    animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
+    learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
+    during this whole 50-year span of human history, the steam engine provided a new source of power.
+<p>
+    Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
+    penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
+    midnight tonight.
+<p>
+    This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
+    vistas of space promise high costs and hardships, as well as high reward.
+<p>
+    Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
+<hr>
+</body>
+</html>

--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.View;
+import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Group;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;
+import static com.pajato.android.gamechat.common.FragmentType.createProtectedUser;
 import static com.pajato.android.gamechat.common.FragmentType.messageList;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.chatGroup;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.chatRoom;
@@ -196,8 +198,21 @@ public abstract class BaseChatFragment extends BaseFragment {
         logEvent(String.format("onClick: (%s) with event {%s};", tag, view));
         switch (view.getId()) {
             case R.id.chatFab:
-                // It is a chat fab button.  Toggle the state.
-                FabManager.chat.toggle(this);
+                // Handle the no-menu case for protected users
+                switch (this.type) {
+                    case protectedUsers:
+                        if (AccountManager.instance.isRestricted()) {
+                            String protectedWarning = getString(R.string.CannotMakeProtectedUser);
+                            Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
+                            break;
+                        }
+                        DispatchManager.instance.chainFragment(getActivity(), createProtectedUser);
+                        break;
+                    default:
+                        // It is a chat fab button.  Toggle the state.
+                        FabManager.chat.toggle(this);
+                        break;
+                }
                 break;
             case R.id.endIcon:
             case R.id.veryEndIcon:

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -36,6 +36,7 @@ import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.MemberChangeEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
+import com.pajato.android.gamechat.help.HelpManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -90,7 +91,7 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 // Ensure that the current user is not a protected user. Then, start the process of
                 // adding a protected user.
                 if (AccountManager.instance.isRestricted()) {
-                    String protectedWarning = "Protected Users cannot make other Protected Users.";
+                    String protectedWarning = getString(R.string.CannotManageProtectedUser);
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
@@ -103,7 +104,7 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 showFutureFeatureMessage(R.string.MenuItemSettings);
                 break;
             case R.id.helpAndFeedback:
-                showFutureFeatureMessage(R.string.MenuItemHelpAndFeedback);
+                HelpManager.instance.launchHelp(getActivity());
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
@@ -17,7 +17,6 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.widget.Toast;
 
@@ -34,7 +33,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.ProfileGroupDeleteEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -91,7 +89,7 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
                 break;
             case R.string.ManageRestrictedUserTitle:
                 if (AccountManager.instance.isRestricted()) {
-                    String protectedWarning = "Protected Users cannot make other Protected Users.";
+                    String protectedWarning = getString(R.string.CannotManageProtectedUser);
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }
@@ -108,11 +106,6 @@ public class ChatShowGroupsFragment extends BaseChatFragment {
             return;
         // Case on the item resource id if there is one to be had.
         switch (event.item != null ? event.item.getItemId() : -1) {
-            case R.string.SwitchToExp:
-                // If the toolbar game icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                break;
             case R.string.MenuItemSearch:
                 showFutureFeatureMessage(R.string.MenuItemSearch);
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.chat.fragment;
 
-import android.support.v4.view.ViewPager;
-
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
 import com.pajato.android.gamechat.common.DispatchManager;
@@ -32,7 +30,6 @@ import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.ProfileRoomDeleteEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -113,11 +110,6 @@ public class ChatShowRoomsFragment extends BaseChatFragment {
             return;
         // Case on the item resource id if there is one to be had.
         switch (event.item != null ? event.item.getItemId() : -1) {
-            case R.string.SwitchToExp:
-                // If the toolbar game icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                break;
             case R.string.MenuItemSearch:
                 showFutureFeatureMessage(R.string.MenuItemSearch);
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.support.annotation.NonNull;
-import android.support.v4.view.ViewPager;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
@@ -27,8 +26,6 @@ import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
-import com.pajato.android.gamechat.event.MenuItemEvent;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -51,22 +48,6 @@ public class ChatShowSignedOutFragment extends BaseChatFragment {
         // On the first chat list change event, attempt to present another fragment based on the
         // chat list change.
         DispatchManager.instance.startNextFragment(this.getActivity(), chat);
-    }
-
-    /** Handle a menu item selection. */
-    @Subscribe public void onMenuItem(final MenuItemEvent event) {
-        if (!this.mActive)
-            return;
-        // Case on the item resource id if there is one to be had.
-        switch (event.item != null ? event.item.getItemId() : -1) {
-            case R.string.SwitchToExp:
-                // If the toolbar game icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                break;
-            default:
-                break;
-        }
     }
 
     /** Handle the setup for the groups panel. */

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
@@ -17,26 +17,21 @@
 package com.pajato.android.gamechat.chat.fragment;
 
 import android.view.View;
-import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
-import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.adapter.MenuEntry;
-import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ProtectedUserChangeEvent;
 import com.pajato.android.gamechat.event.ProtectedUserDeleteEvent;
-import com.pajato.android.gamechat.event.TagClickEvent;
 
 import org.greenrobot.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.pajato.android.gamechat.common.FragmentType.createProtectedUser;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 
@@ -67,31 +62,6 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
         switch (event.view.getId()) {
             default:
                 processClickEvent(event.view, "manageProtectedUsers");
-                break;
-        }
-    }
-
-    /**
-     * Process a FAM menu click event
-     */
-    @Subscribe
-    public void onClick(final TagClickEvent event) {
-        Object payload = event.view.getTag();
-        if (payload == null || !(payload instanceof MenuEntry)) return;
-
-        // The event represents a menu entry.  Close the FAM and case on the title id.
-        FabManager.chat.dismissMenu(this);
-        MenuEntry entry = (MenuEntry) payload;
-        switch (entry.titleResId) {
-            case R.string.CreateRestrictedUserTitle:
-                if (AccountManager.instance.isRestricted()) {
-                    String protectedWarning = "Protected Users cannot make other Protected Users.";
-                    Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
-                    break;
-                }
-                DispatchManager.instance.chainFragment(getActivity(), createProtectedUser);
-                break;
-            default:
                 break;
         }
     }
@@ -135,9 +105,7 @@ public class ManageProtectedUsersFragment extends BaseChatFragment {
 
     /** Get the FAM menu contents */
     private List<MenuEntry> getSelectionMenu() {
-        final List<MenuEntry> menu = new ArrayList<>();
-        menu.add(getTintEntry(R.string.CreateRestrictedUserTitle, R.drawable.ic_create_black_24dp));
-        return menu;
+        return new ArrayList<>();
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -20,7 +20,6 @@ package com.pajato.android.gamechat.chat.fragment;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
-import android.support.v4.view.ViewPager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
@@ -39,7 +38,6 @@ import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.ChatListChangeEvent;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -114,11 +112,6 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
             return;
         // Case on the item resource id if there is one to be had.
         switch (event.item != null ? event.item.getItemId() : -1) {
-            case R.string.SwitchToExp:
-                // If the toolbar game icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.GAME_INDEX);
-                break;
             case R.string.MenuItemSearch:
                 showFutureFeatureMessage(R.string.MenuItemSearch);
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -213,11 +213,6 @@ public abstract class BaseFragment extends Fragment {
     }
 
     /** Return a menu entry for with given title and icon resource items. */
-    protected MenuEntry getNoTintEntry(final int titleId, final int iconId) {
-        return new MenuEntry(new MenuItemEntry(MENU_ITEM_NO_TINT_TYPE, titleId, iconId));
-    }
-
-    /** Return a menu entry for with given title and icon resource items. */
     protected MenuEntry getTintEntry(final int titleId, final int iconId) {
         return new MenuEntry(new MenuItemEntry(MENU_ITEM_TINT_TYPE, titleId, iconId));
     }

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -39,6 +39,7 @@ import com.pajato.android.gamechat.main.PaneManager;
 import static android.view.Menu.NONE;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
+import static com.pajato.android.gamechat.common.FragmentType.chatRoomList;
 
 /** Provide a singleton to manage the rooms panel fab button. */
 public enum ToolbarManager {
@@ -93,8 +94,7 @@ public enum ToolbarManager {
     public enum ToolbarType {
         chatMain (R.drawable.ic_more_vert_white_24dp),
         expMain (R.drawable.ic_more_vert_white_24dp),
-
-        // Define 'standard' toolbar to have the overflow (three vertical dots) and back arrow
+        // Define 'standard' toolbars to have the overflow (three vertical dots) and back arrow
         standardBlack (R.drawable.ic_more_vert_black_24dp, R.drawable.ic_arrow_back_black_24dp),
         standardWhite (R.drawable.ic_more_vert_white_24dp, R.drawable.ic_arrow_back_white_24dp),
         none ();
@@ -247,6 +247,9 @@ public enum ToolbarManager {
             case expGroup:
                 return fragment.getString(R.string.ExpGroupsToolbarTitle);
             case chatGroup:
+                if (fragment.type == chatRoomList) {
+                    return fragment.getString(R.string.RoomsToolbarTitle);
+                }
                 return fragment.getString(R.string.ChatGroupsToolbarTitle);
             case expList:
             case expRoom:

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -117,6 +117,10 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 return new ItemListViewHolder(getView(parent, R.layout.item_with_tint));
             case groupList:
                 return new ItemListViewHolder(getView(parent, R.layout.item_select_for_invites));
+            case helpArticle:
+                return new HelpListViewHolder(getView(parent, R.layout.item_help_article));
+            case helpHeader:
+                return new HeaderViewHolder(getView(parent, R.layout.item_help_header));
             case member:
                 return new ContactViewHolder(getView(parent, R.layout.item_contact));
             case message:
@@ -152,6 +156,7 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 case date:
                 case resourceHeader:
                 case roomsHeader:
+                case helpHeader:
                     // The header item types simply update the section title.
                     int id = item.nameResourceId;
                     String name = holder.itemView.getContext().getResources().getString(id);
@@ -174,6 +179,13 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                     // The group item has to update the group title, the number of new messages,
                     // and the list of rooms with messages (possibly old).
                     updateHolder((ItemListViewHolder) holder, item);
+                    break;
+                case helpArticle:
+                    HelpListViewHolder hh = (HelpListViewHolder) holder;
+                    hh.title.setText(item.name);
+                    hh.title.setTag(item);
+                    hh.icon.setImageResource(R.drawable.content_newspaper_black_24dp);
+                    hh.icon.setTag(item);
                     break;
                 default:
                     Log.e(TAG, String.format(Locale.US, UNHANDLED_FORMAT, item.type));
@@ -291,6 +303,9 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 break;
             case groupList:
                 holder.icon.setImageResource(R.drawable.vd_group_black_24px);
+                break;
+            case helpArticle:
+                holder.icon.setImageResource(R.drawable.content_newspaper_black_24dp);
                 break;
             case protectedUserList:
                 if (item.iconUrl == null) {
@@ -460,6 +475,22 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
                 return;
             button.setVisibility(View.GONE);
             button = (Button) itemView.findViewById(R.id.altSelector);
+        }
+    }
+
+    /** Provide a view holder for a help list item */
+    private class HelpListViewHolder extends RecyclerView.ViewHolder {
+
+        // Private instance variables.
+
+        TextView title;
+        ImageView icon;
+
+        /** Build an instance given the item view. */
+        HelpListViewHolder(View itemView) {
+            super(itemView);
+            title = (TextView) itemView.findViewById(R.id.title);
+            icon = (ImageView) itemView.findViewById(R.id.ListItemIcon);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.contact;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.experience;
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.helpArticle;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.inviteRoom;
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.member;
 
@@ -85,6 +86,8 @@ public class ListItem {
         expRoom ("Exp room item with name {%s}, group, room: {%s, %s}, count: {%s}, text {%s}."),
         experience ("Experience item with group/room/exp keys {%s/%s/%s} and mode {%s}."),
         groupList("Group item with name {%s} and key: {%s}"),
+        helpArticle("Help article with name {%s} and path {%s}"),
+        helpHeader("Help header with name {%s}"),
         roomList("Room item with name {%s}, key: {%s} and group key: {%s}"),
         member ("Member item with name {%s}, key: {%s}, email: {%s} and iconUrl {%s}"),
         message ("Message item with name {%s}, key: {%s}, count: {%s} and text {%s}."),
@@ -148,7 +151,7 @@ public class ListItem {
     /** The item selection state. */
     public boolean selected;
 
-    /** The list of rooms or groups with messages to show, or the text of a message. */
+    /** The list of rooms or groups with messages to show, or the text of a message, or the path */
     public String text;
 
     /** The item type, always non-null. */
@@ -181,6 +184,13 @@ public class ListItem {
     public ListItem(final ItemType type, final int resId) {
         this.type = type;
         nameResourceId = resId;
+    }
+
+    /** Build an instance for a help article with a name and path */
+    public ListItem(final String name, final String path) {
+        this.type = helpArticle;
+        this.name = name;
+        this.text = path;
     }
 
     /** Build an instance for a member item */
@@ -288,6 +298,10 @@ public class ListItem {
                 return String.format(Locale.US, type.format, groupKey, roomKey, key, playMode);
             case groupList:
                 return String.format(Locale.US, type.format, name, groupKey);
+            case helpArticle:
+                return String.format(Locale.US, type.format, name, text);
+            case helpHeader:
+                return String.format(Locale.US, type.format, name, text);
             case roomList:
                 return String.format(Locale.US, type.format, name, roomKey, groupKey);
             case member:

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -255,7 +255,7 @@ public enum JoinManager {
         DBUtils.updateChildren(path, group.toMap());
 
         // Update the "me" room default message on the database.
-        String format = "We have created a room for %s and %s to share private messages.";
+        String format = "A room has been created for %s and %s to share private messages.";
         String accountName = account.getDisplayName();
         String memberName = member.getDisplayName();
         String text = String.format(Locale.getDefault(), format, accountName, memberName);

--- a/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
@@ -65,6 +65,8 @@ public enum JoinManager {
     public void init(final AppCompatActivity context) {
         mMessageMap.clear();
         mMessageMap.put(R.string.HasJoinedMessage, context.getString(R.string.HasJoinedMessage));
+        mMessageMap.put(R.string.JoinMemberRoomMessage,
+                context.getString(R.string.JoinMemberRoomMessage));
     }
 
     /** Join the current account holder to a room specified by a given item. */
@@ -255,7 +257,7 @@ public enum JoinManager {
         DBUtils.updateChildren(path, group.toMap());
 
         // Update the "me" room default message on the database.
-        String format = "A room has been created for %s and %s to share private messages.";
+        String format = mMessageMap.get(R.string.JoinMemberRoomMessage);
         String accountName = account.getDisplayName();
         String memberName = member.getDisplayName();
         String text = String.format(Locale.getDefault(), format, accountName, memberName);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -22,7 +22,6 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.View;
@@ -48,7 +47,6 @@ import com.pajato.android.gamechat.event.PlayModeChangeEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.NetworkManager;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -62,6 +60,7 @@ import static com.pajato.android.gamechat.common.FragmentType.chess;
 import static com.pajato.android.gamechat.common.FragmentType.expGroupList;
 import static com.pajato.android.gamechat.common.FragmentType.expRoomList;
 import static com.pajato.android.gamechat.common.FragmentType.experienceList;
+import static com.pajato.android.gamechat.common.FragmentType.noExperiences;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.FragmentType.selectUser;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
@@ -415,12 +414,6 @@ public abstract class BaseExperienceFragment extends BaseFragment {
                 else
                     InvitationManager.instance.extendGroupInvitation(activity, groupKey);
                 break;
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) activity.findViewById(R.id.viewpager);
-                if (viewPager != null)
-                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
-                break;
             default:
                 break;
         }
@@ -475,15 +468,25 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     // Private instance methods.
 
-    /** Dispatch to the indicated game fragment type */
+    /** Dispatch to the game indicated by the given type */
     private void dispatchToGame(FragmentActivity activity, FragmentType type) {
-        boolean doChain = type == expGroupList || type == expRoomList || type == experienceList;
-        FragmentType nextType = doChain ? type : expGroupList;
-        Dispatcher dispatcher = new Dispatcher(nextType, type.expType);
-        if (doChain)
+        if (this.type != noExperiences) {
+            Dispatcher dispatcher = new Dispatcher(getNextType(type), type.expType);
             DispatchManager.instance.chainFragment(activity, dispatcher);
-        else
+        }
+        else {
+            Dispatcher dispatcher = new Dispatcher(expGroupList, type.expType);
             DispatchManager.instance.startNextFragment(activity, dispatcher);
+        }
+    }
+
+    /** Determine the 'next' type for dispatch chaining */
+    private FragmentType getNextType(final FragmentType nextType) {
+        if (this.type == expGroupList)
+            return expRoomList;
+        if (this.type == expRoomList)
+            return experienceList;
+        return nextType;
     }
 
     /** Process the end icon click */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
-import android.support.v4.view.ViewPager;
-
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
@@ -30,7 +28,6 @@ import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -92,12 +89,6 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
                 else
                     InvitationManager.instance.extendGroupInvitation(getActivity(),
                             mExperience.getGroupKey());
-                break;
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null)
-                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
@@ -29,7 +29,7 @@ import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 import org.greenrobot.eventbus.Subscribe;
 
 import static com.pajato.android.gamechat.common.FragmentType.experienceList;
-import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.search;
@@ -64,7 +64,7 @@ public class ExpShowRoomsFragment extends BaseExperienceFragment {
         super.onStart();
         if (mDispatcher.expType == null) {
             FabManager.game.init(this);
-            ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
+            ToolbarManager.instance.init(this, mItem, helpAndFeedback, chat, search, invite, settings);
             return;
         }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
@@ -18,7 +18,6 @@
 package com.pajato.android.gamechat.exp.fragment;
 
 import android.support.annotation.NonNull;
-import android.support.v4.view.ViewPager;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
@@ -26,9 +25,7 @@ import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.ExperienceChangeEvent;
-import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -49,22 +46,6 @@ public class ExpShowSignedOutFragment extends BaseExperienceFragment {
     @Subscribe public void onExperienceChange(@NonNull final ExperienceChangeEvent event) {
         // An experience event has occurred.  Ensure that we are in the right fragment.
         DispatchManager.instance.startNextFragment(this.getActivity(), exp);
-    }
-
-    /** Handle a menu item selection. */
-    @Subscribe public void onMenuItem(final MenuItemEvent event) {
-        if (!this.mActive)
-            return;
-        // Case on the item resource id if there is one to be had.
-        switch (event.item != null ? event.item.getItemId() : -1) {
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
-                break;
-            default:
-                break;
-        }
     }
 
     /** Deal with the fragment's activity's lifecycle by managing the FAB. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
@@ -98,7 +98,7 @@ public class SelectUserFragment extends BaseExperienceFragment {
                 break;
             case R.string.ManageRestrictedUserTitle:
                 if (AccountManager.instance.isRestricted()) {
-                    String protectedWarning = "Protected Users cannot manage other Protected Users.";
+                    String protectedWarning = getString(R.string.CannotManageProtectedUser);
                     Toast.makeText(getActivity(), protectedWarning, Toast.LENGTH_SHORT).show();
                     break;
                 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
-import android.support.v4.view.ViewPager;
-
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
@@ -31,7 +29,6 @@ import com.pajato.android.gamechat.event.ExperienceDeleteEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -39,7 +36,7 @@ import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
-import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.game;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.search;
@@ -98,12 +95,6 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
                     InvitationManager.instance.extendGroupInvitation(getActivity(),
                             mExperience.getGroupKey());
                 break;
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null)
-                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
-                break;
             default:
                 break;
         }
@@ -127,7 +118,7 @@ public class ShowExperiencesFragment extends BaseExperienceFragment {
         super.onStart();
         if (mDispatcher.expType == null) {
             FabManager.game.init(this);
-            ToolbarManager.instance.init(this, mItem, helpAndFeedback, game, search, invite, settings);
+            ToolbarManager.instance.init(this, mItem, helpAndFeedback, chat, search, invite, settings);
             return;
         }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
@@ -17,8 +17,6 @@
 
 package com.pajato.android.gamechat.exp.fragment;
 
-import android.support.v4.view.ViewPager;
-
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
@@ -29,7 +27,6 @@ import com.pajato.android.gamechat.event.ExperienceChangeEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
 import com.pajato.android.gamechat.exp.BaseExperienceFragment;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -82,12 +79,6 @@ public class ShowNoExperiencesFragment extends BaseExperienceFragment {
                     DispatchManager.instance.chainFragment(getActivity(), selectExpGroupsRooms);
                 else
                     InvitationManager.instance.extendGroupInvitation(getActivity(), groupKey);
-                break;
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null)
-                    viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
@@ -20,7 +20,6 @@ package com.pajato.android.gamechat.exp.fragment;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
@@ -49,7 +48,6 @@ import com.pajato.android.gamechat.exp.NotificationManager;
 import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.exp.model.TTTBoard;
 import com.pajato.android.gamechat.exp.model.TicTacToe;
-import com.pajato.android.gamechat.main.PaneManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -142,11 +140,6 @@ public class TTTFragment extends BaseExperienceFragment implements View.OnClickL
                 else
                     InvitationManager.instance.extendGroupInvitation(getActivity(),
                             mExperience.getGroupKey());
-                break;
-            case R.string.SwitchToChat:
-                // If the toolbar chat icon is clicked, on smart phone devices we can change panes.
-                ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
-                if (viewPager != null) viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 break;
             default:
                 break;

--- a/app/src/main/java/com/pajato/android/gamechat/help/HelpActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/help/HelpActivity.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+package com.pajato.android.gamechat.help;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.adapter.ListAdapter;
+import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.main.SupportManager;
+
+import java.util.List;
+import java.util.Locale;
+
+import static android.support.v7.widget.LinearLayoutManager.VERTICAL;
+
+/**
+ * Provide an activity to display and manage help content.
+ */
+
+public class HelpActivity extends Activity {
+
+    /** The logcat TAG. */
+    private static final String TAG = HelpActivity.class.getSimpleName();
+
+    private String mBitmapPath;
+    private String mLogCatPath;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.help_activity);
+        ImageView image = (ImageView) findViewById(R.id.feedbackIcon);
+        image.setImageResource(R.drawable.ic_feedback_black_24dp);
+        // Save attachments in case user selects 'feedback'
+        mBitmapPath = getIntent().getStringExtra("bitmapPath");
+        mLogCatPath = getIntent().getStringExtra("logCatPath");
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateAdapterList();
+    }
+
+    /** Process a click on a given view by posting a button click event. */
+    public void onClick(final View view) {
+        switch (view.getId()) {
+            case R.id.feedbackIcon:
+            case R.id.feedbackTitle:
+                SupportManager.instance.sendFeedback(this, "GameChat Feedback",
+                        "Feedback: ", mBitmapPath, mLogCatPath);
+
+                break;
+            default:
+                // Use the Event bus to post the click event.
+                Object payload = view.getTag();
+                if (payload == null || !(payload instanceof ListItem))
+                    return;
+                ListItem clickedItem = (ListItem) payload;
+                String path = clickedItem.text;
+                Fragment fragment = HelpContentFragment.newInstance(path);
+                getFragmentManager().beginTransaction().add(android.R.id.content, fragment).
+                        addToBackStack(HelpContentFragment.class.getSimpleName()).
+                        commit();
+                break;
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (getFragmentManager().getBackStackEntryCount() > 0)
+            getFragmentManager().popBackStack();
+        else
+            super.onBackPressed();
+    }
+
+    private boolean updateAdapterList() {
+        // Determine if the fragment has a view and that it has a list type.  Abort if not,
+        // otherwise ensure that the list adapter exists, creating it if necessary.
+        View view = findViewById(R.id.helpItemList);
+        if (view == null)
+            return false;
+        RecyclerView recycler = (RecyclerView) view;
+        RecyclerView.Adapter adapter = recycler.getAdapter();
+        if (adapter == null) {
+            // Initialize the recycler view.
+            adapter = new ListAdapter();
+            recycler.setAdapter(adapter);
+            LinearLayoutManager layoutManager =
+                    new LinearLayoutManager(getBaseContext(), VERTICAL, false);
+            recycler.setLayoutManager(layoutManager);
+            recycler.setItemAnimator(new DefaultItemAnimator());
+        }
+
+        // Inject the list items into the recycler view making sure to scroll to the end of the
+        // list when showing messages.
+        ListAdapter listAdapter = (ListAdapter) adapter;
+        listAdapter.clearItems();
+        List<ListItem> items = HelpManager.instance.getList(this);
+        int size = items != null ? items.size() : 0;
+        Log.d(TAG, String.format(Locale.US, "Updating with %d items.", size));
+        listAdapter.addItems(items);
+        return true;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/help/HelpContentFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/help/HelpContentFragment.java
@@ -1,0 +1,46 @@
+package com.pajato.android.gamechat.help;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebViewFragment;
+
+/**
+ * Fragment for help content.
+ */
+public class HelpContentFragment extends WebViewFragment {
+
+    private static final String KEY_FILE = "file";
+
+    static HelpContentFragment newInstance(String file) {
+        HelpContentFragment fragment = new HelpContentFragment();
+        Bundle args = new Bundle();
+        args.putString(KEY_FILE, file);
+        fragment.setArguments(args);
+        return(fragment);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View result= super.onCreateView(inflater, container, savedInstanceState);
+        getWebView().getSettings().setJavaScriptEnabled(true);
+        getWebView().getSettings().setSupportZoom(true);
+        getWebView().getSettings().setBuiltInZoomControls(true);
+        getWebView().loadUrl(getPage());
+        return(result);
+    }
+
+    private String getPage() {
+        return(getArguments().getString(KEY_FILE));
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/help/HelpManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/help/HelpManager.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
+package com.pajato.android.gamechat.help;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.View;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.main.NavigationManager;
+import com.pajato.android.gamechat.main.SupportManager;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.helpHeader;
+
+/** Provide a singleton to manage the help content. */
+public enum HelpManager {
+    instance;
+
+    /** The logcat TAG. */
+    private static final String TAG = HelpManager.class.getSimpleName();
+
+    /** Constructor */
+    HelpManager() {}
+
+    /** Launch the help activity by first insuring the nav drawer and/or menu are closed. */
+    public void launchHelp(final FragmentActivity activity) {
+        // Close whichever menu started this
+        Toolbar toolbar = (Toolbar) activity.findViewById(R.id.toolbar);
+        if (toolbar.isOverflowMenuShowing())
+            toolbar.hideOverflowMenu();
+        if (NavigationManager.instance.isDrawerOpen(activity)) {
+            final DrawerLayout drawerLayout = (DrawerLayout) activity.findViewById(R.id.drawer_layout);
+            drawerLayout.addDrawerListener(new DrawerLayout.DrawerListener() {
+                @Override
+                public void onDrawerSlide(View drawerView, float slideOffset) {}
+
+                @Override
+                public void onDrawerOpened(View drawerView) {}
+
+                @Override
+                public void onDrawerClosed(View drawerView) {
+                    drawerLayout.removeDrawerListener(this);
+                    // When the drawer is closed, take the screenshot
+                    startHelpAndFeedback(activity);
+                }
+
+                @Override
+                public void onDrawerStateChanged(int newState) {}
+            });
+            NavigationManager.instance.closeDrawerIfOpen(activity);
+        } else
+            startHelpAndFeedback(activity);
+    }
+
+    /** Perform a capture of the current screen, get logcat and send both to help activity. */
+    private void startHelpAndFeedback(final Activity activity) {
+        // Grab the logcat output to send to the help activity
+        String logCatPath = SupportManager.instance.getLogcatPath(activity);
+        // Capture the screen and to send to the help activity.
+        View rootView = activity.getWindow().getDecorView().getRootView();
+        rootView.setDrawingCacheEnabled(false); // clear any previous cached data
+        rootView.destroyDrawingCache();
+        rootView.setDrawingCacheEnabled(true); // start over
+        String bitmapPath =
+                SupportManager.instance.getBitmapPath(rootView.getDrawingCache(), activity);
+        Intent intent = new Intent(activity, HelpActivity.class);
+        intent.putExtra("bitmapPath", bitmapPath);
+        intent.putExtra("logCatPath", logCatPath);
+        activity.startActivity(intent);
+    }
+
+    /** Get list items for help activity display */
+    public List<ListItem> getList(Activity activity) {
+        List<ListItem> items = new ArrayList<>();
+        items.add(new ListItem(helpHeader, R.string.HelpMostPopularTitle));
+        items.addAll(getMostPopularArticles(activity));
+        items.add(new ListItem(helpHeader, R.string.HelpRecentTitle));
+        items.addAll(getRecentArticles(activity));
+        items.add(new ListItem(helpHeader, R.string.HelpAllTitle));
+        items.addAll(getAllArticles(activity));
+        return items;
+    }
+
+    /** Get a list of all help articles */
+    private List<ListItem> getAllArticles(Activity activity) {
+        List<ListItem> articlesList = new ArrayList<>();
+        // Read list of articles from JSON list
+        try {
+            String inputText = loadJSONFromAsset("article_list.json", activity);
+            JSONObject inputJson = new JSONObject(inputText);
+            JSONArray jsonArray = inputJson.getJSONArray("articles");
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject article = (JSONObject) jsonArray.get(i);
+                article.get("name");
+                article.get("path");
+                articlesList.add(new ListItem((String)article.get("name"), (String)article.get("path")));
+            }
+        } catch (JSONException e){
+            Log.e(TAG, "Error reading JSON");
+        }
+        return articlesList;
+    }
+
+    /** Get a list of popular articles - TODO: how to get popular? (Future feature) */
+    private List<ListItem> getMostPopularArticles(Activity activity) {
+        List<ListItem> articlesList = new ArrayList<>();
+        // Read list of articles from JSON list
+        try {
+            String inputText = loadJSONFromAsset("article_list.json", activity);
+            JSONObject inputJson = new JSONObject(inputText);
+            JSONArray jsonArray = inputJson.getJSONArray("articles");
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject article = (JSONObject) jsonArray.get(i);
+                article.get("name");
+                article.get("path");
+                articlesList.add(new ListItem((String)article.get("name"), (String)article.get("path")));
+            }
+        } catch (JSONException e){
+            Log.e(TAG, "Error reading JSON");
+        }
+        return articlesList;
+    }
+
+    /** Get a list of recent articles - TODO: how to get recent? (Future feature) */
+    private List<ListItem> getRecentArticles(Activity activity) {
+        List<ListItem> articlesList = new ArrayList<>();
+        // Read list of articles from JSON list
+        try {
+            String inputText = loadJSONFromAsset("article_list.json", activity);
+            JSONObject inputJson = new JSONObject(inputText);
+            JSONArray jsonArray = inputJson.getJSONArray("articles");
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject article = (JSONObject) jsonArray.get(i);
+                article.get("name");
+                article.get("path");
+                articlesList.add(new ListItem((String)article.get("name"), (String)article.get("path")));
+            }
+        } catch (JSONException e){
+            Log.e(TAG, "Error reading JSON");
+        }
+        return articlesList;
+    }
+
+    /** Read JSON data from specified file */
+    private String loadJSONFromAsset(String fileName, Activity activity) {
+        String json = null;
+        InputStream inputStream = null;
+        try {
+            inputStream = activity.getAssets().open(fileName);
+            int size = inputStream.available();
+            byte[] buffer = new byte[size];
+            int readSize = inputStream.read(buffer);
+            Log.i(TAG, "Read " + readSize + " from " + fileName);
+            json = new String(buffer, "UTF-8");
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (inputStream != null)
+                    inputStream.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return json;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -17,13 +17,9 @@
 
 package com.pajato.android.gamechat.intro;
 
-import android.animation.ObjectAnimator;
-import android.animation.StateListAnimator;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.database.DataSetObserver;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v4.view.PagerAdapter;
@@ -95,17 +91,9 @@ public class IntroActivity extends AppCompatActivity {
     }
     /** Create the intro activity to highlight some features and provide a get started operation. */
     @Override protected void onCreate(final Bundle savedInstanceState) {
-        // Establish the activity state and set up the intro layout enhancing the experience for
-        // Lollipop and follow on devices by enabling elevated animation.
+        // Establish the activity state and set up the intro layout
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_intro);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            final StateListAnimator animator = new StateListAnimator();
-            final TextView button = (TextView) findViewById(R.id.register_button);
-            addState(animator, android.R.attr.state_pressed, button, 2.0f, 4.0f);
-            addState(animator, -1, button, 4.0f, 2.0f);
-            button.setStateListAnimator(animator);
-        }
 
         // Set up icon switching animation.
         ImageView topImage1 = (ImageView) findViewById(R.id.icon_image1);
@@ -124,18 +112,6 @@ public class IntroActivity extends AppCompatActivity {
     }
 
     // Private instance methods.
-
-    /** Add an animation state to a given state list animator.  Only called on Lollipop. */
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void addState(final StateListAnimator animator, final int viewStateId, final View view,
-                          final float... heights) {
-        // Animate the Z property on the given view over the given heights for 200 milliseconds.
-        final int DURATION = 200;
-        final String PROP = "z";
-        int [] viewState = viewStateId != -1 ? new int[] {viewStateId} : new int[] {};
-        ObjectAnimator viewAnimator = ObjectAnimator.ofFloat(view, PROP, heights);
-        animator.addState(viewState, viewAnimator.setDuration(DURATION));
-    }
 
     /** Finish the intro screen and handle the given mode in a new activity. */
     private Intent getAuthIntent(final String mode) {

--- a/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
@@ -62,12 +62,16 @@ public enum NavigationManager {
     /** Return true iff the navigation drawer was open and is now closed. */
     public boolean closeDrawerIfOpen(final Activity activity) {
         DrawerLayout drawer = (DrawerLayout) activity.findViewById(R.id.drawer_layout);
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
+        if (isDrawerOpen(activity)) {
             drawer.closeDrawer(GravityCompat.START);
             return true;
         }
-
         return false;
+    }
+
+    public boolean isDrawerOpen(final Activity activity) {
+        DrawerLayout drawer = (DrawerLayout) activity.findViewById(R.id.drawer_layout);
+        return drawer.isDrawerOpen(GravityCompat.START);
     }
 
     /** Initialize the navigation drawer. Only used for 'chatMain' toolbar type.*/

--- a/app/src/main/res/drawable/content_newspaper_black_24dp.xml
+++ b/app/src/main/res/drawable/content_newspaper_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20 2.001l-17 0c-0.553 0 -1 0.448 -1 1l0 18c0 0.552 0.447 1 1 1l17 0c0.553 0 1 -0.448 1 -1l0 -18c0 -0.551 -0.447 -1 -1 -1zm-9 17l-6 0 0 -2 6 0 0 2zm0 -3l-6 0 0 -2 6 0 0 2zm0 -2.999l-6 0 0 -2 6 0 0 2zm7 5.999l-6 0 0 -2 6 0 0 2zm0 -3l-6 0 0 -2 6 0 0 2zm0 -2.999l-6 0 0 -2 6 0 0 2zm0 -5l-13 0 0 -3 13 0 0 3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_feedback_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_feedback_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM13,14h-2v-2h2v2zM13,10h-2L11,6h2v4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -59,20 +59,9 @@ http://www.gnu.org/licenses
         android:layout_marginRight="10dp"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="16sp"
-            android:text="@string/signInButtonText"
-            android:gravity="center"
-            android:paddingLeft="20dp"
-            android:paddingRight="20dp"
-            android:paddingTop="10dp"
-            android:paddingBottom="10dp"
-            android:id="@+id/register_button"/>
-
         <Button
             style="@style/IntroTheme.Button"
+            android:id="@+id/introSignInButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:onClick="doSignIn"

--- a/app/src/main/res/layout/chat_signed_out.xml
+++ b/app/src/main/res/layout/chat_signed_out.xml
@@ -26,16 +26,24 @@ http://www.gnu.org/licenses
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/emptyListMessage"
-        android:padding="24dp"
+        android:padding="32dp"
         android:text="@string/ChatSignedOutMessageText"
         android:textAlignment="center"
         android:textSize="24sp" />
-    <TextView
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/emptyListMessage2"
-        android:text="@string/SignInMessageText"
-        android:padding="24dp"
-        android:textAlignment="center"
-        android:textSize="24sp" />
+        android:layout_weight="10"
+        android:paddingTop="20dp">
+        <Button
+            style="@style/IntroTheme.Button"
+            android:id="@+id/signIn"
+            android:layout_centerHorizontal="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onClick"
+            android:text="@string/sign_in"/>
+
+    </RelativeLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/help_activity.xml
+++ b/app/src/main/res/layout/help_activity.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2017 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.pajato.android.gamechat.help.HelpActivity">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:id="@+id/topLayout"
+        android:layout_marginTop="8dp">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/gcIcon"
+            android:contentDescription="@string/app_name"
+            android:layout_centerHorizontal="true"
+            android:src="@drawable/ic_launcher"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/helpTitle"
+            android:text="@string/HelpTitle"
+            android:textSize="20sp"
+            android:layout_marginTop="10dp"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/gcIcon"
+            android:textColor="@color/tw__composer_black"
+            android:textStyle="bold" />
+
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_below="@id/helpTitle"
+            android:layout_margin="8dp"
+            android:background="#FF0000FF" />
+    </RelativeLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/helpItemList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/topLayout"
+        android:layout_above="@+id/divider1"
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="8dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:id="@+id/divider1"
+        android:layout_above="@+id/feedbackIcon"
+        android:layout_margin="8dp"
+        android:background="#FF0000FF" />
+
+    <ImageView
+        android:id="@+id/feedbackIcon"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_gravity="center"
+        android:layout_marginStart="16dp"
+        android:layout_alignParentBottom="true"
+        app:srcCompat="@drawable/ic_feedback_black_24dp"
+        android:layout_marginBottom="10dp"
+        android:contentDescription="@string/ListItemIconDesc"
+        android:onClick="onClick"
+        android:tint="@color/colorPrimaryDark" />
+
+    <TextView
+        android:id="@+id/feedbackTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="36dp"
+        android:gravity="center_vertical"
+        android:layout_toEndOf="@+id/feedbackIcon"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="10dp"
+        android:layout_marginBottom="10dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:onClick="onClick"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        android:text="@string/SendFeedback" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/item_help_article.xml
+++ b/app/src/main/res/layout/item_help_article.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+Copyright (C) 2017 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="1dp"
+        android:layout_marginTop="1dp"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/ListItemIcon"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_gravity="center"
+            android:layout_marginStart="16dp"
+            android:contentDescription="@string/ListItemIconDesc"
+            android:onClick="onClick"
+            android:tint="@color/colorPrimaryDark" />
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:onClick="onClick"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            tools:text="Help article title" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_gravity="center"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="@android:color/darker_gray" />
+</LinearLayout>
+
+

--- a/app/src/main/res/layout/item_help_header.xml
+++ b/app/src/main/res/layout/item_help_header.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2017 Pajato Technologies LLC.
+
+This file is part of Pajato GameChat.
+
+GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with GameChat.  If not, see
+http://www.gnu.org/licenses
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+    <TextView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:textSize="16sp"
+        android:textColor="@color/tw__composer_black"
+        android:textStyle="bold"
+        tools:text="Header Title"/>
+</LinearLayout>

--- a/app/src/main/res/layout/item_select_for_invites.xml
+++ b/app/src/main/res/layout/item_select_for_invites.xml
@@ -20,7 +20,7 @@
             <TextView style="@style/ListItemTitle" android:id="@+id/Name"
                 android:ellipsize="end"
                 android:maxLines="1"
-                tools:text="My Group Name"/>
+                tools:text="@string/YourGroupTitle"/>
         </LinearLayout>
     </LinearLayout>
     <View style="@style/ListItemFooter" />

--- a/app/src/main/res/layout/item_select_user.xml
+++ b/app/src/main/res/layout/item_select_user.xml
@@ -25,7 +25,7 @@
             <TextView style="@style/ListItemSubtitle" android:id="@+id/Text"
                 android:ellipsize="end"
                 android:maxLines="1"
-                tools:text="My Group Name"/>
+                tools:text="@string/YourGroupTitle"/>
         </LinearLayout>
     </LinearLayout>
     <View style="@style/ListItemFooter" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,13 +35,13 @@
     <string name="facebook_application_id" translatable="false">477157459160674</string>
     <!-- Facebook Application ID, prefixed by 'fb'.  Enables Chrome Custom tabs. -->
     <string name="facebook_login_protocol_scheme" translatable="false">fb477157459160674</string>
-    <string name="intro_chat_message">Public private secure messaging with any Google user</string>
+    <string name="intro_chat_message">Public, private, and secure messaging</string>
     <string name="intro_chat_title">Chat</string>
-    <string name="intro_game_message">Play popular well known games with other GameChat users or against the computer</string>
+    <string name="intro_game_message">Play games with GameChat members or against the computer</string>
     <string name="intro_game_title">Game</string>
     <string name="intro_home_message">Chat and play games with friends and family</string>
     <string name="intro_home_title">GameChat</string>
-    <string name="intro_levels_message">Relaxed games for teaching and learning as well as competitive levels for serious players</string>
+    <string name="intro_levels_message">Relaxed levels for teaching and learning. Competitive levels for serious players.</string>
     <string name="intro_levels_title">Levels</string>
     <string name="intro_page_circle">\u25CF</string>
     <string name="nav_header_label_android_studio">Android Studio</string>
@@ -57,7 +57,6 @@
     <string name="switch_account">\u25bc Switch account</string>
     <string name="me">me</string>
     <string name="OfflineMessageText">The network is not available.  You can continue to play games while offline.</string>
-    <string name="signInButtonText">Sign in to teach, learn and have fun with friends and family.</string>
     <string name="SignInFailedFormat">The email/password sign in using {%s} failed.</string>
     <string name="SignedOutTitleText">Signed Out</string>
 </resources>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -48,6 +48,7 @@
     <string name="JoinedGroupsMessage">You have joined group %s</string>
     <string name="JoinedOneRoom">You have joined the %1$s room in group %2$s</string>
     <string name="JoinedMultiRooms">You have joined rooms: %1$s in group %2$s</string>
+    <string name="JoinMemberRoomMessage">A room has been created for %1$s and %2$s to share private messages.</string>
     <string name="JoinRoomsMenuTitle">Join Rooms</string>
     <string name="MembersAvailableHeaderText">Members</string>
     <string name="MembersNotAvailableHeaderText">No Available Members</string>

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -5,6 +5,8 @@
     <string name="ButtonNext">NEXT</string>
     <string name="ButtonFinish">FINISH</string>
     <string name="ChatGroupsToolbarTitle">Groups with Messages</string>
+    <string name="CannotMakeProtectedUser">Protected Users cannot create other Protected Users</string>
+    <string name="CannotManageProtectedUser">Protected Users cannot manage other Protected Users</string>
     <string name="ClearSelectionsMenuTitle">Clear Selections</string>
     <string name="CreateGroupMenuTitle">Create Group</string>
     <string name="CreateGroupNameHint">Type group name</string>Title">
@@ -12,7 +14,7 @@
     <string name="CreateRoomNameHint">Type room name</string>
     <string name="CreateRoomPrivate">Private</string>
     <string name="CreateRoomPublic">Public</string>
-    <string name="ChatSignedOutMessageText">GameChat is much more fun when you can chat with your family and friends.</string>
+    <string name="ChatSignedOutMessageText">Sign in to chat with your family and friends.</string>
     <string name="ChatTitle">Chat</string>
     <string name="DefaultRoomName">Common</string>
     <string name="DeleteConfirmMessage">Do you want to delete %s?</string>
@@ -25,7 +27,11 @@
     <string name="Group">Group</string>
     <string name="GroupExistsMessage">You already have a group named %s. Do you want to continue anyway?</string>
     <string name="GroupExistsTitle">Group %s already exists!</string>
-    <string name="GroupMeToolbarTitle">My Chat Room</string>
+    <string name="GroupMeToolbarTitle">Your Chat Room</string>
+    <string name="HelpTitle">GameChat Help</string>
+    <string name="HelpMostPopularTitle">Most Popular</string>
+    <string name="HelpRecentTitle">Recently Viewed</string>
+    <string name="HelpAllTitle">Browse All Articles</string>
     <string name="LeaveConfirmMessage">Do you want to leave %s?</string>
     <string name="LeaveGroupTitle">Leave Group?</string>
     <string name="LeaveRoomTitle">Leave Room?</string>
@@ -69,11 +75,13 @@
     <string name="SelectRoomsMenuTitle">Select All Rooms</string>
     <string name="SetCreateIconFeature">Setting the create group or room icon</string>
     <string name="SetCreateIconDesc">Set the group or room icon</string>
+    <string name="SendFeedback">Send feedback</string>
     <string name="TakePicture">Inserting a picture using your camera</string>
     <string name="TakePictureDesc">Take a camera picture image button.</string>
     <string name="TakeVideo">Inserting a video from your camera</string>
     <string name="TakeVideoDesc">Take a video image button.</string>
     <string name="UserNameHint">First and Last Name</string>
     <string name="WelcomeMessageText">Welcome to your private messages. Use this space to take notes and stash files. Enjoy!</string>
+    <string name="YourGroupTitle">Your Group Name</string>
     <string name="editMessageHint">Type a message</string>
 </resources>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -13,10 +13,10 @@
     <string name="InviteFriendFromChat">Invite friends</string>
     <string name="InviteFriendNav">Invite friends</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
-    <string name="MyExperiencesToolbarTitle">My Games</string>
-    <string name="MyGameRoomToolbarTitle">My Game Room</string>
+    <string name="MyExperiencesToolbarTitle">Your Games</string>
+    <string name="MyGameRoomToolbarTitle">Your Game Room</string>
     <string name="NoExperiencesMessage">You have no experiences</string>
-    <string name="NoGamesMessageText">You currently have no games. Select a game button to create one, or join other rooms to play or watch ongoing games.</string>
+    <string name="NoGamesMessageText">Select a game button to create a game, or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="NoUsersFound">No Available Users</string>
     <string name="PlayAgain">Play Again</string>


### PR DESCRIPTION
# Rationale
This pull request includes:
* Add the "help and feedback" feature. Add placeholder text for help topics. "Recently Viewed" and "Most Popular" are future feature place-holders.
* After reviewing Android developer's pages on help (https://developer.android.com/design/patterns/help.html and https://material.io/guidelines/style/writing.html), make some updates on text. Fix various bugs encountered during debug.
* Change the "Create Protected Users" so it is the single action on the "manage protected users" fragment FAB (remove the FAB menu in this case)
* Move handling of help-and-feedback, switch-to-experience and switch-to-chat toolbar menu buttons to MainActivity to consolidate code

## Files Changed
#### app/src/main/AndroidManifest.xml
* Add new help activity to manifest

#### app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
* processClickEvent(): add case for chat FAB to create protected users

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
* onClick(): use string resource for "cannot create protected user" message and add call to HelpManager to handle "help and feedback" selection

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowGroupsFragment.java
* onClick(): use string resource for "cannot create protected user" message
* onMenItem(): move handling of switch-to-experience to the MainActivity

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowRoomsFragment.java
* onMenItem(): move handling of switch-to-experience to the MainActivity

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatShowSignedOutFragment.java
* onMenItem(): move handling of switch-to-experience to the MainActivity which enables removing this method completely

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ManageProtectedUsersFragment.java
* onClick(): remove; for this fragment, the FAB doesn't have a menu, and the handling is now in ChatEnvelopeFragment
* getSelectionMenu(): the FAB doesn't have a menu in this case, so just return an empty array list

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
* onMenItem(): move handling of switch-to-experience to the MainActivity

#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* getNoTintEntry(): remove unused method

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* getTitle(): in the case where the item is a chatGroup, also check for the fragment type and set the appropriate title for rooms versus groups

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* onCreateViewHolder(): add cases for new helpArticle and helpHeader item types
* onBindViewHolder(): add cases for helpHeader and helpArticle
* setIcon(): add case for helpArticle to set "content newspaper" icon
* HelpListViewHolder: new class for handling help articles

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
* Add helpArticle and helpHeader types
* Add a constructor to support helpArticle
* getDescription(): add cases for helpArticle and helpHeader

#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* joinMember(): improve text in message and make it a string resource

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity
* dispatchToGame(): fix bug in handing of dispatch for games
* getNextType(): add helper method to determine 'next' type for game dispatch

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity which enables removing this method completely

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowRoomsFragment.java
* onStart(): fix bug in toolbar setup (switch-to-experience should be switch-to-chat for overflow menu)

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowSignedOutFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity which enables removing this method completely

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/SelectUserFragment.java
* onClick(): use string resource for "cannot manage protected user" message

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowExperiencesFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity which enables removing this method completely
* onStart(): fix bug in toolbar setup (switch-to-experience should be switch-to-chat for overflow menu)

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ShowNoExperiencesFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity which enables removing this method completely

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/TTTFragment.java
* onMenItem(): move handling of switch-to-chat to the MainActivity which enables removing this method completely

#### app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
* onCreate(): remove extraneous text from intro screen and the related but not used animator code
* addState(): remove unused method

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* onMenuItem(): add cases for help-and-feedback, switch-to-experience and switch-to-chat.
* getAbout(), getBitmapPath(), getLogcatPath(), handleBugReport(): move to SupportManager

#### app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java
* isDrawerOpen(): add public method to determine if nav drawer is open

#### app/src/main/java/com/pajato/android/gamechat/main/SupportManager.java
* sendFeedback(): remove two unused variants of this method; add new version to handle screen bitmap and logcat file paths as params which are used as intent extras
* getAbout(), getBitmapPath(), getLogcatPath(), handleBugReport(): moved here from MainActivity

#### app/src/main/res/layout/activity_intro.xml
* Remove no-longer-used text view and add id to sign-in button

#### app/src/main/res/layout/chat_signed_out.xml
* Add button to let user click directly to sign in, rather than a text view stating how to find a button to sign in

#### app/src/main/res/layout/item_select_for_invites.xml
* Make group name text a string resource and change "My" to "Your" per Google instructions

#### app/src/main/res/layout/item_select_user.xml
* Make group name text a string resource and change "My" to "Your" per Google instructions

#### app/src/main/res/values/strings.xml
* Various text change based on Google guidelines; remove unused "signInButtonText"

#### app/src/main/res/values/strings_chat.xml
* Various text change based on Google guidelines; add new strings

#### app/src/main/res/values/strings_exp.xml
* Various text change based on Google guidelines

## New Files
#### app/src/main/assets/article_list.json
* A JSON text source which contains information about help articles and the path to find them

#### app/src/main/assets/misc/creatingGroups.html
* Placeholder text for help topic on creating groups

#### app/src/main/assets/misc/invitations.html
* Placeholder text for help topic on invitation

#### app/src/main/assets/misc/protectedUsers.html
* Placeholder text for help topic on protected users

#### app/src/main/java/com/pajato/android/gamechat/help/HelpActivity.java
* New activity to manage help and feedback feature

#### app/src/main/java/com/pajato/android/gamechat/help/HelpContentFragment.java
* New fragment to show a help topic

#### app/src/main/java/com/pajato/android/gamechat/help/HelpManager.java
* New class to manage the 'help' feature

#### app/src/main/res/drawable/content_newspaper_black_24dp.xml
* new icon for help article

#### app/src/main/res/drawable/ic_feedback_black_24dp.xml
* new icon for "feedback"

#### app/src/main/res/layout/help_activity.xml
* New layout for help activity

#### app/src/main/res/layout/item_help_article.xml
* New layout for help article

#### app/src/main/res/layout/item_help_header.xml
* New layout for help header
