### PR TITLE
Prepare to release version b1.11 to fix a pawn movement bug.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+# Release b1.11
+
+## Bug fixes
+
+Fix the bug whereby a pawn on column position 7 (base 1) in any row was not able to take a piece to the right.
+
 # Release b1.10
 
 ## Bug fixes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "com.pajato.android.gamechat"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
+        versionCode rootProject.ext.versionCode
         versionName "b1.$versionCode"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
@@ -300,7 +300,7 @@ public class ChessHelper {
                     && board.getTeam(downRight).equals(Team.PRIMARY)) {
                 threatRange.add(downRight);
             }
-            if (board.getPiece(downLeft) != null && downRight % 8 != 7
+            if (board.getPiece(downLeft) != null && downLeft % 8 != 7
                     && board.getTeam(downLeft).equals(Team.PRIMARY)) {
                 threatRange.add(downLeft);
             }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
@@ -31,7 +31,7 @@ allprojects {
     // incurring the stress, strain and inherent problem in trying to
     // sync build files.  The build files would likely live isolated
     // to each local development system.
-    //
+
     // TODO: A better solution, possibly optimal, would be to provide
     // a Gradle plugin to handle a more complete implementation
     // mirroring the app structure.
@@ -58,11 +58,12 @@ ext {
     targetSdkVersion = 25
     compileSdkVersion = 25
     buildToolsVersion = '25.0.1'
+    versionCode = 11
 
     // App dependencies
     espressoVersion = '2.2.2'
     firebaseAuthUIVersion = '1.2.0'
-    gmsVersion = '11.0.1'
+    gmsVersion = '11.0.2'
     runnerVersion = '0.5'
     supportLibraryVersion = '25.4.0'
     uiautomatorVersion = '2.1.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 19 21:20:43 EDT 2017
+#Fri Jul 07 02:10:47 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug that prevented a pawn from making a valid move to take a piece.

<h1>File changes:</h1>

modified:   ReleaseNotes.md

- Summary: details the bug.

modified:   app/build.gradle

- Summary: obtain the version code from the root project ext block.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java

- getPawnThreatRange(): fix the bug by doing a correct threat validity check.

modified:   build.gradle

- Summary: upgrade to use AS 3.0 Preview 5; add a "versionCode" parameter to the ext block; upgrade to use GMS version 11.0.2

modified:   gradle/wrapper/gradle-wrapper.properties

- Summary: upgrade to use AS 3.0 Preview 5 (gradle 4.1-milestone1)