### PR TITLE
Fix bug causing empty group to appear in experience list.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -257,6 +257,11 @@ public enum ExperienceManager {
         if (event.account != null) return;
         expGroupMap.clear();
         experienceMap.clear();
+        mGroupToRecentMap.clear();
+        mDateHeaderGroupMap.clear();
+        mDateHeaderExpMap.clear();
+        mDateHeaderRoomMap.clear();
+        mRoomToRecentMap.clear();
     }
 
     /** Handle an experience change event by updating the date headers. */


### PR DESCRIPTION
# Rationale
When switching users, clear all the maps in the ExperienceManager so that the experience screens aren't confused.

## File Changed
#### app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
* onAuthenticationChange(): clear ALL maps saved by ExperienceManager so that experience lists are correct for this user.