### PR TITLE
Continue enabling offline mode play

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -37,6 +37,7 @@ import com.pajato.android.gamechat.event.ExperienceDeleteEvent;
 import com.pajato.android.gamechat.event.ExperienceResetEvent;
 import com.pajato.android.gamechat.exp.ExpType;
 import com.pajato.android.gamechat.exp.Experience;
+import com.pajato.android.gamechat.main.NetworkManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -289,6 +290,13 @@ public enum ExperienceManager {
         String groupKey = experience.getGroupKey();
         String roomKey = experience.getRoomKey();
         String expKey = experience.getExperienceKey();
+        // Handle offline game play
+        if (groupKey == null && roomKey == null &&
+                experience.getExperienceKey().equals(NetworkManager.OFFLINE_EXPERIENCE_KEY)) {
+            AppEventManager.instance.post(new ExperienceChangeEvent(experience,
+                    ExperienceChangeEvent.CHANGED));
+            return;
+        }
         String path = String.format(Locale.US, EXPERIENCE_PATH, groupKey, roomKey, expKey);
         FirebaseDatabase.getInstance().getReference().child(path).setValue(experience.toMap());
     }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -101,7 +101,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     protected Experience mExperience;
 
     /** A click handler for the board tiles. */
-    protected TileClickHandler mTileClickHandler = new TileClickHandler();
+    protected TileClickHandler mTileClickHandler;
 
     // Public constructors.
 
@@ -182,6 +182,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
         super.onStart();
         if (mAdView != null && mLayout != null && type != null && type.expType == null)
             initAdView(mLayout);
+        // Initialize tile click handler
+        mTileClickHandler = new TileClickHandler(getString(R.string.friend), getString(R.string.you));
     }
 
     // Protected instance methods.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
@@ -25,6 +25,7 @@ import com.pajato.android.gamechat.common.DispatchManager;
 import com.pajato.android.gamechat.common.FragmentType;
 import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.exp.model.Player;
+import com.pajato.android.gamechat.main.NetworkManager;
 
 import static com.pajato.android.gamechat.exp.NotificationManager.NotifyType.experience;
 
@@ -37,6 +38,17 @@ public class TileClickHandler implements View.OnClickListener {
 
     /** The experience model class. */
     private Experience mModel;
+
+    private String friendName;
+
+    private String youName;
+
+    // Constructor
+
+    TileClickHandler(String friend, String you) {
+        friendName = friend;
+        youName = you;
+    }
 
     // Public instance methods.
 
@@ -81,6 +93,10 @@ public class TileClickHandler implements View.OnClickListener {
         for (Player player :  mModel.getPlayers()) {
             if(player.id != null && player.id.equals(AccountManager.instance.getCurrentAccountId()))
                 return false;
+            // Handle offline case
+            if (player.id == null &&
+                    mModel.getExperienceKey().equals(NetworkManager.OFFLINE_EXPERIENCE_KEY))
+                return false;
         }
         return true;
     }
@@ -99,7 +115,10 @@ public class TileClickHandler implements View.OnClickListener {
         // playing with a "Friend", then we don't need to worry about confirming players' identities
         Team playerTeam = team;
         for (Player player :  mModel.getPlayers()) {
-            if(player.id == null && player.name.equals("Friend")) {
+            if(player.id == null && player.name.equals(friendName)) {
+                playerTeam = team;
+                break;
+            } else if (player.id == null && player.name.equals(youName)) {
                 playerTeam = team;
                 break;
             } else if(player.id.equals(AccountManager.instance.getCurrentAccountId())) {

--- a/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
@@ -39,8 +39,10 @@ public class TileClickHandler implements View.OnClickListener {
     /** The experience model class. */
     private Experience mModel;
 
+    /** The default name to use for the second player */
     private String friendName;
 
+    /** The name to use for the primary player when in offline mode */
     private String youName;
 
     // Constructor


### PR DESCRIPTION
#  Rationale

Allow game playing while no network is available.

## Files Changed

#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

* updateExperience(): if the game play is in offline mode and the group and room keys are null (so database path is invalid), just post an experinece change event to allow play to continue.

#### app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
* pass the 'you' and 'friend' strings to be used in offline mode into the TileClickHandler constructor

#### app/src/main/java/com/pajato/android/gamechat/exp/TileClickHandler.java
* add fields to save default player names
* pass default player name fields in constructor
* isNotAPlayer(): allow play in the offline case
* isPlayingOutOfTurn(): use friend name string rather than hard-coded value; check for 'you' case for offline mode play
