### PR TITLE
Fix some bugs in experience traversal.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
@@ -79,6 +79,10 @@ public class Dispatcher {
                 key = item.roomKey;
                 roomKey = item.roomKey;
                 break;
+            case experienceList:
+                groupKey = item.groupKey;
+                roomKey = item.roomKey;
+                break;
             default:
                 groupKey = item.groupKey;
                 roomKey = item.key;

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -251,8 +251,11 @@ public enum ToolbarManager {
                     return fragment.getString(R.string.RoomsToolbarTitle);
                 }
                 return fragment.getString(R.string.ChatGroupsToolbarTitle);
-            case expList:
             case expRoom:
+                if (AccountManager.instance.isMeGroup(item.groupKey))
+                    return fragment.getString(R.string.MyExperiencesToolbarTitle);
+                return fragment.getString(R.string.ExpRoomsToolbarTitle);
+            case expList:
                 // Determine if the group is the me group and give it special handling.
                 if (AccountManager.instance.isMeGroup(item.groupKey))
                     return fragment.getString(R.string.MyExperiencesToolbarTitle);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -81,6 +81,8 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
 
     /** Add items to the adapter's main list. */
     public void addItems(final List<ListItem> items) {
+        if (items == null)
+            return;
         // Add all the items after clearing the current ones.
         mList.addAll(items);
         notifyDataSetChanged();

--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -336,7 +336,7 @@ public enum ExperienceManager {
         return result;
     }
 
-    /** Return a list of experience group items. */
+    /** Return a list of experience group items, excluding the 'me' group */
     private List<ListItem> getItemListGroups() {
         // Generate a list of items to render in the group list by extracting the items based
         // on the date header type ordering.
@@ -365,20 +365,27 @@ public enum ExperienceManager {
         return accountId == null || unseenList == null || unseenList.contains(accountId);
     }
 
-    /** Process all the headers for a given map to determine */
+    /** Process all headers and associated items for a given map. Exclude the 'me' group. */
     private void processHeaders(final List<ListItem> result, ItemType itemType,
                                 final Map<DateHeaderType, List<String>> map) {
+        String meGroupKey = AccountManager.instance.getMeGroupKey();
         // Walk through the set of date header types to collect the list items.
         for (ListItem.DateHeaderType dht : ListItem.DateHeaderType.values()) {
             List<String> list = map.get(dht);
             if (list != null && list.size() > 0) {
-                // Add the header item followed by all the items from the given map.
-                result.add(new ListItem(date, dht.resId));
+                // Add the header item followed by all the items from the given map.  However, if
+                // the only item in the list is the 'me' group, don't include either the header or
+                // the group item (we only show the 'me' room, never the 'me' group.
+                if(list.size() > 1 || !list.get(0).equals(meGroupKey))
+                    result.add(new ListItem(date, dht.resId));
                 for (String key : list)
-                    addItem(result, itemType, key);
+                    // Don't include the me group
+                    if (!key.equals(meGroupKey))
+                        // Add relevant items based on itemType
+                        addItem(result, itemType, key);
             }
         }
-    }
+     }
 
     /** Update the timestamp ordered map of experiences in a given group and room. */
     private void updateExpMap(@NonNull final String groupKey, @NonNull final String roomKey,

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
@@ -31,7 +31,6 @@ import com.pajato.android.gamechat.exp.BaseExperienceFragment;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.expRoomList;
 import static com.pajato.android.gamechat.common.FragmentType.selectExpGroupsRooms;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
@@ -66,11 +65,12 @@ public class ExpShowGroupsFragment extends BaseExperienceFragment {
     }
 
     /** Handle an experience list change event by dispatching again. */
-    @Subscribe public void onExperienceListChangeEvent(ExperienceChangeEvent event) {
+    @Subscribe public void onExperienceChangeEvent(ExperienceChangeEvent event) {
         switch (event.changeType) {
             case CHANGED:
             case NEW:
-                DispatchManager.instance.startNextFragment(getActivity(), exp);
+                if (mActive)
+                    updateAdapterList();
                 break;
             default:
                 break;


### PR DESCRIPTION
# Rationale

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/common/Dispatcher.java
* Constructor: add case for experienceList which has the roomKey in the item's roomKey field (not in the key)

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* getTitle(): add separate case for expRoom to handle 'me' versus other groups

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* addItems(): check for items set to null (prevent NullPointerException)

#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
* processHeaders(): exclude the 'me' group (because we add it separately later) to prevent redundant entries in the resulting list

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* handlePlayModeChange(): reorder within file and remove commented-out code from previous checkin (oops)
* onSetup(): allow null experience type when handling a list of rooms, groups or experiences

#### app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpShowGroupsFragment.java
* onExperienceListChangeEvent(): rename to onExperienceChangeEvent (this handles the non-list type of event) and in the case of a new or changed event, just update the adapter list - don't start a new fragment
