### PR TITLE
Fix the very annoying new fatal exception crash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ captures/
 *.iml
 .idea/
 app/release
+app/src/release
+app/src/debug
+app/src/stage
 
 # Mac OS X detritus
 .DS_Store

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
             shrinkResources true
             minifyEnabled true
             useProguard false
-            proguardFile 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testCoverageEnabled = true
         }
         release {


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a new problem introduced by recent Android Studio changes. With those changes, the release build type worked fine but the debug and stage build types would get a fatal exception that was not traceable back to GameChat code. The fix turned out to be to use consistent pro-guard files across all three build types. The best guess is that a change to resource/apk shrinking surfaced the crash.

Also, the git ignore file was modified to add the build type google-services.json files.

<h1>File changes:</h1>

modified:   .gitignore

- Summary: exclude the google-services.json files.

modified:   app/build.gradle

- Summary: resolve the new fatal exception issue.