### PR TITLE
Only Let Players Play on Their Turns

### DIFF
--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -51,6 +51,7 @@
     <string name="wins">wins</string>
     <string name="xValue">X</string>
     <string name="SelectUserListIcon">Select User</string>
+    <string name="NotAPlayerMessageText">You are not a player in this game.</string>
     <string name="PlayOutOfTurnMessageText">Please wait for your turn.</string>
     <string name="CheckMateText">Checkmate!</string>
 </resources>


### PR DESCRIPTION
# Rationale

Ensuring that players can only move a piece when it is their turn is essential in online play. With the new changes, I ensure that players who are playing online (with another user in a room) can no longer play a piece if it is not their turn, effectively allowing them to take their opponents turns for them.

# Changed Files

## Java Files

### exp/TileClickHandler.java
* Check if the user is a player in the game with the new method *isNotAPlayer*. If they are not a player, inform them that they will need to make their own game via a snackbar notification.
* Modify method *isPlayingOutOfTurn* to get the Experience's Model's Player object for the current user and ensure that it is the current user's turn before letting them play.
* This should only affect online play. If there is a user without an ID in the list and the name is "Friend" -- the default placeholder name for a "local" player, then we can ignore checking the current logged in user's credentials.

## XML Files

### res/values/strings.exp.xml
* Added new string *NotAPlayerMessageText* that is used to notify players trying to move pieces when they are not a player in the current experience.