### PR TITLE
Fixing Chess + Checkers Behaviors

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
@@ -45,14 +45,14 @@ public class Checkerboard {
 
     // Private class constants.
 
-    /** The amount of space taken by a smart phone toolbar in dp units. */
-    private static final int SMART_PHONE_HEIGHT = 56;
+    /** The space taken by a smart phone notification bar and digital buttons in dp units. */
+    private static final int SMART_PHONE_HEIGHT = 84; // 56 * 1.5
 
-    /** The amount of space taken by a tablet toolbar in dp units. */
-    private static final int TABLET_HEIGHT = 64;
+    /** The space taken by a tablet notification bar and digital buttons in dp units. */
+    private static final int TABLET_HEIGHT = 42; // 28 * 1.5
 
     /** The amount of vertical space allocated for the player controls. */
-    private static final int CONTROLS_HEIGHT = 112;
+    private static int CONTROLS_HEIGHT;
 
     /**
      * The amount of vertical space allocated to the mini FAB control, which consists of three
@@ -73,6 +73,16 @@ public class Checkerboard {
 
     /** Build an instance to establish the cell size for a given context. */
     Checkerboard(final Context context) {
+        // Establish the controls height. Remember to convert the SP of text in the layout to DP.
+        // The default is 1-1, but is not necessarily, as SP can scale based on user settings.
+        DisplayMetrics d = context.getResources().getDisplayMetrics();
+
+        int toolbarTextRow1 = convertSPtoDP(20, d);
+        int toolbarTextRow2 = Math.max(toolbarTextRow1, (4 + convertSPtoDP(14, d)));
+        int controlsRow1 = Math.max(toolbarTextRow1, (40 + convertSPtoDP(14, d)));
+        int controlsRow2 = Math.max(56, Math.max(convertSPtoDP(20, d), (36 + convertSPtoDP(14, d))));
+        CONTROLS_HEIGHT = toolbarTextRow1 + toolbarTextRow2 + controlsRow1 + controlsRow2;
+
         mCellSize = getCellSize(context);
     }
 
@@ -198,5 +208,9 @@ public class Checkerboard {
         // float dp = px / (metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
         return (px * DisplayMetrics.DENSITY_DEFAULT) / metrics.densityDpi;
 
+    }
+    private int convertSPtoDP(final int spValue, final DisplayMetrics displayMetrics) {
+        int px = (int) (spValue * displayMetrics.scaledDensity);
+        return getDips(displayMetrics, px);
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/Checkerboard.java
@@ -45,14 +45,21 @@ public class Checkerboard {
 
     // Private class constants.
 
-    /** The space taken by a smart phone notification bar and digital buttons in dp units. */
-    private static final int SMART_PHONE_HEIGHT = 84; // 56 * 1.5
+    /**
+     * The space taken by a smart phone notification bar and digital buttons in dp units. The
+     * number comes from the calculation of 56dp * 1.5. 56 comes from an estimation of the DP of the
+     * phone's lower digital button area, and the additional half of the 1.5 comes from the
+     * notification bar at the top of the phone's screen, which was eyeballed to be roughly half the
+     * size of the digital button area. This is something that could potentially be improved upon.
+     */
+    private static final int SMART_PHONE_HEIGHT = 84;
 
-    /** The space taken by a tablet notification bar and digital buttons in dp units. */
-    private static final int TABLET_HEIGHT = 42; // 28 * 1.5
-
-    /** The amount of vertical space allocated for the player controls. */
-    private static int CONTROLS_HEIGHT;
+    /**
+     * The space taken by a tablet notification bar and digital buttons in dp units. Similar to the
+     * Smart Phone Height variable, it is based on a calculation of 28dp * 1.5, which was a similar
+     * estimate of the tablet's digital button area, and the roughly-half-the-size notification bar.
+     */
+    private static final int TABLET_HEIGHT = 42;
 
     /**
      * The amount of vertical space allocated to the mini FAB control, which consists of three
@@ -73,16 +80,6 @@ public class Checkerboard {
 
     /** Build an instance to establish the cell size for a given context. */
     Checkerboard(final Context context) {
-        // Establish the controls height. Remember to convert the SP of text in the layout to DP.
-        // The default is 1-1, but is not necessarily, as SP can scale based on user settings.
-        DisplayMetrics d = context.getResources().getDisplayMetrics();
-
-        int toolbarTextRow1 = convertSPtoDP(20, d);
-        int toolbarTextRow2 = Math.max(toolbarTextRow1, (4 + convertSPtoDP(14, d)));
-        int controlsRow1 = Math.max(toolbarTextRow1, (40 + convertSPtoDP(14, d)));
-        int controlsRow2 = Math.max(56, Math.max(convertSPtoDP(20, d), (36 + convertSPtoDP(14, d))));
-        CONTROLS_HEIGHT = toolbarTextRow1 + toolbarTextRow2 + controlsRow1 + controlsRow2;
-
         mCellSize = getCellSize(context);
     }
 
@@ -170,7 +167,20 @@ public class Checkerboard {
         final int dipsHeight = getDips(metrics, metrics.heightPixels);
         final int dipsWidth = getDips(metrics, metrics.widthPixels);
         final int toolbarDps = PaneManager.instance.isTablet() ? TABLET_HEIGHT : SMART_PHONE_HEIGHT;
-        final int unavailableHeight = CONTROLS_HEIGHT + FAB_HEIGHT + toolbarDps;
+
+        // Establish the controls height. Remember to convert the SP of text in the layout to DP.
+        // The default is 1-1, but is not necessarily, as SP can scale based on user settings.
+        // This is very arbitrary based on the current physical XML layouts -- if those are changed
+        // (particularly those in exp_toolbar_game_inc.xml and exp_checkers.xml) then this should be
+        // changed to reflect them.
+        int toolbarTextRow1 = convertSPtoDP(20, metrics);
+        int toolbarTextRow2 = Math.max(toolbarTextRow1, (4 + convertSPtoDP(14, metrics)));
+        int controlsRow1 = Math.max(toolbarTextRow1, (40 + convertSPtoDP(14, metrics)));
+        int controlsRow2 = Math.max(convertSPtoDP(20, metrics), (36 + convertSPtoDP(14, metrics)));
+        controlsRow2 = Math.max(56, controlsRow2);
+        final int controlsHeight = toolbarTextRow1 + toolbarTextRow2 + controlsRow1 + controlsRow2;
+
+        final int unavailableHeight = controlsHeight + FAB_HEIGHT + toolbarDps;
         final int boardHeight = dipsHeight - unavailableHeight;
         final int boardWidth = (PaneManager.instance.isTablet() ? dipsWidth / 2 : dipsWidth) - 32;
         boolean useWidth = boardHeight > boardWidth;
@@ -204,11 +214,14 @@ public class Checkerboard {
         mGrid.getChildAt(position).setBackgroundColor(ContextCompat.getColor(context, colorResId));
     }
 
+    /** Convert a given pixel number to dps. */
     private int getDips(final DisplayMetrics metrics, final int px) {
         // float dp = px / (metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
         return (px * DisplayMetrics.DENSITY_DEFAULT) / metrics.densityDpi;
 
     }
+
+    /** Convert a given sp value into dps in order to account for variable text size. */
     private int convertSPtoDP(final int spValue, final DisplayMetrics displayMetrics) {
         int px = (int) (spValue * displayMetrics.scaledDensity);
         return getDips(displayMetrics, px);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
@@ -71,7 +71,7 @@ public class TileClickHandler implements View.OnClickListener {
         // If so, return false, otherwise true.
         Board board = mModel.getBoard();
         Team team = board.getTeam(position);
-        if (team == Team.NONE) // clicking on an empty cell should be ignored
+        if (team == Team.NONE) // clicking on an empty cell is not playing out of turn
             return false;
         boolean turn = mModel.getTurn();
         boolean isOwnPlayer = (team == Team.PRIMARY && turn) || (team == Team.SECONDARY && !turn);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
@@ -68,10 +68,11 @@ public class TileClickHandler implements View.OnClickListener {
     /** Return TRUE iff the piece selected is from the other team and not being captured. */
     private boolean isPlayingOutOfTurn(final int position) {
         // Ensure that the piece played is correct according to the turn or is being captured.
-        // If so, return false, otherwise true.
+        // If the tile clicked has no piece, return false. Otherwise ensure it's not being played
+        // out of turn.
         Board board = mModel.getBoard();
         Team team = board.getTeam(position);
-        if (team == Team.NONE) // clicking on an empty cell is not playing out of turn
+        if (team == Team.NONE)
             return false;
         boolean turn = mModel.getTurn();
         boolean isOwnPlayer = (team == Team.PRIMARY && turn) || (team == Team.SECONDARY && !turn);

--- a/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/checkers/CheckersEngine.java
@@ -122,12 +122,13 @@ public enum CheckersEngine implements Engine {
         // Ignore clicks on invalid positions.  If the position represents a valid piece then
         // mark it as the selected piece and get a list of possible move positions that exclude
         // the possibility of putting the moving player into check.
-        if (mModel.board.hasPiece(position)) {
-            mModel.board.setSelectedPosition(position);
-            mModel.board.getPossibleMoves().clear();
+        mModel.board.setSelectedPosition(position);
+        mModel.board.getPossibleMoves().clear();
+        if (mModel.board.hasPiece(position))
             mModel.board.getPossibleMoves().addAll(getPossibleMoves(position));
-            ExperienceManager.instance.updateExperience(mModel);
-        }
+        else
+            mModel.board.clearSelectedPiece();
+        ExperienceManager.instance.updateExperience(mModel);
     }
 
     // Private instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessEngine.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessEngine.java
@@ -384,7 +384,8 @@ public enum ChessEngine implements Engine {
         boolean result;
         ChessBoard board = mModel.board;
         ChessPiece savedSelectedPiece = board.delete(selectedPosition);
-        if(savedSelectedPiece == null) return false;
+        if(savedSelectedPiece == null)
+            return false;
         ChessPiece savedMovePiece = board.hasPiece(position) ? board.getPiece(position) : null;
 
         // Add the selected piece to the move position, clear it from the board and test for check.

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -41,7 +41,7 @@
     <string name="TieMessage">Tie game!</string>
     <string name="TieMessageNotification">Well done players</string>
     <string name="WinMessageFormat">%1$s Wins!</string>
-    <string name="WinMessageNotificationFormat">Congratulations %s, you win</string>
+    <string name="WinMessageNotificationFormat">Congratulations %s, you win!</string>
     <string name="chess_promotion_bishop">Bishop</string>
     <string name="chess_promotion_knight">Knight</string>
     <string name="chess_promotion_queen">Queen</string>


### PR DESCRIPTION
# Rationale

With the constant updates to GameChat, a bit of functionality was compromised. The functionality that I have endeavored to reimplement is correctly adjusting the board size for both tablets and smartphones, along with correctly removing a highlight on a piece if the player clicks an empty tile after a piece has been highlighted. Both of these issues have been addressed for both Chess and Checkers. In addition, I took the initiative to implement a proper checkmate.

 I understand that the ideal chosen workflow for GameChat is one change per pull request, so in the future I will do my best to follow this principle.

# Changed Files

## Java Files

### exp/checkers/CheckersEngine.java
* Rather than ignoring clicks on tiles without a piece, **all** moves started by a tile click now change the selected position to the tile clicked and clear the possible moves. Then, if that tile contains a piece, collect possible moves and proceed as before. However, if it doesn't contain a piece, we clear the selected piece and update the experience, effectively clearing the highlighted tiles.

### exp/chess/ChessEngine.java
* Similar to the changes to **CheckersEngine**, we do not ignore tiles clicked when they do not have a piece, and instead clear the selected piece and all highlighted tiles.
* In addition, several changes to accommodate checkmate have been implemented.
 * The *checkFinished* method has been tweaked -- win conditions now no longer depend on capturing a king, but involve putting the king in a check that cannot be escaped from -- the player must be in check and have no possible moves.
 * Added method *getAllMoves* that searches all the valid moves of a given team.
 * Added a Checkmate! portion to the snackbar notification for winning.
 * Changed the *removeCheckExposingMoves* and *testForCheck* methods to no longer use the **mModel.board.selectedPiece** by default and now accept a parameter to facilitate checking for valid moves during *checkFinished*.

 ### exp/Checkerboard.java
 * Factor in variable text size (as SP can change depending on device settings) when adjusting the height of the controls to prevent the board from being too large.
 * Adjusted the Smart Phone Height and Tablet Height properties to more closely reflect the actual space of the notification bar and digital buttons of tablets and smartphones.
 * Added a helper method that converts DP to SP.

 ### exp/TileClickHandler.java
 * Fixed a comment to better reflect how we now handle clicking on an empty tile.

## XML Files

### res/values/strings_exp.xml
* Added exclamation point to the win message. Excitement!