### PR TITLE
Provide a Beta hack to allow email users to leverage switch user.

### DIFF
--- a/app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java
+++ b/app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java
@@ -1,17 +1,10 @@
 package com.pajato.android.gamechat.main;
 
 import com.pajato.android.gamechat.BaseTest;
-import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.common.FragmentKind;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Provide a placeholder for testing the main activity class.

--- a/app/src/main/java/com/pajato/android/gamechat/authentication/AuthenticationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/authentication/AuthenticationManager.java
@@ -30,6 +30,7 @@ import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.pajato.android.gamechat.BuildConfig;
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.event.AppEventManager;
 import com.pajato.android.gamechat.event.AuthStateChangedEvent;
@@ -40,6 +41,7 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.pajato.android.gamechat.event.RegistrationChangeEvent.REGISTERED;
@@ -81,7 +83,7 @@ public enum AuthenticationManager implements FirebaseAuth.AuthStateListener {
                 new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build()));
         intentBuilder.setLogo(R.drawable.signin_logo);
         intentBuilder.setTheme(R.style.signInTheme);
-        //intentBuilder.setIsSmartLockEnabled(!BuildConfig.DEBUG);
+        intentBuilder.setIsSmartLockEnabled(!BuildConfig.DEBUG);
         Intent intent = intentBuilder.build();
         intent.putExtra("signin", true);
         return intent;
@@ -155,6 +157,7 @@ public enum AuthenticationManager implements FirebaseAuth.AuthStateListener {
     /** Handle a switch user event by attempting a sign-in to the given email address. */
     private static void signIn(@NonNull final String email) {
         // Ensure that the given email address is valid.  Abort if not.
+        Log.d(TAG, String.format(Locale.US, "Signing in with email address: {%s}.", email));
         AuthCredential authCredential = CredentialsManager.instance.getAuthCredential(email);
         if (authCredential == null)
             return;
@@ -166,8 +169,9 @@ public enum AuthenticationManager implements FirebaseAuth.AuthStateListener {
                         if (!task.isSuccessful()) {
                             Exception exc = task.getException();
                             String excMessage = exc != null ? exc.getMessage() : "N/A";
-                            Log.i(TAG, "Sign operation failed with exception: " + excMessage);
-                        }
+                            Log.d(TAG, "Sign operation failed with exception: " + excMessage);
+                        } else
+                            Log.d(TAG, "Sign in successful and complete.");
                     }
                 });
     }

--- a/app/src/main/java/com/pajato/android/gamechat/authentication/CredentialsManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/authentication/CredentialsManager.java
@@ -22,6 +22,8 @@ import android.support.annotation.NonNull;
 
 import com.firebase.ui.auth.IdpResponse;
 import com.google.firebase.auth.AuthCredential;
+import com.google.firebase.auth.EmailAuthCredential;
+import com.google.firebase.auth.EmailAuthProvider;
 import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.TwitterAuthProvider;
@@ -74,6 +76,9 @@ public enum CredentialsManager {
 
         // Return the appropriate authentication credential.
         switch (credentials.provider) {
+            case EmailAuthProvider.PROVIDER_ID:
+                // Provide a Beta hack to permit email users to leverage "switch user".
+                return EmailAuthProvider.getCredential(email, "gamechat");
             case GoogleAuthProvider.PROVIDER_ID:
                 return GoogleAuthProvider.getCredential(credentials.token, null);
             case FacebookAuthProvider.PROVIDER_ID:

--- a/app/src/main/java/com/pajato/android/gamechat/preferences/PreferencesProvider.java
+++ b/app/src/main/java/com/pajato/android/gamechat/preferences/PreferencesProvider.java
@@ -22,8 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Provide an interface that models the use of shared preferences within GameChat to facilitate
- * testing.
+ * Provide an interface to model the app use of shared preferences to facilitate testing.
  *
  * @author Paul Michael Reilly on 7/29/2017
  */


### PR DESCRIPTION
<h1>Rationale:</h1>

This commit allows protected users using email authentication to use the switch user function via a temporary hack.

For the record, the long term plan for handling email authentication is 1) Smart Lock and 2) leverage the Firebase Authentication intent but make it more direct.

<h1>File changes:</h1>

modified:   app/src/androidTest/java/com/pajato/android/gamechat/main/MainActivityTest.java

- Summary: fix some AS warnings.

modified:   app/src/main/java/com/pajato/android/gamechat/authentication/AuthenticationManager.java

- Summary: enable SmartLock and provide better logging for sign-in.

modified:   app/src/main/java/com/pajato/android/gamechat/authentication/CredentialsManager.java

- getAuthCredential(): provide an email beta hack for protected users.

modified:   app/src/main/java/com/pajato/android/gamechat/preferences/PreferencesProvider.java

- Summary: enhance the JavaDoc class comment.