### PR TITLE
Updating Gradle to Most Recent Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 07 04:05:50 EDT 2017
+#Mon Jun 19 21:20:43 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-rc-1-all.zip


### PR DESCRIPTION
# Rationale
Rather than have the developers each have changes to gradle files
locally, we should be updating the gradle version as it changes in
version control.

# Changed Files

## Gradle Files

### gradle-wrapper.properties
* Updated distribution URL to **gradle-4.0-rc-1-all**

### build.gradle
* Updated gradle plugin version to **3.0.0-alpha4**