### PR TITLE
Ensure that all sign in operations persist the current user.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
+++ b/app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java
@@ -17,6 +17,8 @@
 
 package com.pajato.android.gamechat.credentials;
 
+import android.net.Uri;
+
 /**
  * Provide a POJO to model an a User.
  *
@@ -56,11 +58,17 @@ public class Credentials {
         this.accountIsKnown = isKnown;
     }
 
-    /** Build an instance */
+    /** Build an instance accepting all string properties. */
     public Credentials(final String provider, final String email, final String url) {
         this.email = email;
         this.provider = provider;
         this.url = url;
     }
 
+    /** Build an instance accepting a URI for the photo URL. */
+    public Credentials(String provider, String email, Uri uri) {
+        this.provider = provider;
+        this.email = email;
+        url = uri != null ? uri.toString() : null;
+    }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/event/AuthStateChangedEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AuthStateChangedEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+import com.google.firebase.auth.FirebaseUser;
+
+/**
+ * Provides a Firebase authentication state change event data model class.
+ *
+ * @author Paul Michael Reilly
+ */
+public class AuthStateChangedEvent {
+
+    // Public instance variables
+
+    /** The changed account: if null the User signed out, if non-null the User signed in. */
+    public FirebaseUser user;
+
+    // Public constructor.
+
+    /** Build the instance with the given account; null indicates a sign out occurred. */
+    public AuthStateChangedEvent(final FirebaseUser user) {
+        this.user = user;
+    }
+
+    // Public instance methods.
+
+    /** Provide debug support. */
+    @Override public String toString() {
+        return user != null ? user.toString() : "(null)";
+    }
+}


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit ensures that all signin operations (not just the intro screen signin) persist (and cache) the most current information.  With this commit, a complete set of login information should be available with the switch User feature.  The last remaining piece of switch User is to actually perform the sign in.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/credentials/Credentials.java

- Credentials(): new constructor that takes a Uri property for the user photo.

modified:   app/src/main/java/com/pajato/android/gamechat/credentials/CredentialsManager.java

- persist(): new method with three overloads: one for persisting intent based data, one for persisting User data and some common code for updating the persistence store (shared preferences).

modified:   app/src/main/java/com/pajato/android/gamechat/database/AccountManager.java

- onAuthStateChanged(): post the persistence request.
- onRoomProfileChanged(): simplify (RNF).
- signIn(): make priviate and simplify.

new file:   app/src/main/java/com/pajato/android/gamechat/event/AuthStateChangedEvent.java

- Summary: new file used to capture User data changes.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onAuthStateChange(): deal with credentials persisting.
- onActivityResult(): use the CredentialsManager class directly.
- saveAccountData(): move this functionality into the CredentialsManager class.