### PR TITLE
Prepare for next Beta release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 apply plugin: 'project-report'
 
 android {
@@ -9,8 +10,8 @@ android {
         applicationId "com.pajato.android.gamechat"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 6
-        versionName "1.0-beta"
+        versionCode 7
+        versionName "b1.$versionCode"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
@@ -49,16 +50,13 @@ android {
         }
         stage {
             initWith debug
+            proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
             signingConfig signingConfigs.stage
         }
     }
 
-    //noinspection GroovyMissingReturnStatement
     packagingOptions {
         exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE-FIREBASE.txt'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/MANIFEST.MF'
     }
 
     lintOptions {
@@ -106,6 +104,9 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation 'de.hdodenhof:circleimageview:1.3.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
+
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     // Espresso UI testing dependencies.
     androidTestImplementation "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,9 +18,9 @@
 #-dontshrink
 #-dontoptimize
 -dontpreverify
--repackageclasses ''
--allowaccessmodification
--optimizations !code/simplification/arithmetic
+#-repackageclasses ''
+#-allowaccessmodification
+#-optimizations !code/simplification/arithmetic
 -keepattributes *Annotation*
 -keep class com.pajato.** {
     *;

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.1.2-4'
     repositories {
         maven { url 'https://maven.google.com' }
         jcenter()
@@ -8,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
         classpath 'com.google.gms:google-services:3.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -43,7 +45,8 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-// Define and load the hidden property file holding API keys and other secrets.
+// Define and load the hidden property file holding API keys and other secrets. Idea borrowed from
+// https://medium.com/@cassioso/a-strategy-to-secure-your-api-keys-using-gradle-b9c107272860
 def secretsPropertiesFile = file("secrets.properties")
 def secretsProperties = new Properties()
 secretsProperties.load(new FileInputStream(secretsPropertiesFile))
@@ -61,7 +64,7 @@ ext {
     firebaseAuthUIVersion = '1.2.0'
     gmsVersion = '11.0.0'
     runnerVersion = '0.5'
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '25.4.0'
     uiautomatorVersion = '2.1.2'
 
     // GameChat secrets


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit sets the version code and version name for the next beta release.  It also prunes some stale build script code, enables Kotlin going forward, eliminates annoying Proguard build warnings, and upgrades the support library version.

modified:   app/build.gradle

- Summary: prepare for the next Beta release, silence an annoying build warning and enable Kotlin.

modified:   app/proguard-rules.pro

- Summary: disable some unused flags.

modified:   build.gradle

- Summary: enable Kotlin and upgrade the support library version.