### PR TITLE
Fix broken sign-out code.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -202,8 +202,8 @@ public class MainActivity extends BaseActivity
             case R.id.signOut:
                 // On a sign in or sign out event, make sure the navigation drawer gets closed.
                 AppEventManager.instance.post(new NavDrawerOpenEvent(this, null));
-                FragmentActivity activity = DispatchManager.instance.getFragment(FragmentType
-                        .chatEnvelope).getActivity();
+                FragmentType type = DispatchManager.instance.currentChatFragmentType;
+                FragmentActivity activity = DispatchManager.instance.getFragment(type).getActivity();
                 AccountManager.instance.signOut(activity);
                 break;
             case R.id.switchAccount:


### PR DESCRIPTION
# Rationale
Sign-out broke because the DispatchManager returned a null activity for the chat envelope fragment. Instead, use the current chat fragment (saved by the DispatchManager).

## File Changed

#### app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

* onClick(): in the signOut case, use the current chat fragment (saved by the DispatchManager) to find a valid activity. The chat envelope returned a null activity.
