### PR TITLE
Bugfixes for Experience Displays

### DIFF
--- a/app/src/main/assets/misc/creatingGroups.html
+++ b/app/src/main/assets/misc/creatingGroups.html
@@ -8,24 +8,15 @@
     <h1>Creating Groups</h1>
 </center>
 <hr>
-<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
-<p>
-September 12, 1962
-<p>
-No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
-half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
-animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
-learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
-during this whole 50-year span of human history, the steam engine provided a new source of power.
-<p>
-Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
-penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
-midnight tonight.
-<p>
-This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
-vistas of space promise high costs and hardships, as well as high reward.
-<p>
-Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
-<hr>
+<h2>What are Groups for?</h2>
+<ul>
+    <li>Only member of groups can access rooms</li>
+    <li>Private rooms</li>
+    <li>Public rooms</li>
+    <li>Use invitations to invite someone to a room</li>
+    <li>Protected users are invited when they are created (by selecting specific groups)</li>
+</ul>
+<h2>Who can invite users?</h2>
+<h2>What other things are important about groups?</h2>
 </body>
 </html>

--- a/app/src/main/assets/misc/invitations.html
+++ b/app/src/main/assets/misc/invitations.html
@@ -8,22 +8,12 @@
     <h1>Invitations</h1>
 </center>
 <hr>
-<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
-<p>
-    September 12, 1962
-<p>
-    No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
-    half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
-    animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
-    learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
-    during this whole 50-year span of human history, the steam engine provided a new source of power.
-<p>
-    Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
-    penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
-    midnight tonight.
-<p>
-    This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
-    vistas of space promise high costs and hardships, as well as high reward.
+<h2>How to Send Invitations</h2>
+<ul>
+    <li>First select what groups and rooms you want to include in your invitation (unless you are already in a  group context, in which case GameChat defaults the group)</li>
+    <li>Can't send invitations to protected users (invite their chaperone account, instead)</li>
+    <li>Once the invitation is accepted, the invited user can join all public rooms in the target group(s)</li>
+</ul>
 <p>
     Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
 <hr>

--- a/app/src/main/assets/misc/protectedUsers.html
+++ b/app/src/main/assets/misc/protectedUsers.html
@@ -8,22 +8,37 @@
     <h1>Protected Users</h1>
 </center>
 <hr>
-<h2>Portion of text of JFK's Rice Stadium "Moon Speech"</h2>
+<h2>What is a Protected User?</h2>
 <p>
-    September 12, 1962
-<p>
-    No man can fully grasp how far and how fast we have come, but condense, if you will, the 50,000 years of man¹s recorded history in a time span of but a
-    half-century. Stated in these terms, we know very little about the first 40 years, except at the end of them advanced man had learned to use the skins of
-    animals to cover them. Then about 10 years ago, under this standard, man emerged from his caves to construct other kinds of shelter. Only five years ago man
-    learned to write and use a cart with wheels. Christianity began less than two years ago. The printing press came this year, and then less than two months ago,
-    during this whole 50-year span of human history, the steam engine provided a new source of power.
-<p>
-    Newton explored the meaning of gravity. Last month electric lights and telephones and automobiles and airplanes became available. Only last week did we develop
-    penicillin and television and nuclear power, and now if America's new spacecraft succeeds in reaching Venus, we will have literally reached the stars before
-    midnight tonight.
-<p>
-    This is a breathtaking pace, and such a pace cannot help but create new ills as it dispels old, new ignorance, new problems, new dangers. Surely the opening
-    vistas of space promise high costs and hardships, as well as high reward.
+    A protected user allows GameChat access to a child or other person who does not have an online presence.
+
+<h3>GameChat Users</h3>
+<ul>
+    <li>
+        <u>Standard User:</u> A user who logs in to GameChat using Google, Facebook or email credentials, which are used to track the user's GameChat experiences and chat.
+    </li>
+    <li>
+        <u>Chaperone:</u> A standard user who creates a protected user becomes that protected users <i>chaperone</i>. The chaperone account is the only account that can
+        manage their protected users.
+    </li>
+    <li>
+        <u>Protected User:</u> A special type of restricted user which has limited functions (and presumably no online presence).
+    </li>
+</ul>
+
+<h2>Creating a Protected User</h2>
+<ul>
+    <li>A protected user account is created by a standard user.</li>
+    <li>The email address can be fake.
+    <br>The protected user does not need to have a valid e-mail address, although GameChat will ask you to specify an email address when you create the
+    protected user. <i><b>Wait, what?</b></i> Yes, GameChat will use this "email address" as a means to track the protected user's
+    chat and game experiences and to make sure that no other accounts can access them. The email address does not have to be valid (we will never send
+    email to the address), and in fact we suggest that it is <i>not</i> valid, which will help your protected user stay below the Internet radar.
+    </li>
+    <li>When creating a protected user, the chaperone selects one or more groups for the protected user to access.</li>
+    <li>To complete the creation of the protected user account, GameChat will log in to the protected user account.</li>
+</ul>
+
 <p>
     Send mail to <a href="mailto:support@pajato.com">support@pajato.com</a>.
 <hr>

--- a/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/PlayModeManager.java
@@ -84,7 +84,7 @@ public enum PlayModeManager {
     }
 
     /** Handle a use selection in the play mode menu */
-    public void handlePlayModeUserSelection(TextView view, BaseExperienceFragment fragment) {
+    public void handlePlayModeUserSelection(View view, BaseExperienceFragment fragment) {
         Object payload = view.getTag();
         if (payload == null || !(payload instanceof PlayModeMenuEntry))
             return;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -146,7 +146,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             PlayModeManager.instance.closePlayModeMenu();
             return;
         }
-        PlayModeManager.instance.handlePlayModeUserSelection((TextView)event.view, this);
+        PlayModeManager.instance.handlePlayModeUserSelection(event.view, this);
     }
 
     @Subscribe public void onExperienceListChange(ExpListChangeEvent event) {


### PR DESCRIPTION
# Rationale
Fixed problems with how we access and update the maps for the experiences.

# Changed Files

## HTML Files

### assets/misc/creatingGroups.html
* Start updating the help text.

### assets/misc/invitations.html
* Start updating the help text.

### assets/misc/protectedUsers.html
* Start updating the help text.

## Java Files

### common/PlayModeManager.java
* Casting the first parameter of *handlePlayModeUserSelection* to a TextView is not necessary, so we're leaving it as a standard view.

### database/AccountManager.java
* In *onRoomProfileChange*, we now only join the user automatically to the common room, as opposed to all rooms.
* In *onRoomProfileChange*, if the room is a private room and the current account has not joined it, remove the watcher on it to allow private rooms to stay private.

### database/ExperienceManager.java
* Fixed a few nit-picky typos in comments and variable names.
* Renamed *updateHeaderMaps* to *updateAllMaps* to be more accurate.
* Fixed a logic bug in *updateHeaderMaps* to always put the content into the roomMap.
* Fixed a logic bug in *updateHeaders* to not overwrite the room map contents, and to correctly fill up the room list before adding to the Date Header Room Map.

### exp/BaseExperienceFragment.java
* In the *handlePlayModeChange* handler, casting the first parameter of *handlePlayModeUserSelection* to a TextView is not necessary.