### PR TITLE
Fix Chess/Checkers reset for release.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ android {
             testCoverageEnabled = true
         }
         release {
+            debuggable false
             shrinkResources true
             minifyEnabled true
             useProguard false

--- a/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java
@@ -200,13 +200,6 @@ public enum ExperienceManager {
         return null;
     }
 
-    /** Update an experience in the database after its model has been reset */
-    @Subscribe void handleExperienceResetEvent(ExperienceResetEvent event) {
-        Experience experience = getExperience(event.experienceKey);
-        if (experience != null)
-            ExperienceManager.instance.updateExperience(experience);
-    }
-
     /** Get the data as a set of list items for all groups. */
     public List<ListItem> getGroupListItemData() {
         // Determine whether to handle no groups (a set of welcome list items), one group (a set of

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
@@ -6,6 +6,7 @@ import com.google.firebase.database.Exclude;
 import com.google.firebase.database.IgnoreExtraProperties;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.BaseFragment;
+import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.ExperienceResetEvent;
 import com.pajato.android.gamechat.exp.Board;
@@ -212,7 +213,7 @@ import static com.pajato.android.gamechat.exp.State.active;
         DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
             @Override public void onClick(DialogInterface d, int id) {
                 resetModel();
-                AppEventManager.instance.post(new ExperienceResetEvent(key));
+                ExperienceManager.instance.updateExperience(Chess.this);
             }
         };
         fragment.showAlertDialog(fragment.getString(R.string.ResetGameTitle),

--- a/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java
@@ -332,8 +332,8 @@ public class ChessHelper {
         int leftLeftUp = highlightedIndex - 10;
 
         // Ensure we obey the sides of the board when we set up our movement options.
-        if(upUpLeft % 8 == 7) upUpLeft = -1;
-        if(upUpRight % 8 == 0) upUpRight = -1;
+        if (upUpLeft % 8 == 7) upUpLeft = -1;
+        if (upUpRight % 8 == 0) upUpRight = -1;
         if (rightRightUp % 8 == 0 || rightRightUp % 8 == 1) rightRightUp = -1;
         if (rightRightDown % 8 == 0 || rightRightDown % 8 == 1) rightRightDown = -1;
         if (downDownRight % 8 == 0) downDownRight = -1;

--- a/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import com.google.firebase.database.Exclude;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.BaseFragment;
+import com.pajato.android.gamechat.database.ExperienceManager;
 import com.pajato.android.gamechat.database.model.Base;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.ExperienceResetEvent;
@@ -178,7 +179,7 @@ public class Checkers extends Base implements Experience {
         DialogInterface.OnClickListener okListener = new DialogInterface.OnClickListener() {
             @Override public void onClick(DialogInterface d, int id) {
                 resetModel();
-                AppEventManager.instance.post(new ExperienceResetEvent(key));
+                ExperienceManager.instance.updateExperience(Checkers.this);
             }
         };
         fragment.showAlertDialog(fragment.getString(R.string.ResetGameTitle),


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit fixes a bug whereby doing a FAB reset on Chess and Checkers did not work in the release build type but did work for debug and stage build types.  Go figure.

<h1>File changes:</h1>

modified:   app/build.gradle

Summary: make it explicit that the release build type is not debuggable.

modified:   app/src/main/java/com/pajato/android/gamechat/database/ExperienceManager.java

- handleExperienceResetEvent(): remove as it is now unnecessary.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/Chess.java
modified:   app/src/main/java/com/pajato/android/gamechat/exp/model/Checkers.java

- reset(): immediately update the database with the reset game model.

modified:   app/src/main/java/com/pajato/android/gamechat/exp/chess/ChessHelper.java

- Summary: cosmetic RNF changes.