### PR TITLE
Provide more contrast in some UI components.

### DIFF
--- a/app/src/main/res/layout/item_create_new.xml
+++ b/app/src/main/res/layout/item_create_new.xml
@@ -20,7 +20,7 @@ http://www.gnu.org/licenses
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/colorLightGray"
+    android:background="@color/colorVeryLightGray"
     android:orientation="vertical">
     <LinearLayout style="@style/ListItemLayout" android:id="@+id/ListItem">
         <ImageView style="@style/ListItemImage" android:id="@+id/NewListItemIcon"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="colorGreen">#00c853</color>
     <color name="colorGray">#616161</color>
     <color name="colorLightGray">#cfd8dc</color>
+    <color name="colorVeryLightGray">#e1e4e6</color>
     <color name="colorLightBlue">#e0f2f1</color>
     <color name="white">#ffffff</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -78,7 +78,7 @@ http://www.gnu.org/licenses
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:background">@color/colorLightGray</item>
+        <item name="android:background">@color/colorVeryLightGray</item>
         <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
         <item name="android:textColor">@color/colorPrimary</item>
         <item name="android:paddingStart">4dp</item>
@@ -103,7 +103,7 @@ http://www.gnu.org/licenses
         <item name="android:textColor">@color/colorPrimary</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:background">@color/colorLightGray</item>
+        <item name="android:background">@color/colorVeryLightGray</item>
         <item name="android:textAppearance">?android:attr/textAppearanceListItem</item>
         <item name="android:textStyle">bold</item>
     </style>


### PR DESCRIPTION
# Rationale:
For improved usability, use a lighter gray background for contrast in the "new" item layout and in the item "count" value.

## Files Changed 
#### app/src/main/res/layout/item_create_new.xml
* Change light gray background to very light gray background in new item layout.
#### app/src/main/res/values/colors.xm
* Add definition of a "very light" gray.
#### app/src/main/res/values/styles.xml
* ListItemCount and NewItemTitle: use very light gray, rather than light gray, for more contrast.
