### PR TITLE
Updating Checkerboard Generation

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/BaseTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/BaseTest.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.pajato.android.gamechat.database.AccountManager;
 import com.pajato.android.gamechat.main.MainActivity;
 
 import org.junit.After;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -158,7 +158,7 @@ public class CheckersFragment extends BaseExperienceFragment {
         if (dispatcher.roomKey == null) {
             Log.e(TAG, "Got to onSetup without a room key - we may be offline");
         }
-        mBoard = new Checkerboard(context);
+        mBoard = new Checkerboard();
 
         // If a Checkers experience is available in the given room, use it; else create a new one
         mExperience = ExperienceManager.instance.getExperience(dispatcher.groupKey,

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -148,7 +148,7 @@ public class ChessFragment extends BaseExperienceFragment {
         if (dispatcher.roomKey == null) {
             Log.e(TAG, "Got to onSetup without a room key - we may be offline");
         }
-        mBoard = new Checkerboard(context);
+        mBoard = new Checkerboard();
 
         // If a Chess experience is available in the given room, use it; else create a new one
         mExperience = ExperienceManager.instance.getExperience(dispatcher.groupKey,

--- a/app/src/main/res/layout/exp_checkers.xml
+++ b/app/src/main/res/layout/exp_checkers.xml
@@ -33,8 +33,8 @@ http://www.gnu.org/licenses
             android:id="@+id/wins"
             android:layout_width="wrap_content"
             android:layout_height="16dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="20dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp"
             android:background="@color/colorLightBlue"
             android:text="@string/wins"
             android:textSize="14sp"
@@ -65,27 +65,14 @@ http://www.gnu.org/licenses
             app:layout_constraintBottom_toBottomOf="@id/wins"
             tools:text="0" />
 
-        <TextView android:id="@+id/turn"
-            android:layout_width="wrap_content"
-            android:layout_height="20dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginTop="20dp"
-            android:background="@color/colorLightBlue"
-            android:text="@string/turn"
-            android:textSize="14sp"
-            app:layout_constraintLeft_toRightOf="parent"
-            app:layout_constraintRight_toLeftOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/wins"
-            tools:text="turn" />
-
         <ImageView android:id="@+id/player_1_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:contentDescription="@string/player1"
             app:srcCompat="@drawable/ic_account_circle_black_36dp"
-            app:layout_constraintTop_toTopOf="@id/turn"
-            app:layout_constraintBottom_toBottomOf="@id/turn"
+            app:layout_constraintTop_toTopOf="@id/wins"
+            app:layout_constraintBottom_toBottomOf="@id/wins"
             app:layout_constraintRight_toLeftOf="@+id/rightIndicator1" />
 
         <TextView android:id="@+id/leftIndicator1"
@@ -109,7 +96,7 @@ http://www.gnu.org/licenses
             android:textColor="@color/colorPrimary"
             android:textSize="20sp"
             android:textStyle="bold"
-            app:layout_constraintRight_toLeftOf="@id/turn"
+            app:layout_constraintRight_toLeftOf="@id/player1WinCount"
             app:layout_constraintTop_toTopOf="@+id/player_1_icon"
             app:layout_constraintBottom_toBottomOf="@+id/player_1_icon"/>
 
@@ -120,8 +107,8 @@ http://www.gnu.org/licenses
             android:layout_marginEnd="8dp"
             android:contentDescription="@string/player2"
             app:srcCompat="@drawable/ic_account_circle_black_36dp"
-            app:layout_constraintTop_toTopOf="@+id/turn"
-            app:layout_constraintBottom_toBottomOf="@+id/turn"
+            app:layout_constraintTop_toTopOf="@+id/wins"
+            app:layout_constraintBottom_toBottomOf="@+id/wins"
             app:layout_constraintLeft_toRightOf="@+id/leftIndicator2" />
 
         <TextView android:id="@+id/leftIndicator2"
@@ -135,7 +122,7 @@ http://www.gnu.org/licenses
             android:textStyle="bold"
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="@+id/player_2_icon"
-            app:layout_constraintLeft_toRightOf="@id/turn"
+            app:layout_constraintLeft_toRightOf="@id/player2WinCount"
             app:layout_constraintTop_toTopOf="@+id/player_2_icon" />
 
         <TextView android:id="@+id/rightIndicator2"
@@ -166,7 +153,9 @@ http://www.gnu.org/licenses
         <GridLayout android:id="@+id/board"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="20dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginTop="12dp"
             android:padding="6dp"
             android:columnCount="8"
             android:columnOrderPreserved="true"
@@ -176,7 +165,7 @@ http://www.gnu.org/licenses
             android:background="@color/colorGray"
             app:layout_constraintLeft_toLeftOf="@id/checkers_panel"
             app:layout_constraintRight_toRightOf="@id/checkers_panel"
-            app:layout_constraintTop_toBottomOf="@id/turn" />
+            app:layout_constraintTop_toBottomOf="@id/wins" />
 
     </android.support.constraint.ConstraintLayout>
 </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/layout/exp_envelope.xml
+++ b/app/src/main/res/layout/exp_envelope.xml
@@ -59,8 +59,8 @@ http://www.gnu.org/licenses
         <android.support.design.widget.FloatingActionButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="8dp"
             android:layout_gravity="bottom|end"
             android:id="@+id/gameFab"
             android:onClick="onClick"

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ ext {
     GC_RELEASE_KEY_ALIAS = secretsProperties['gcReleaseKeyAlias']
     GC_RELEASE_KEY_PASSWORD = secretsProperties['gcReleaseKeyPassword']
     GC_STAGE_KEY_ALIAS = secretsProperties['gcStageKeyAlias']
-    GC_STAGE_KEY_PASSWORD = secretsProperties['gcStagePassword']
+    GC_STAGE_KEY_PASSWORD = secretsProperties['gcStageKeyPassword']
     GC_TEST_EMAIL = secretsProperties['gcTestAddress']
     GC_TEST_PASSWORD = secretsProperties['gcTestPassword']
     GC_TEST_PROVIDER = secretsProperties['gcTestProvider']


### PR DESCRIPTION
# Rationale
Due to recently events that revealed flaws in how we generate the
checkerboard's size at runtime, I have updated that process entirely.

# Changed Files

## Java Files

### BaseTest.java
* Included missing imports.

### exp/fragment/CheckersFragment.java
* Updated the Checkerboard constructor, as it no longer needs a context.

### exp/fragment/ChessFragment.java
* Updated the Checkerboard constructor, as it no longer needs a context.

### exp/Checkerboard.java
* Removed size constants.
* Removed context from constructor. Cell size is now determined in **init**.
* Revamped **getCellSize** to now use the experience envelope as a base for height and width rather than the height and width of the device screen, which eliminates the need for trying to factor in the height of the toolbar, along with notification bars or navigation buttons that we didn't factor in beforehand. In addition, the calculations have been updated to match new margins and sizes, and more comprehensive comments have been included.
* New method **dipsToPx** that facilitates conversions that take place in **getCellSize**

## XML Files

### layout/exp_checkers.xml
* Reduced margins on the "wins" indicator text.
* Removed the *turn* text, and moved the turn indicators to the upper row, allowing more room for the board.
* Reduced margins on the board.

### layout/exp_envelope.xml
* Reduced margins on the Floating Action Button.

## Gradle Files

### build.gradle
* Fixed a typo in the definition of GC_STAGE_KEY_PASSWORD.