### PR TITLE
Fix bugs toolbar title/subtitle for a list of rooms and the messages in a room.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
@@ -230,6 +230,9 @@ public enum ToolbarManager {
         switch (item.type) {
             case expList:
                 return GroupManager.instance.getGroupName(item.groupKey);
+            case chatGroup:
+            case chatRoom:
+                return GroupManager.instance.getGroupName(item.groupKey);
             default:
                 return item.key == null
                         ? GroupManager.instance.getGroupName(item.groupKey)

--- a/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
@@ -169,7 +169,7 @@ public enum RoomManager {
     /** Obtain a name for the room with the given key, "Anonymous" if a name is not available. */
     public String getRoomName(final String roomKey) {
         Room room = roomMap.get(roomKey);
-        return room != null ? room.name : "Anonymous";
+        return room != null ? room.name : null;
     }
 
     /** Get the profile for a given room. */


### PR DESCRIPTION
# Rationale
When a user clicks on a group, the room list Toolbar shows the group name as "Anonymous". When the user clicks on a room to view messages, the Toolbar shows the group name as the room name. Fix both cases to show the group name.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/common/ToolbarManager.java
* getSubtitle(): add cases for chatGroup and chatRoom which both get the group name from the GroupManager
#### app/src/main/java/com/pajato/android/gamechat/database/RoomManager.java
* getRoomName(): never use "Anonymous" - return null instead if no room name is available (this is analogous to what is done in the GroupManager when no group name is available)
