### PR TITLE
Use live credentials data in switch user.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java
@@ -214,7 +214,7 @@ public class CreateProtectedUsersFragment extends BaseChatFragment {
                 showNameLayout(true, false);
             }
             showPasswordLayout(true, false);
-            passwordText.setText(credentials.secret);
+            passwordText.setText("");
             enableFinishButton(true);
             pwdBtn.setEnabled(true);
         } else {

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java
@@ -72,7 +72,7 @@ public class SelectGroupsFragment extends BaseChatFragment {
                     break;
                 }
                 AccountManager.instance.createProtectedAccount(credentials.email, credentials.name,
-                        credentials.secret, credentials.accountIsKnown, getGroupSelections());
+                        credentials.url, credentials.accountIsKnown, getGroupSelections());
                 break;
             case R.id.selector:
                 // Checkbox click, just update the adapter

--- a/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
@@ -35,11 +35,8 @@ public class Credentials {
     /** The identity provider. */
     public String provider;
 
-    /** The identity secret. */
-    public String secret;
-
-    /** The identity token. */
-    public String token;
+    /** The identity icon url. */
+    public String url;
 
     /** The user name */
     public String name;
@@ -51,20 +48,19 @@ public class Credentials {
 
 
     /** Build an instance for e-mail login (used when creating a protected user) */
-    public Credentials(final String email, final String name, final String password, final boolean isKnown) {
+    public Credentials(final String email, final String name, final String url,
+                       final boolean isKnown) {
         this.email = email;
         this.name = name;
-        this.secret = password;
+        this.url = url;
         this.accountIsKnown = isKnown;
     }
 
     /** Build an instance */
-    public Credentials(final String provider, final String email, final String secret,
-                       final String token) {
+    public Credentials(final String provider, final String email, final String url) {
         this.email = email;
         this.provider = provider;
-        this.secret = secret;
-        this.token = token;
+        this.url = url;
     }
 
 }

--- a/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java
@@ -42,8 +42,6 @@ import java.util.Arrays;
 import static android.view.animation.AnimationUtils.loadAnimation;
 import static com.pajato.android.gamechat.credentials.CredentialsManager.EMAIL_KEY;
 import static com.pajato.android.gamechat.credentials.CredentialsManager.PROVIDER_KEY;
-import static com.pajato.android.gamechat.credentials.CredentialsManager.SECRET_KEY;
-import static com.pajato.android.gamechat.credentials.CredentialsManager.TOKEN_KEY;
 
 /**
  * Provide an intro activity ala Telegram.
@@ -63,7 +61,7 @@ public class IntroActivity extends AppCompatActivity {
     /** Handle signing into an existing account by invoking the sign-in activity. */
     public void doSignIn(final View view) {
         // Prepare an intent to handle sign in and let it rip.
-        startActivityForResult(getAuthIntent("signin"), RC_SIGN_IN);
+        startActivityForResult(getAuthIntent(), RC_SIGN_IN);
     }
 
     // Protected instance methods.
@@ -72,26 +70,23 @@ public class IntroActivity extends AppCompatActivity {
      * Handle the sign in activity result. If the sign-in completes with an "OK status, this
      * intro activity is done so return to the main activity with an "OK" status.
      */
-    @Override protected void onActivityResult(final int requestCode, final int resultCode,
-                                              final Intent intent) {
-        super.onActivityResult(requestCode, resultCode, intent);
-        if (requestCode == RC_SIGN_IN && resultCode == RESULT_OK) {
-            IdpResponse response = IdpResponse.fromResultIntent(intent);
-            if (response != null) {
-                String format = "Sign in completed with provider type: %s, e-mail: %s, secret: %s, token: %s";
-                Log.i(IntroActivity.class.getSimpleName(),
-                        String.format(format, response.getProviderType(), response.getEmail(),
-                                response.getIdpSecret(), response.getIdpToken()));
-                intent.putExtra(PROVIDER_KEY, response.getProviderType());
-                intent.putExtra(EMAIL_KEY, response.getEmail());
-                intent.putExtra(SECRET_KEY, response.getIdpSecret());
-                intent.putExtra(TOKEN_KEY, response.getIdpToken());
-            }
-            // Pass the intent obtained from the sign in activity through to the calling intent.
-            setResult(RESULT_OK, intent);
-            finish();
+    @Override
+    protected void onActivityResult(final int request, final int result, final Intent intent) {
+        super.onActivityResult(request, result, intent);
+        IdpResponse response = request == RC_SIGN_IN && result == RESULT_OK
+                ? IdpResponse.fromResultIntent(intent) : null;
+        if (response != null) {
+            String format = "Sign in completed with provider type: %s, e-mail: %s, url: %s";
+            Log.i(IntroActivity.class.getSimpleName(),
+                    String.format(format, response.getProviderType(), response.getEmail()));
+            intent.putExtra(PROVIDER_KEY, response.getProviderType());
+            intent.putExtra(EMAIL_KEY, response.getEmail());
         }
+        // Pass the intent obtained from the sign in activity through to the calling intent.
+        setResult(RESULT_OK, intent);
+        finish();
     }
+
     /** Create the intro activity to highlight some features and provide a get started operation. */
     @Override protected void onCreate(final Bundle savedInstanceState) {
         // Establish the activity state and set up the intro layout
@@ -117,7 +112,7 @@ public class IntroActivity extends AppCompatActivity {
     // Private instance methods.
 
     /** Finish the intro screen and handle the given mode in a new activity. */
-    private Intent getAuthIntent(final String mode) {
+    private Intent getAuthIntent() {
         // Get an intent for which to handle the authentication mode.  While in development mode,
         // disable smart lock.
         AuthUI.SignInIntentBuilder intentBuilder = AuthUI.getInstance().createSignInIntentBuilder();
@@ -129,7 +124,7 @@ public class IntroActivity extends AppCompatActivity {
         intentBuilder.setTheme(R.style.signInTheme);
         //intentBuilder.setIsSmartLockEnabled(!BuildConfig.DEBUG);
         Intent intent = intentBuilder.build();
-        intent.putExtra(mode, true);
+        intent.putExtra("signin", true);
         return intent;
     }
 
@@ -143,11 +138,8 @@ public class IntroActivity extends AppCompatActivity {
         for (int index = 0; index < count; index++) {
             TextView child = (TextView) pageMonitor.getChildAt(index);
             child.setText(R.string.intro_page_circle);
-            if (index == position) {
-                child.setTextSize(TypedValue.COMPLEX_UNIT_SP, LARGE);
-            } else {
-                child.setTextSize(TypedValue.COMPLEX_UNIT_SP, SMALL);
-            }
+            float size = index == position ? LARGE : SMALL;
+            child.setTextSize(TypedValue.COMPLEX_UNIT_SP, size);
         }
     }
 

--- a/app/src/main/res/menu/drawer_body.xml
+++ b/app/src/main/res/menu/drawer_body.xml
@@ -24,12 +24,5 @@
             <item android:title=""/>
         </group>
     </group>
-    <group android:id="@+id/menu_group_users">
-        <item
-            android:title="user1@gmail.com"
-            android:icon="@drawable/ic_verified_user_black_24dp" />
-        <item
-            android:title="user2@gmail.com"
-            android:icon="@drawable/ic_share_black_24dp"/>
-    </group>
+    <group android:id="@+id/menu_group_users"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="AddAccountMenuTitle">Add account</string>
     <string name="AuthFailureInvalidCredentials">Invalid credentials specified.</string>
     <string name="AuthFailureInvalidUser">This user is no longer valid in the Firebase database.</string>
     <string name="AuthSignInFailure">Sign in failed: %s</string>
@@ -19,6 +20,7 @@
     <string name="InviteToGroupFormat">You are invited to join my GameChat group: %s</string>
     <string name="InviteFriendMessage">Invite friends</string>
     <string name="ItemCreatedMessage">%s is created</string>
+    <string name="ManageAccountsMenuTitle">Manage accounts</string>
     <string name="ManageRestrictedUserTitle">Protected Users</string>
     <string name="MenuItemHelpAndFeedback">Help &amp; Feedback</string>
     <string name="MenuItemSearch">Search</string>


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit moves the task of implementing switch user further along.  With these changes, the CredentailsManager is used to supply credentials to the switch user menu generator. Handling these menu choices is the next task.  Also, protected user creation and sign-in both need to ensure that the choices made are persisted with the CredentialsManager class.

Lastly, some small changes have been made to address AS warnings and to provide slightly simpler code in a few places.  See the comments below.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/CreateProtectedUsersFragment.java

- onResume(): passwords and tokens are no longer saved.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectGroupsFragment.java

- onClick(): provide an icon URL instead of a password or token.

modified:   app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java

- secret, token: replace with a url property.

modified:   app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java

- SECRET_KEY, TOKEN_KEY, FORMAT_SECRET, FORMAT_TOKEN: replace with URL_KEY and FORMAT_URL.
- mLastUsedEmailAddress: remove (essentially not used)
- getAuthCredential(): remove (pass the credentials map instead).
- getMap(): new method to provide credentials to the app.
- persist(): placeholder for protected user creation and signin persistence of additional device credentials.

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- getAuthStateChanged(): simply by providing two clauses, one to unregister an existing handler if necessary and one to add a handler if necessary.

modified:   app/src/main/java/com/pajato/android/gamechat/intro/IntroActivity.java

- doSignIn(), getAuthIntent(): fix an AS warning with the mode argument.
- onActivityResult(): simplify and replace the secret/token stuff with icon URL.
- updatePageMonitor(): simplify.

modified:   app/src/main/java/com/pajato/android/gamechat/main/NavigationManager.java

- addUsers(), addUsersWithCredentials(): new methods to support user switching.

modified:   app/src/main/res/menu/drawer_body.xml

- Summary: remove placeholder email address entries.

modified:   app/src/main/res/values/strings.xml

- Summary: add menu titles for adding an account and managing accounts.