### PR TITLE
Address deficiencies in create of protected user. Address previous review comments.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
@@ -255,39 +254,26 @@ public abstract class BaseChatFragment extends BaseFragment {
 
     /** Handle click on item to promote a protected user */
     private void processPromoteProtectedUserClick(final ListItem item) {
-        new AlertDialog.Builder(getActivity())
-                .setTitle(R.string.PromoteUserTitle)
-                .setMessage(String.format(getString(R.string.PromoteUserConfirm),
-                        item.name))
-                .setNegativeButton(android.R.string.cancel, null) // dismiss
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                ProtectedUserManager.instance.promoteUser(item.key);
-                            }
-                        })
-                .create()
-                .show();
+        String message = String.format(getString(R.string.PromoteUserConfirm), item.name);
+        DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface d, int id) {
+                ProtectedUserManager.instance.promoteUser(item.key);
+            }
+        };
+        showAlertDialog(getString(R.string.PromoteUserTitle), message, null, okListener);
     }
 
     /** Handle click on item to delete a protected user */
     private void processDeleteProtectedUserClick(final ListItem item) {
-        new AlertDialog.Builder(getActivity())
-                .setTitle(R.string.DeleteUserTitle)
-                .setMessage(String.format(getString(R.string.DeleteUserConfirm),
-                        item.name))
-                .setNegativeButton(android.R.string.cancel, null) // dismiss
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                ProtectedUserManager.instance.deleteProtectedUser(item.key);
-                            }
-                        })
-                .create()
-                .show();
+        String message = String.format(getString(R.string.DeleteUserConfirm), item.name);
+        DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface d, int id) {
+                ProtectedUserManager.instance.deleteProtectedUser(item.key);
+            }
+        };
+        showAlertDialog(getString(R.string.DeleteUserTitle), message, null, okListener);
     }
+
     /** Handle click on item to leave (or delete) group */
     private void handleLeaveGroupClick(final ListItem item) {
         final Group group = GroupManager.instance.getGroupProfile(item.groupKey);
@@ -296,20 +282,13 @@ public abstract class BaseChatFragment extends BaseFragment {
         if (AccountManager.instance.getCurrentAccountId().equals(group.owner))
             showFutureFeatureMessage(R.string.DeleteGroupMessage);
         else {
-            new AlertDialog.Builder(getActivity())
-                    .setTitle(getString(R.string.LeaveGroupTitle))
-                    .setMessage(String.format(getString(R.string.LeaveConfirmMessage),
-                            group.name))
-                    .setNegativeButton(android.R.string.cancel, null) // dismiss
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    AccountManager.instance.leaveGroup(group);
-                                }
-                    })
-                    .create()
-                    .show();
+            String message = String.format(getString(R.string.LeaveConfirmMessage), group.name);
+            DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+                @Override public void onClick(DialogInterface d, int id) {
+                    AccountManager.instance.leaveGroup(group);
+                }
+            };
+            showAlertDialog(getString(R.string.LeaveGroupTitle), message, null, okListener);
         }
     }
 
@@ -321,20 +300,13 @@ public abstract class BaseChatFragment extends BaseFragment {
         if (AccountManager.instance.getCurrentAccountId().equals(room.owner))
             showFutureFeatureMessage(R.string.DeleteRoomMessage);
         else {
-            new AlertDialog.Builder(getActivity())
-                    .setTitle(getString(R.string.LeaveRoomTitle))
-                    .setMessage(String.format(getString(R.string.LeaveConfirmMessage),
-                            room.getName()))
-                    .setNegativeButton(android.R.string.cancel, null) // dismiss
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    AccountManager.instance.leaveRoom(room);
-                                }
-                            })
-                    .create()
-                    .show();
+            String message = String.format(getString(R.string.LeaveConfirmMessage), room.getName());
+            DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+                @Override public void onClick(DialogInterface d, int id) {
+                    AccountManager.instance.leaveRoom(room);
+                }
+            };
+            showAlertDialog(getString(R.string.LeaveRoomTitle), message, null, okListener);
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.content.DialogInterface;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AlertDialog;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.RadioGroup;
@@ -98,20 +97,15 @@ public class CreateGroupFragment extends BaseCreateFragment {
         // Determine if the specified name is unique within the current user's groups
         if (AccountManager.instance.hasGroupWithName(mGroup.name) && !ignoreDupName) {
             dismissKeyboard();
-            new AlertDialog.Builder(getActivity())
-                    .setTitle(String.format(getString(R.string.GroupExistsTitle), mGroup.name))
-                    .setMessage(String.format(getString(R.string.GroupExistsMessage), mGroup.name))
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    save(account, true);
-                                    DispatchManager.instance.startNextFragment(getActivity(), chat);
-                                }
-                            })
-                    .create()
-                    .show();
+            String title = String.format(getString(R.string.GroupExistsTitle), mGroup.name);
+            String message = String.format(getString(R.string.GroupExistsMessage), mGroup.name);
+            DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+                @Override public void onClick(DialogInterface d, int id) {
+                    save(account, true);
+                    DispatchManager.instance.startNextFragment(getActivity(), chat);
+                }
+            };
+            showAlertDialog(title, message, null, okListener);
             return false;
         }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -61,9 +61,8 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
     private class EmailOnSuccessListener implements OnSuccessListener<ProviderQueryResult> {
         @Override
         public void onSuccess(ProviderQueryResult result) {
-            RelativeLayout layout =
-                    (RelativeLayout) getActivity().
-                            findViewById(R.id.email_next_btn_layout);
+            int id = R.id.email_next_btn_layout;
+            RelativeLayout layout = (RelativeLayout) getActivity().findViewById(id);
             layout.setVisibility(View.GONE);
             List<String> providers = result.getProviders();
             if (providers == null || providers.isEmpty()) {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -19,7 +19,6 @@ package com.pajato.android.gamechat.chat.fragment;
 
 import android.content.DialogInterface;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AlertDialog;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseCreateFragment;
@@ -98,20 +97,15 @@ public class CreateRoomFragment extends BaseCreateFragment {
         // Determine if the specified name is unique within the current group's rooms
         if (GroupManager.instance.groupHasRoomName(mGroup.key, mRoom.name) && !ignoreDupName) {
             dismissKeyboard();
-            new AlertDialog.Builder(getActivity())
-                    .setTitle(String.format(getString(R.string.RoomExistsTitle), mRoom.name))
-                    .setMessage(String.format(getString(R.string.RoomExistsMessage), mRoom.name))
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .setPositiveButton(android.R.string.ok,
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface d, int id) {
-                                    save(account, true);
-                                    DispatchManager.instance.startNextFragment(getActivity(), chat);
-                                }
-                            })
-                    .create()
-                    .show();
+            String title = String.format(getString(R.string.RoomExistsTitle), mRoom.name);
+            String message = String.format(getString(R.string.RoomExistsMessage), mRoom.name);
+            DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+                @Override public void onClick(DialogInterface d, int id) {
+                    save(account, true);
+                    DispatchManager.instance.startNextFragment(getActivity(), chat);
+                }
+            };
+            showAlertDialog(title, message, null, okListener);
             return false;
         }
 

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
@@ -51,9 +51,8 @@ public class SelectGroupsFragment extends BaseChatFragment {
                     Log.e(TAG, "Cannot create protected user: e-mail credentials are not set");
                     break;
                 }
-                ProtectedUserManager.instance.removeEMailCredentials();
                 AccountManager.instance.createProtectedAccount(credentials.email, credentials.name,
-                        credentials.secret, getGroupSelections());
+                        credentials.secret, credentials.accountIsKnown, getGroupSelections());
                 break;
             case R.id.selector:
                 // Checkbox click, just update the adapter

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -18,6 +18,7 @@
 package com.pajato.android.gamechat.common;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -51,6 +52,7 @@ import com.pajato.android.gamechat.database.MessageManager;
 import com.pajato.android.gamechat.database.ProtectedUserManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.main.MainActivity;
 
 import java.util.List;
 import java.util.Locale;
@@ -360,5 +362,13 @@ public abstract class BaseFragment extends Fragment {
         else
             state.setType(active);
         MemberManager.instance.updateMember(member);
+    }
+
+    /** Show an alert dialog with "ok" and "cancel". */
+    public void showAlertDialog(final String title, final String message,
+                                   DialogInterface.OnClickListener cancelListener,
+                                   DialogInterface.OnClickListener okListener) {
+        MainActivity activity = (MainActivity) this.getActivity();
+        activity.showOkCancelDialog(title, message, cancelListener, okListener);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -98,15 +98,7 @@ public enum FabManager {
         if (layout != null) dismissMenu(fragment, layout);
     }
 
-    /** Ensure that the FAb is not being shown. */
-    public void hide(@NonNull final Fragment fragment) {
-        View layout = getFragmentLayout(fragment);
-        if (layout == null) return;
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
-        fab.setVisibility(View.GONE);
-    }
-
-    /** Initialize the FAB. Set size to small FAB for games to small; all others use normal .*/
+    /** Initialize the FAB. Use small FAB size for game fragments; all others use normal size. */
     public void init(@NonNull final BaseFragment fragment) {
         // Ensure that the layout and the recycler views exist. Abort quietly if they do not.
         View layout = getFragmentLayout(fragment);

--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -60,8 +60,8 @@ public enum ToolbarManager {
         chat (R.string.SwitchToChat, 0, IF_ROOM, R.drawable.ic_chat_bubble_outline_white_24px),
         game (R.string.SwitchToExp, 0, IF_ROOM, R.drawable.ic_games_white),
         helpAndFeedback (R.string.MenuItemHelpAndFeedback, 55, NEVER, -1), // should always be included
-        invite (R.string.InviteFriendsOverflow, 20, IF_ROOM, R.drawable.ic_share_white_24dp),
-        search (R.string.MenuItemSearch, 20, IF_ROOM, R.drawable.ic_search_white_24px),
+        invite (R.string.InviteFriendsOverflow, 20, NEVER, R.drawable.ic_share_white_24dp),
+        search (R.string.MenuItemSearch, 20, NEVER, R.drawable.ic_search_white_24px),
         members (R.string.MembersMenuItem, 30, NEVER, -1),
         settings (R.string.MenuItemSettings, 0, NEVER, -1); // should always be included
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
 package com.pajato.android.gamechat.common.adapter;
 
 import android.support.v7.widget.RecyclerView;
@@ -8,7 +24,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
-import com.pajato.android.gamechat.common.PlayModeManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.PlayModeChangeEvent;
 

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies LLC.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat.  If not,
+ * see http://www.gnu.org/licenses
+ */
 package com.pajato.android.gamechat.common.adapter;
 
 import java.util.Locale;

--- a/app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserAuthFailureEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserAuthFailureEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+package com.pajato.android.gamechat.event;
+
+/**
+ * Provides an event indicating that an attempt to create or sign in a Firebase user has failed.
+ */
+public class ProtectedUserAuthFailureEvent {
+
+    // Public instance variable.
+
+    public String message;
+
+    // Public constructor.
+
+    /** Build the instance with a specified message */
+    public ProtectedUserAuthFailureEvent(final String message) {
+        this.message = message;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -22,7 +22,6 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
@@ -568,20 +567,13 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         final Experience exp = ExperienceManager.instance.experienceMap.get(item.key);
         if (exp == null)
             return;
-        new AlertDialog.Builder(getActivity())
-                .setTitle(getString(R.string.DeleteExperienceTitle))
-                .setMessage(String.format(getString(R.string.DeleteConfirmMessage),
-                        exp.getName()))
-                .setNegativeButton(android.R.string.cancel, null) // dismiss
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                ExperienceManager.instance.deleteExperience(item);
-                            }
-                        })
-                .create()
-                .show();
+        String message = String.format(getString(R.string.DeleteConfirmMessage), exp.getName());
+        DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface d, int id) {
+                ExperienceManager.instance.deleteExperience(item);
+            }
+        };
+        showAlertDialog(getString(R.string.DeleteExperienceTitle), message, null, okListener);
     }
 
     /** Return the fragment type corresponding to the sole experience in the map. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
@@ -140,12 +140,10 @@ public enum NotificationManager {
         }
 
         @Override public void onDismissed(final Snackbar snackbar, final int event) {
-            if (mType == chat) {
+            if (mType == chat)
                 FabManager.chat.setVisibility(mFragment, View.VISIBLE);
-            }
-            else {
+            else
                 FabManager.game.setVisibility(mFragment, View.VISIBLE);
-             }
         }
 
         @Override public void onShown(final android.support.design.widget.Snackbar snackbar) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
@@ -71,6 +71,8 @@ public class TileClickHandler implements View.OnClickListener {
         // If so, return false, otherwise true.
         Board board = mModel.getBoard();
         Team team = board.getTeam(position);
+        if (team == Team.NONE) // clicking on an empty cell should be ignored
+            return false;
         boolean turn = mModel.getTurn();
         boolean isOwnPlayer = (team == Team.PRIMARY && turn) || (team == Team.SECONDARY && !turn);
         boolean isCapture = !isOwnPlayer && board.isHighlighted(position);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.exp.chess;
 
 import android.content.DialogInterface;
-import android.support.v7.app.AlertDialog;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
@@ -210,20 +209,14 @@ import static com.pajato.android.gamechat.exp.State.active;
             return true;
         }
         final String key = this.key;
-        new AlertDialog.Builder(fragment.getActivity())
-                .setTitle(fragment.getString(R.string.ResetGameTitle))
-                .setMessage(fragment.getString(R.string.ResetGameMessage))
-                .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                resetModel();
-                                AppEventManager.instance.post(new ExperienceResetEvent(key));
-                            }
-                        })
-                .create()
-                .show();
+        DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface d, int id) {
+                resetModel();
+                AppEventManager.instance.post(new ExperienceResetEvent(key));
+            }
+        };
+        fragment.showAlertDialog(fragment.getString(R.string.ResetGameTitle),
+                fragment.getString(R.string.ResetGameMessage), null, okListener);
         return false;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.exp.model;
 
 import android.content.DialogInterface;
-import android.support.v7.app.AlertDialog;
 
 import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
@@ -203,20 +202,14 @@ public class Checkers implements Experience {
             return true;
         }
         final String key = this.key;
-        new AlertDialog.Builder(fragment.getActivity())
-                .setTitle(fragment.getString(R.string.ResetGameTitle))
-                .setMessage(fragment.getString(R.string.ResetGameMessage))
-                .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface d, int id) {
-                                resetModel();
-                                AppEventManager.instance.post(new ExperienceResetEvent(key));
-                            }
-                        })
-                .create()
-                .show();
+        DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface d, int id) {
+                resetModel();
+                AppEventManager.instance.post(new ExperienceResetEvent(key));
+            }
+        };
+        fragment.showAlertDialog(fragment.getString(R.string.ResetGameTitle),
+                fragment.getString(R.string.ResetGameMessage), null, okListener);
         return false;
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -18,12 +18,14 @@
 package com.pajato.android.gamechat.main;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.ViewPager;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
@@ -54,6 +56,7 @@ import com.pajato.android.gamechat.event.InviteEvent;
 import com.pajato.android.gamechat.event.GroupJoinedEvent;
 import com.pajato.android.gamechat.event.MenuItemEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
+import com.pajato.android.gamechat.event.ProtectedUserAuthFailureEvent;
 import com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment;
 import com.pajato.android.gamechat.help.HelpManager;
 import com.pajato.android.gamechat.intro.IntroActivity;
@@ -240,6 +243,38 @@ public class MainActivity extends BaseActivity
                 Log.d(TAG, String.format(Locale.US, format, event.item.getTitle()));
                 break;
         }
+    }
+
+    @Subscribe public void onProtectedUserAuthFailureEvent(ProtectedUserAuthFailureEvent event) {
+        // Pop up an alert indicating the problem
+        String title = getString(R.string.AuthProtectedUserFailureTitle);
+        String userEmail = ProtectedUserManager.instance.getEMailCredentials().email;
+        String format = getString(R.string.AuthProtectedUserFailureMessage);
+        String message = String.format(Locale.US, format, userEmail, event.message);
+        showAlertDialog(title, message, false, null, true, null);
+    }
+
+    /** Show an alert dialog with "ok" and "cancel". */
+    public void showOkCancelDialog(final String title, final String message,
+                                   DialogInterface.OnClickListener cancelListener,
+                                   DialogInterface.OnClickListener okListener) {
+        showAlertDialog(title, message, true, cancelListener, true, okListener);
+    }
+
+    /** Show an alert dialog with cancel and/or ok button(s). */
+    public void showAlertDialog(final String title, final String message, boolean showCancel,
+                                DialogInterface.OnClickListener cancelListener, boolean showOk,
+                                DialogInterface.OnClickListener okListener) {
+        if (!showCancel && !showOk)
+            Log.e(TAG, "showAlertDialog called but no buttons are specified.");
+        AlertDialog.Builder builder = new AlertDialog.Builder(this).
+                setTitle(title).
+                setMessage(message);
+        if (showCancel)
+            builder.setNegativeButton(android.R.string.cancel, cancelListener);
+        if (showOk)
+            builder.setPositiveButton(android.R.string.ok, okListener);
+        builder.create().show();
     }
 
     /** Process the result from a request for a permission */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
+    <string name="AuthFailureInvalidCredentials">Invalid credentials specified.</string>
+    <string name="AuthFailureInvalidUser">This user is no longer valid in the Firebase database.</string>
+    <string name="AuthSignInFailure">Sign in failed: %s</string>
+    <string name="AuthProtectedUserFailureTitle">Failed to authorize protected user</string>
+    <string name="AuthProtectedUserFailureMessage">Failed to authorize protected user %1$s due to error. %2$s</string>
     <string name="AccessToGroupsTitle">Allow Access to Groups</string>
     <string name="CreateRestrictedUserTitle">Create Protected User</string>
     <string name="DeleteGroupMessage">Delete Group</string>


### PR DESCRIPTION
# Rationale
This commit includes the following:
* Fix creation of a protected user so that it works even if there is an authorized account in Firebase for the specified e-mail.
* Fix error handling during creation of protected user.
* Create a general method to handle alert dialogs to eliminate redundant code.
*Address some previous review comments.

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/BaseChatFragment.java

* processPromoteProtectedUserClick(): Utilize new method to show alert dialog.
* processDeleteProtectedUserClick(): Utilize new method to show alert dialog.
* handleLeaveGroupClick(): Utilize new method to show alert dialog.
* handleLeaveRoomClick(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
* save(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
* EmailOnSuccessListener.onSuccess: make code more RNF

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* save(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
* onClick(): add accountIsKnown param to createProtectedAccount call

#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
* showAlertDialg(): wrap alert dialog method in main activity

#### app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
* Fix clunky comment
* hide(): remove unused method

#### app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
* some cleanup to address review comments

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* Change 'search' and 'invite' to never show up in the toolbar since they can cause crowding/truncation of the title

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
* Add missing copyright notice

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
* Add missing copyright notice

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* createProtectedAccount(): improve error handling. Fix creating an Account when the user's e-mail is already an authorized user in the Firebase database. Create separate private classes for completion, success and failure handling.

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* verifyDeleteExperience(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
* SnackbarChangeHandler.onDismissed(): minor fix to address review comment

#### app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
* isPlayingOutOfTurn(): ignore click on empty cell (no Toast message)

#### app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
* reset(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
* reset(): Utilize new method to show alert dialog.

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* onProtectedUserAuthFailureEvent(): handle protected user authorization failure by showing an alert dialog
* showOkCancelDialog(): show an alert dialog with both "ok" and "cancel" buttons
* showAlertDialog(): show an alert dialog with alert and/or cancel buttons and handlers

#### app/src/main/res/values/strings.xml
* various new strings

## New Files

#### app/src/main/java/com/pajato/android/gamechat/event/ProtectedUserAuthFailureEvent.java
* provide an event which indicates that a Firebase auth failure occurred for a protected user
