### PR TITLE
Silence a lint warning.

### DIFF
--- a/app/src/main/res/layout/item_help_article.xml
+++ b/app/src/main/res/layout/item_help_article.xml
@@ -49,6 +49,11 @@ http://www.gnu.org/licenses
             android:onClick="onClick"
             android:textAppearance="?android:attr/textAppearanceListItem"
             tools:text="Help article title" />
+        <ImageView
+            android:id="@+id/DummyItemIcon"
+            android:contentDescription="@string/dummy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
     </LinearLayout>
 
     <View

--- a/app/src/main/res/values/strings_chat.xml
+++ b/app/src/main/res/values/strings_chat.xml
@@ -21,6 +21,7 @@
     <string name="DeleteExperienceTitle">Delete Experience?</string>
     <string name="DeleteUserTitle">Delete Protected User</string>
     <string name="DeleteUserConfirm">Are you sure you want to delete %s?</string>
+    <string name="dummy">Placeholder</string>
     <string name="EmailHint">Email (does not need to be a real email account)</string>
     <string name="EmailInvalidMessage">Invalid email format</string>
     <string name="FutureFeature">is a future feature. Volunteer by sending feedback using the Help &amp; Feedback menu item.</string>


### PR DESCRIPTION
Add an empty ImageView to the item_help_article layout file to silence lint complaints about merging the existing TextView and ImageView (using the TextView's drawable). Since the icon needs a tint and needs to be sized, using the TextView drawable is possible but introduces a lot of problems which aren't worth addressing at this time. We also have to add a string for the image view content description to silence another potential lint complaint.