### PR TITLE
For play-mode and join-rooms selections, only show one member entry even if the member is in multiple groups.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -121,6 +121,11 @@ public abstract class BaseFragment extends Fragment {
         return type != null ? type.toolbarType : null;
     }
 
+    /** Determine if this fragment is active */
+    public boolean isActive() {
+        return mActive;
+    }
+
     @Override public void onActivityCreated(Bundle bundle) {
         super.onActivityCreated(bundle);
         logEvent("onActivityCreated", bundle);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ViewHolder;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -359,11 +360,23 @@ public class ListAdapter extends RecyclerView.Adapter<ViewHolder>
         // Set the title and list text view content based on the given item.  Provide the item in
         // the view holder tag field.
         holder.name.setText(item.name);
-        if (holder.text != null)
+        if (holder.text != null) {
             if (item.text == null || item.text.length() == 0)
                 holder.text.setVisibility(View.GONE);
+            else if (item.mGroupKeyList != null) {
+                List<String> groupNames = new ArrayList<>();
+                for (String aGroupKey : item.mGroupKeyList) {
+                    Group g = GroupManager.instance.getGroupProfile(aGroupKey);
+                    if (g != null)
+                        groupNames.add(g.name);
+                }
+                String groupList = TextUtils.join(", ", groupNames);
+                holder.text.setText(groupList);
+            }
             else
                 holder.text.setText(CompatUtils.fromHtml(item.text));
+
+        }
         setIcon(holder, item);
         setEndIcon(holder, item);
         holder.itemView.setTag(item);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
@@ -25,6 +25,8 @@ import com.pajato.android.gamechat.chat.model.Room;
 import com.pajato.android.gamechat.database.GroupManager;
 import com.pajato.android.gamechat.exp.Experience;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import static com.pajato.android.gamechat.common.adapter.ListItem.ItemType.contact;
@@ -123,6 +125,9 @@ public class ListItem {
     /** The group (push) key, possibly null, used for many list items (groups, rooms, messages) */
     public String groupKey;
 
+    /** A list of group keys, used only for an item that overlaps multiple groups */
+    List<String> mGroupKeyList;
+
     /** The item image resource id for dynamic images, as used with experiences. */
     public int iconResId;
 
@@ -162,10 +167,7 @@ public class ListItem {
         this.type = type;
         this.groupKey = groupKey;
         this.roomKey = roomKey;
-        if (roomKey != null)
-            key = roomKey;
-        else
-            key = groupKey;
+        key = roomKey != null ? roomKey : groupKey;
         this.name = name;
         this.count = count;
         this.text = text;
@@ -260,6 +262,16 @@ public class ListItem {
         Group group = GroupManager.instance.getGroupProfile(groupKey);
         text = group != null ? group.name : "";
         enabled = type == inviteRoom;
+    }
+
+    /** Add a new group key to the group key list. Initialize the list if necessary. */
+    public void addGroupKey(String additionalGroupKey) {
+        if (mGroupKeyList == null) {
+            mGroupKeyList = new ArrayList<>();
+            if (groupKey != null)
+                mGroupKeyList.add(groupKey);
+        }
+        mGroupKeyList.add(additionalGroupKey);
     }
 
     // Public instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
@@ -110,7 +110,6 @@ public class PlayModeMenuAdapter extends RecyclerView.Adapter<ViewHolder> implem
         /** The text view showing the simple text */
         TextView title;
 
-
         /** Build a simple text menu item view holder from the given adapter item view. */
         MenuTextViewHolder(final View adapterItemView) {
             super(adapterItemView);

--- a/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
@@ -16,6 +16,8 @@
  */
 package com.pajato.android.gamechat.common.adapter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -30,8 +32,8 @@ public class PlayModeMenuEntry {
     /** The associated account push key, or null if not a user entry */
     public String accountKey;
 
-    /** The group key associated with the target member, if any */
-    public String groupKey;
+    /** Group keys list, usually contains one entry, except when a member belongs to > 1 group */
+    public List<String> groupKeyList;
 
     /** A description of the item. */
     private String mDescription;
@@ -46,7 +48,8 @@ public class PlayModeMenuEntry {
     public PlayModeMenuEntry(String text, String accountKey, String groupKey) {
         this.type = MENU_TEXT_TYPE;
         this.accountKey = accountKey;
-        this.groupKey = groupKey;
+        this.groupKeyList = new ArrayList<>();
+        this.groupKeyList.add(groupKey);
         this.title = text;
         String format = "Play Mode Menu item with title {%s}, account id {%s} and group key {%s}.";
         mDescription = String.format(Locale.US, format, title, accountKey, groupKey);

--- a/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
@@ -180,6 +180,7 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
         // just sign in. Otherwise, create a new Firebase user.
         if (accountIsKnown)
             FirebaseAuth.getInstance().signInWithEmailAndPassword(email, password)
+                    .addOnSuccessListener(new AuthSuccessListener())
                     .addOnFailureListener(new AuthFailureListener());
         else
             FirebaseAuth.getInstance().createUserWithEmailAndPassword(email, password)
@@ -693,6 +694,14 @@ public enum AccountManager implements FirebaseAuth.AuthStateListener {
                 message = String.format(mMessageMap.get(R.string.AuthSignInFailure),
                         e.getLocalizedMessage());
             AppEventManager.instance.post(new ProtectedUserAuthFailureEvent(message));
+        }
+    }
+
+    /** A listener for authorization success. */
+    public class AuthSuccessListener implements OnSuccessListener<AuthResult> {
+        @Override public void onSuccess(@NonNull AuthResult result) {
+            // Clean up the stashed credentials after authorization is successful
+            ProtectedUserManager.instance.removeEMailCredentials();
         }
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
@@ -27,6 +27,7 @@ import android.support.v4.content.ContextCompat;
 import android.view.View;
 
 import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.BaseFragment;
 import com.pajato.android.gamechat.common.FabManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.InviteEvent;
@@ -139,14 +140,22 @@ public enum NotificationManager {
             mType = type;
         }
 
+        /** Show the FAB when the snackbar is dismissed */
         @Override public void onDismissed(final Snackbar snackbar, final int event) {
+            // Prevent null pointer exception by checking for fragment is active.
+            if (!(mFragment instanceof BaseFragment) || !((BaseFragment)mFragment).isActive())
+                return;
             if (mType == chat)
                 FabManager.chat.setVisibility(mFragment, View.VISIBLE);
             else
                 FabManager.game.setVisibility(mFragment, View.VISIBLE);
         }
 
+        /** Hide the FAB when the snackbar is shown */
         @Override public void onShown(final android.support.design.widget.Snackbar snackbar) {
+            // Prevent null pointer exception by checking for fragment is active
+            if (!(mFragment instanceof BaseFragment) || !((BaseFragment)mFragment).isActive())
+                return;
             if (mType == chat)
                 FabManager.chat.setVisibility(mFragment, View.INVISIBLE);
             else

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -292,7 +292,7 @@ public class MainActivity extends BaseActivity
         // Handle a result from either the intro activity or the invite activity.
         super.onActivityResult(request, result, intent);
         if (result != RESULT_OK)
-            logFailedResult(request, intent);
+            logFailedResult(request, intent, result == RESULT_CANCELED);
         else if (request == RC_INVITE) {
             // Invite activity result; process in the invitation manager.
             Log.d(TAG, "onActivityResult: requestCode=RC_INVITE, resultCode=" + result);
@@ -357,7 +357,7 @@ public class MainActivity extends BaseActivity
     }
 
     /** Provide a logcat message about a failed result. */
-    private void logFailedResult(int request, Intent intent) {
+    private void logFailedResult(int request, Intent intent, boolean isCancelled) {
         String requester;
         switch (request) {
             case RC_INTRO:
@@ -370,8 +370,14 @@ public class MainActivity extends BaseActivity
                 requester = "Unknown";
                 break;
         }
-        String format = "onActivityResult: %s, FAILED, \nIntent: %s";
-        Log.d(TAG, String.format(Locale.US, format, requester, intent.toString()));
+        // Intent may be null so prevent null-pointer-exception crash
+        if (isCancelled) {
+            String message = String.format(Locale.US, "%s CANCELED", request);
+            Log.d(TAG, message);
+        } else {
+            String format = "onActivityResult: %s, FAILED, \nIntent: %s";
+            Log.d(TAG, String.format(Locale.US, format, requester, intent.toString()));
+        }
     }
 
     /** Determine if the intro screen needs to be presented and do so. */

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -48,7 +48,7 @@
     <string name="JoinedGroupsMessage">You have joined group %s</string>
     <string name="JoinedOneRoom">You have joined the %1$s room in group %2$s</string>
     <string name="JoinedMultiRooms">You have joined rooms: %1$s in group %2$s</string>
-    <string name="JoinMemberRoomMessage">A room has been created for %1$s and %2$s to share private messages.</string>
+    <string name="JoinMemberRoomMessage">This room is for %1$s and %2$s to share private messages.</string>
     <string name="JoinRoomsMenuTitle">Join Rooms</string>
     <string name="MembersAvailableHeaderText">Members</string>
     <string name="MembersNotAvailableHeaderText">No Available Members</string>


### PR DESCRIPTION
# Rationale
For play mode menu members and join rooms members selections, only show a member once, even if the account is available in multiple groups. Just pick a group and use it if the user is selected.

#### app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

* isActive(): add accessor for mActive

#### app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java

* handlePlayModeUserSelection(): reflect change of PlayModeMenuEntry from a single groupKey value to a list of groupKey values, defaulting to use of the 0th element in the list. Also move creation of the experience ListItem prior to making changes in the experience, so we don't delete the experience that we just finished creating.
* getMenuItems(): create a map of member id to PlayModeMenuEntry and use it to keep track of member entries. Using a map insures only one value per key. Once we have a list with no duplicate members, use the map values() method to add to the resulting list of PlayModeMenuEntry values.

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListAdapter.java
* updateHolder(): If the ListItem has a list of group keys, use all the names to make a comma-separated list used as the 'subtitle' text value.

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/ListItem.java
* add a member variable to hold a possible list of group keys
* ListItem(): refactor to tighten code using ternary operator
* addGroupKey(): new method to initialize and add a value to the group key list

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuAdapter.java
* remove extraneous blank line

#### app/src/main/java/com/pajato/android/gamechat/common/adapter/PlayModeMenuEntry.java
* replace groupKey with groupKeyList member variable
* Constructor: initialize groupKeyList and add groupKey to it

#### app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java
* add AuthSuccessListener and insure that credentials are cleared from ProtectedUserManager (prevents next launch of creation of protected user from showing the previous credentials)

#### app/src/main/java/com/pajato/android/gamechat/database/JoinManager.java
* getAvailableMembers(): check for duplicate members and don't allow them in the returned list; instead add additional groups (if found) to the first entry in the list so it can reflect >1 group

#### app/src/main/java/com/pajato/android/gamechat/exp/NotificationManager.java
* prevent null pointer exceptions in the logcat output by checking for BaseFragment isActive in the onDismissed and onShown handlers for the snackbar. This needs to be reconsidered, because in the case of creating a room or group, the snackbar item is shown using the create fragment just as we return from the fragment to the caller and the create fragment isn't showing (so manipulating it's FAB doesn't work)

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
* onActivityResult() and logFailedRequest(): prevent null pointer exception by handling RESULT_CANCELED (no intent is returned in this case)

#### app/src/main/res/values/strings_chat.xml
* tweak to JoinMemberRoomMessage text
