### PR TITLE
Fix bug causing room and group list fragments to appear overlapping. Fix some NPEs.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
@@ -28,7 +28,6 @@ import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
-import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.database.AccountManager;
@@ -38,7 +37,6 @@ import org.greenrobot.eventbus.Subscribe;
 
 import java.util.Locale;
 
-import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.PRIVATE;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.PUBLIC;
 
@@ -72,7 +70,7 @@ public abstract class BaseCreateFragment extends BaseChatFragment {
                 Account account = AccountManager.instance.getCurrentAccount();
                 if (account != null) {
                     if (save(account, false))
-                        DispatchManager.instance.startNextFragment(getActivity(), chat);
+                        getActivity().onBackPressed(); // Go back
                 } else {
                     dismissKeyboard();
                     abort(getString(R.string.InvalidAccountError));

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
@@ -28,7 +28,6 @@ import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
-import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.common.model.JoinState;
@@ -44,7 +43,6 @@ import java.util.Locale;
 
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
 import static com.pajato.android.gamechat.chat.model.Room.RoomType.COMMON;
-import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 
@@ -102,7 +100,7 @@ public class CreateGroupFragment extends BaseCreateFragment {
             DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
                 @Override public void onClick(DialogInterface d, int id) {
                     save(account, true);
-                    DispatchManager.instance.startNextFragment(getActivity(), chat);
+                    getActivity().onBackPressed(); // Go back
                 }
             };
             showAlertDialog(title, message, null, okListener);

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
@@ -25,7 +25,6 @@ import com.pajato.android.gamechat.chat.BaseCreateFragment;
 import com.pajato.android.gamechat.chat.model.Group;
 import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.chat.model.Room.RoomType;
-import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.ToolbarManager;
 import com.pajato.android.gamechat.common.model.Account;
 import com.pajato.android.gamechat.common.model.JoinState;
@@ -37,7 +36,6 @@ import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.exp.NotificationManager;
 
 import static com.pajato.android.gamechat.chat.model.Message.STANDARD;
-import static com.pajato.android.gamechat.common.FragmentKind.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
 
@@ -102,7 +100,7 @@ public class CreateRoomFragment extends BaseCreateFragment {
             DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
                 @Override public void onClick(DialogInterface d, int id) {
                     save(account, true);
-                    DispatchManager.instance.startNextFragment(getActivity(), chat);
+                    getActivity().onBackPressed(); // Go back
                 }
             };
             showAlertDialog(title, message, null, okListener);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -162,6 +162,10 @@ public class ListItem {
         this.type = type;
         this.groupKey = groupKey;
         this.roomKey = roomKey;
+        if (roomKey != null)
+            key = roomKey;
+        else
+            key = groupKey;
         this.name = name;
         this.count = count;
         this.text = text;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -514,6 +514,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
 
     /** Dispatch to the game indicated by the given type */
     private void dispatchToGame(FragmentActivity activity, FragmentType type) {
+        if (type == null || type.expType == null)
+            return;
         if (this.type != noExperiences) {
             Dispatcher dispatcher = new Dispatcher(getNextType(type), type.expType);
             DispatchManager.instance.chainFragment(activity, dispatcher);


### PR DESCRIPTION
# Rationale
After creating a room, the list of groups is presented to the user. The system back button causes the list of groups and list of rooms to appear at the same time one on top of the other in a crazy ugly display. Further button clicks cause the app to crash. This is solved by changing the "create" code for rooms and groups to use the onBackPressed method to return to the previous fragment, rather than calling the DispatchManager to start the next (chat) fragment (thus ignoring, and ultimately confusing, the back stack and back button press behavior).

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/chat/BaseCreateFragment.java
* onClick(): in the 'save' case, call the activity's onBackPressed rather than startNextFragment
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateGroupFragment.java
* save(): in the 'save' case, call the activity's onBackPressed rather than startNextFragment
#### app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateRoomFragment.java
* save(): in the 'save' case, call the activity's onBackPressed rather than startNextFragment
#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
* ListItem constructor for groups/rooms; try to set the 'key' member variable correctly to prevent subsequent poor display (using toString()) of ListItem in debugger
#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* dispatchToGame(): check for null values to prevent null pointer exceptions