### PR TITLE
Release the gradient background sign-in code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ captures/
 # Android Studio other
 *.iml
 .idea/
+app/release
 
 # Mac OS X detritus
 .DS_Store

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "com.pajato.android.gamechat"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
+        versionCode 9
         versionName "b1.$versionCode"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true
@@ -23,6 +23,7 @@ android {
             storePassword GC_STORE_PASSWORD
             keyAlias GC_RELEASE_KEY_ALIAS
             keyPassword GC_RELEASE_KEY_PASSWORD
+            v2SigningEnabled false
         }
         stage {
             storeFile file(GC_STORE_FILE)
@@ -34,25 +35,30 @@ android {
 
     buildTypes {
         debug {
+            debuggable true
             shrinkResources true
             minifyEnabled true
             useProguard false
-            proguardFile getDefaultProguardFile('proguard-android.txt')
             proguardFile 'proguard-rules.pro'
-            debuggable true
             testCoverageEnabled = true
         }
         release {
-            initWith debug
-            proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
-            debuggable false
+            shrinkResources true
+            minifyEnabled true
+            useProguard false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
         stage {
             initWith debug
-            proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
             signingConfig signingConfigs.stage
         }
+    }
+
+    buildTypes.each {
+        it.buildConfigField 'String', 'GC_TEST_EMAIL_KEY', GC_TEST_EMAIL
+        it.buildConfigField 'String', 'GC_TEST_PASSWORD_KEY', GC_TEST_PASSWORD
+        it.buildConfigField 'String', 'GC_TEST_PROVIDER_KEY', GC_TEST_PROVIDER
     }
 
     packagingOptions {

--- a/app/src/androidTest/java/com/pajato/android/gamechat/BaseTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/BaseTest.java
@@ -4,8 +4,6 @@ import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
-import com.google.firebase.auth.FirebaseAuth;
-import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.main.MainActivity;
 
 import org.junit.After;
@@ -35,8 +33,8 @@ public abstract class BaseTest {
 
     // Private class constants.
 
-    /** The logcat tag. */
-    private static final String TAG = BaseTest.class.getSimpleName();
+    ///** The logcat tag. */
+    //private static final String TAG = BaseTest.class.getSimpleName();
 
     // Public instance variables.
 
@@ -47,9 +45,9 @@ public abstract class BaseTest {
     @Before public void setup() {
         Intent intent = new Intent();
         intent.putExtra(MainActivity.SKIP_INTRO_ACTIVITY_KEY, true);
-        intent.putExtra(TEST_USER_KEY, getProperty("testAccountName", "nobody@gamechat.com"));
-        intent.putExtra(TEST_PROVIDER_KEY, getProperty("testAccountProvider", "email"));
-        intent.putExtra(TEST_PASSWORD_KEY, getProperty("testAccountPassword", null));
+        intent.putExtra(TEST_USER_KEY, getProperty(BuildConfig.GC_TEST_EMAIL_KEY, "nobody@gamechat.com"));
+        intent.putExtra(TEST_PROVIDER_KEY, getProperty(BuildConfig.GC_TEST_PROVIDER_KEY, "email"));
+        intent.putExtra(TEST_PASSWORD_KEY, getProperty(BuildConfig.GC_TEST_PASSWORD_KEY, null));
         mRule.launchActivity(intent);
     }
 

--- a/app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java
@@ -1,10 +1,17 @@
 package com.pajato.android.gamechat.main;
 
 import com.pajato.android.gamechat.BaseTest;
+import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FragmentKind;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Provide a placeholder for testing the main activity class.
@@ -27,7 +34,11 @@ public class MainActivityTest extends BaseTest {
 
     //@Test public void onBackPressed1() throws Exception {}
 
-    //@Test public void onClick() throws Exception {}
+    @Test public void onClick() throws Exception {
+        // Trigger the onClick(View) method using a click on the chat envelope's FAB button.
+        // Open up the FAB menu
+        onView(withId(R.id.chatFab)).check(matches(isDisplayed())).perform(click());
+    }
 
     //@Test public void onClick1() throws Exception {}
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,4 +74,7 @@ ext {
     GC_RELEASE_KEY_PASSWORD = secretsProperties['gcReleaseKeyPassword']
     GC_STAGE_KEY_ALIAS = secretsProperties['gcStageKeyAlias']
     GC_STAGE_KEY_PASSWORD = secretsProperties['gcStagePassword']
+    GC_TEST_EMAIL = secretsProperties['gcTestAddress']
+    GC_TEST_PASSWORD = secretsProperties['gcTestPassword']
+    GC_TEST_PROVIDER = secretsProperties['gcTestProvider']
 }


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit replaces the huge checkerboard background with a gradient background significantly reducing the size of the APK.

It also hides the Android Studio generated release APK which is, by default, placed in the source tree under the app folder.

Lastly, it greases the skids for more MainActivity test coverage.

<h1>File changes:</h1>

modified:   .gitignore

- Summary: hide the default signed APK generated by Android Studio.

modified:   app/build.gradle

- Summary: update the release to version 9; disable V2 signing; completely specify the release configuration instead of basing off of the debug code; set the BuildConfig testing  secrets.

modified:   app/src/androidTest/java/com/pajato/android/gamechat/BaseTest.java

- Summary: silence some Android Studio warnings.

modified:   app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java

- Summary: start working on increasing the MainActivity class test coverage.

modified:   build.gradle

- Summary: make the test User secrets available to Java code.