### PR TITLE
Set game toolbar title to "Offline" when playing offline.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
@@ -21,6 +21,7 @@ import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.database.RoomManager;
 import com.pajato.android.gamechat.exp.model.Player;
 import com.pajato.android.gamechat.main.MainService;
+import com.pajato.android.gamechat.main.NetworkManager;
 
 import java.util.List;
 import java.util.Locale;
@@ -105,7 +106,13 @@ public class ExpHelper {
         TextView name = getTextView(model, R.id.roomName);
         if (name == null)
             return;
-        name.setText(RoomManager.instance.getRoomName(model.getRoomKey()));
+        if (model.getRoomKey() == null &&
+                model.getExperienceKey().equals(NetworkManager.OFFLINE_EXPERIENCE_KEY)) {
+            BaseFragment fragment = getBaseFragment(model);
+            name.setText(fragment.getString(R.string.offline));
+        }
+        else
+            name.setText(RoomManager.instance.getRoomName(model.getRoomKey()));
     }
 
     /** Update the move on the database and generate notifications to room members. */

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -43,6 +43,7 @@
     <string name="friend">Friend</string>
     <string name="you">You</string>
     <string name="game">Game</string>
+    <string name="offline">Offline</string>
     <string name="oValue">O</string>
     <string name="player1">Player 1</string>
     <string name="player2">Player 2</string>


### PR DESCRIPTION
# Rationale
When playing a game offline, the toolbar title was empty. Set it to "Offline".

## Files Changed
#### app/src/main/java/com/pajato/android/gamechat/exp/ExpHelper.java
* setRoomName(): set name to reflect offline mode
#### app/src/main/res/values/strings_exp.xml
* add string for Offline