### PR TITLE
Add a progress spinner to invitations.

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java
@@ -20,6 +20,8 @@ package com.pajato.android.gamechat.chat.fragment;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
+import android.view.View;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.pajato.android.gamechat.R;
@@ -36,6 +38,7 @@ import com.pajato.android.gamechat.event.AuthenticationChangeEvent;
 import com.pajato.android.gamechat.event.MemberChangeEvent;
 import com.pajato.android.gamechat.event.NavDrawerOpenEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
+import com.pajato.android.gamechat.event.ProgressSpinnerEvent;
 import com.pajato.android.gamechat.help.HelpManager;
 import com.pajato.android.gamechat.main.PaneManager;
 
@@ -83,6 +86,24 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
         return null;
     }
 
+    /** Handle a request to show a progress spinner. */
+    @Subscribe public void onProgressSpinnerChange(final ProgressSpinnerEvent event) {
+        // Ensure that the event is well formed. Abort if not.
+        if (event == null)
+            return;
+
+        // Process the event by setting the visibility on the progress bar (spinner) and the
+        // progress dimmer view.
+        int visibility = event.state ? View.VISIBLE : View.GONE;
+        logEvent(String.format(Locale.US, "onProgressSpinnerChange with state: {%s}", event.state));
+        ProgressBar progressBar = getActivity().findViewById(R.id.chatProgressBar);
+        View progressDimmer = getActivity().findViewById(R.id.chatProgressDimmer);
+        if (progressBar != null)
+            progressBar.setVisibility(visibility);
+        if (progressDimmer != null)
+            progressDimmer.setVisibility(visibility);
+    }
+
     /** Handle a authentication change event by dealing with the fragment to display. */
     @Subscribe public void onAuthenticationChange(final AuthenticationChangeEvent event) {
         // Simply start the next logical fragment.
@@ -116,7 +137,7 @@ public class ChatEnvelopeFragment extends BaseChatFragment {
                 // If not on a tablet, make sure that we switch to the chat perspective and remember
                 // the type that we came from.
                 if (!PaneManager.instance.isTablet()) {
-                    ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+                    ViewPager viewPager = getActivity().findViewById(R.id.viewpager);
                     if (viewPager != null)
                         viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 }

--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectInviteFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectInviteFragment.java
@@ -35,6 +35,7 @@ import com.pajato.android.gamechat.common.adapter.MenuEntry;
 import com.pajato.android.gamechat.common.model.GroupInviteData;
 import com.pajato.android.gamechat.event.ClickEvent;
 import com.pajato.android.gamechat.event.TagClickEvent;
+import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -82,6 +83,8 @@ public class SelectInviteFragment extends BaseChatFragment {
         switch (event.view.getId()) {
             case R.id.inviteButton:
                 // Handle the invitation
+                logEvent("Extending an invitation using a progress spinner.");
+                ProgressManager.instance.show();
                 InvitationManager.instance.extendInvitation(getActivity(), getSelections());
                 DispatchManager.instance.dispatchReturn(this);
                 break;
@@ -125,6 +128,7 @@ public class SelectInviteFragment extends BaseChatFragment {
         FabManager.chat.setImage(R.drawable.ic_add_white_24dp);
         FabManager.chat.init(this, INVITE_CHAT_FAM_KEY);
         FabManager.chat.setVisibility(this, View.VISIBLE);
+        updateSelections(false);
     }
 
     /** Setup the fragment configuration using the specified dispatcher. */
@@ -145,7 +149,7 @@ public class SelectInviteFragment extends BaseChatFragment {
     /** Return a map of group key to data representing the current selections of groups/rooms */
     private Map<String, GroupInviteData> getSelections() {
         Map<String, GroupInviteData> selections = new HashMap<>();
-        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        RecyclerView view = mLayout.findViewById(R.id.ItemList);
         ListAdapter adapter = (ListAdapter) view.getAdapter();
         // First loop through adapter items and handle groups
         for (ListItem item : adapter.getItems()) {
@@ -215,7 +219,7 @@ public class SelectInviteFragment extends BaseChatFragment {
         // Toggle the selection state and operate accordingly on the selected items lists.
         clickedItem.selected = !clickedItem.selected;
 
-        RecyclerView recyclerView = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        RecyclerView recyclerView = mLayout.findViewById(R.id.ItemList);
         ListAdapter adapter = (ListAdapter) recyclerView.getAdapter();
         List <ListItem> adapterList = adapter.getItems();
 
@@ -267,7 +271,7 @@ public class SelectInviteFragment extends BaseChatFragment {
 
     /** Called from FAM click handling to update selections in the recycler view adapter list */
     private void updateSelections(final boolean selectedState) {
-        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        RecyclerView view = mLayout.findViewById(R.id.ItemList);
         ListAdapter adapter = (ListAdapter) view.getAdapter();
         List <ListItem> itemList = adapter.getItems();
 
@@ -283,7 +287,7 @@ public class SelectInviteFragment extends BaseChatFragment {
     /** Update the invite button state based on the current join map content. */
     private void updateSendInviteButton() {
         View inviteButton = mLayout.findViewById(R.id.inviteButton);
-        RecyclerView view = (RecyclerView) mLayout.findViewById(R.id.ItemList);
+        RecyclerView view = mLayout.findViewById(R.id.ItemList);
         ListAdapter adapter = (ListAdapter) view.getAdapter();
         List <ListItem> adapterList = adapter.getItems();
         for (ListItem item : adapterList) {

--- a/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java
@@ -221,7 +221,7 @@ public abstract class BaseFragment extends Fragment {
 
     /** Initialize the ad view by building and loading an ad request. */
     protected void initAdView(@NonNull final View layout) {
-        mAdView = (AdView) layout.findViewById(R.id.adView);
+        mAdView = layout.findViewById(R.id.adView);
         if (mAdView != null) {
             AdRequest adRequest = new AdRequest.Builder().build();
             mAdView.loadAd(adRequest);
@@ -305,7 +305,7 @@ public abstract class BaseFragment extends Fragment {
         // Determine if the keyboard is active before dismissing it.
         InputMethodManager manager;
         manager = (InputMethodManager) getActivity().getSystemService(INPUT_METHOD_SERVICE);
-        if (manager.isAcceptingText() && getActivity().getCurrentFocus() != null)
+        if (manager != null && manager.isAcceptingText() && getActivity().getCurrentFocus() != null)
             manager.hideSoftInputFromWindow(getActivity().getCurrentFocus().getWindowToken(), 0);
     }
 
@@ -331,8 +331,8 @@ public abstract class BaseFragment extends Fragment {
 
     /** Show an alert dialog with "ok" and "cancel". */
     public void showAlertDialog(final String title, final String message,
-                                   DialogInterface.OnClickListener cancelListener,
-                                   DialogInterface.OnClickListener okListener) {
+                                DialogInterface.OnClickListener cancelListener,
+                                DialogInterface.OnClickListener okListener) {
         MainActivity activity = (MainActivity) this.getActivity();
         activity.showOkCancelDialog(title, message, cancelListener, okListener);
     }

--- a/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
@@ -111,7 +111,7 @@ public enum DispatchManager {
         // When offline, switch automatically to experience (game) pane on a smartphone
         if (dispatcher.type == chatOffline || dispatcher.type == expOffline &&
                 !PaneManager.instance.isTablet()) {
-            ViewPager viewPager = (ViewPager) fragment.getActivity().findViewById(R.id.viewpager);
+            ViewPager viewPager = fragment.getActivity().findViewById(R.id.viewpager);
             if (viewPager != null)
                 viewPager.setCurrentItem(PaneManager.GAME_INDEX);
         }

--- a/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FabManager.java
@@ -95,7 +95,8 @@ public enum FabManager {
     public void dismissMenu(@NonNull final Fragment fragment) {
         // Determine if the chat fragment is accessible.  If so, dismiss the FAM.
         View layout = getFragmentLayout(fragment);
-        if (layout != null) dismissMenu(fragment, layout);
+        if (layout != null)
+            dismissMenu(fragment, layout);
     }
 
     /** Initialize the FAB. Use small FAB size for game fragments; all others use normal size. */
@@ -114,7 +115,7 @@ public enum FabManager {
         recyclerView.setAdapter(new MenuAdapter());
 
         // Set the FAB state to closed by assuming an open FAM and dismissing it.
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        FloatingActionButton fab = layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, opened);
         fab.setVisibility(View.VISIBLE);
         switch (fragment.type) {
@@ -155,7 +156,7 @@ public enum FabManager {
         View layout = getFragmentLayout(fragment);
         if (layout == null)
             return;
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        FloatingActionButton fab = layout.findViewById(mFabId);
         fab.setVisibility(state);
     }
 
@@ -178,7 +179,7 @@ public enum FabManager {
         View layout = getFragmentLayout(fragment);
         if (layout == null)
             return;
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        FloatingActionButton fab = layout.findViewById(mFabId);
         fab.setVisibility(View.VISIBLE);
     }
 
@@ -231,10 +232,11 @@ public enum FabManager {
         // Dismiss the FAM and ensure that the default menu has been setup.
         View menu = layout.findViewById(mFabMenuId);
         menu.setVisibility(View.GONE);
-        if (mDefaultMenuName != null) setMenu(fragment, mDefaultMenuName);
+        if (mDefaultMenuName != null)
+            setMenu(fragment, mDefaultMenuName);
 
         // Restore the FAB to the closed state and dismiss the dimmer view.
-        FloatingActionButton fab = (FloatingActionButton) layout.findViewById(mFabId);
+        FloatingActionButton fab = layout.findViewById(mFabId);
         fab.setTag(R.integer.fabStateKey, State.closed);
         fab.setImageResource(mImageResourceId);
         View dimmerView = layout.findViewById(mFabDimmerId);

--- a/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java
@@ -63,6 +63,7 @@ import com.pajato.android.gamechat.event.GroupJoinedEvent;
 import com.pajato.android.gamechat.event.ProfileGroupChangeEvent;
 import com.pajato.android.gamechat.event.ProfileRoomChangeEvent;
 import com.pajato.android.gamechat.main.MainActivity;
+import com.pajato.android.gamechat.main.ProgressManager;
 
 import org.greenrobot.eventbus.Subscribe;
 
@@ -315,6 +316,7 @@ public enum InvitationManager implements GoogleApiClient.OnConnectionFailedListe
 
     /** Handle app invitation result. Called only from MainActivity onResult method. */
     public void onInvitationResult(final int resultCode, final Intent intent) {
+        ProgressManager.instance.hide();
         if (resultCode != RESULT_OK)
             clearInvitationMap();
         else {

--- a/app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java
@@ -54,6 +54,11 @@ public enum AppEventManager {
         EventBus.getDefault().cancelEventDelivery(event);
     }
 
+    /** Return TRUE iff the given class name is registered to receive events. */
+    public boolean isRegistered(final String name) {
+        return mHandlerMap.containsKey(name);
+    }
+
     /** Post an event using the GreenRobot library. */
     public void post(final Object event) {
         // Maintain the posting level using a stack; report the start and end of the post.

--- a/app/src/main/java/com/pajato/android/gamechat/event/ProgressSpinnerEvent.java
+++ b/app/src/main/java/com/pajato/android/gamechat/event/ProgressSpinnerEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Pajato Technologies, Inc.
+ *
+ * This file is part of Pajato GameChat.
+
+ * GameChat is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * GameChat is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along with GameChat. If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pajato.android.gamechat.event;
+
+/**
+ * Provides an event class to encapsulate a progress spinner state.
+ *
+ * @author Paul Michael Reilly
+ */
+public class ProgressSpinnerEvent {
+
+    // Public instance variables.
+
+    /** The event state: true => show the spinner, false => clear the spinner. */
+    public boolean state;
+
+    /** Build the event with the given list. */
+    public ProgressSpinnerEvent(final boolean state) {
+        this.state = state;
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java
@@ -158,7 +158,6 @@ public class MainActivity extends BaseActivity
         // Due to a "bug" in Android, using XML to configure the navigation header current profile
         // click handler does not work.  Instead we do it here programmatically.  But first, turn
         // off the sign in spinner.
-        ProgressManager.instance.hide();
         Account account = event != null ? event.account : null;
         NavigationView navView = findViewById(R.id.nav_view);
         View header = navView.getHeaderView(0) != null
@@ -176,6 +175,7 @@ public class MainActivity extends BaseActivity
 
     /** Handle a back button press event delivered by the system. */
     @Override public void onBackPressed() {
+        ProgressManager.instance.hide();
         if (NavigationManager.instance.closeDrawerIfOpen(this))
             return;
         FragmentType type = DispatchManager.instance.currentChatFragmentType; // Default to chat
@@ -351,11 +351,12 @@ public class MainActivity extends BaseActivity
     protected void onActivityResult(final int request, final int result, final Intent intent) {
         // Handle a result from either the intro activity or the invite activity.
         super.onActivityResult(request, result, intent);
+        ProgressManager.instance.hide();
         if (result != RESULT_OK)
             logFailedResult(request, intent, result == RESULT_CANCELED);
-        else if (request == RC_SIGN_IN) {
+        else if (request == RC_SIGN_IN)
             processSignIn(intent);
-        } else if (request == RC_INVITE)
+        else if (request == RC_INVITE)
             InvitationManager.instance.onInvitationResult(result, intent);
     }
 
@@ -436,6 +437,7 @@ public class MainActivity extends BaseActivity
         NetworkManager.instance.init(this);
         PaneManager.instance.init(this);
         InvitationManager.instance.init(this, getIntent());
+        ProgressManager.instance.init();
         JoinManager.instance.init(this);
         NavigationManager.instance.init(this, (Toolbar) findViewById(R.id.toolbar));
 

--- a/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
+++ b/app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java
@@ -17,9 +17,19 @@
 
 package com.pajato.android.gamechat.main;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
+
+import com.pajato.android.gamechat.chat.fragment.ChatEnvelopeFragment;
+import com.pajato.android.gamechat.event.AppEventManager;
+import com.pajato.android.gamechat.event.ProgressSpinnerEvent;
+import com.pajato.android.gamechat.event.RegistrationChangeEvent;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
 
 /** Provide a singleton to manage showing and hiding the initial loading status. */
 public enum ProgressManager {
@@ -32,42 +42,57 @@ public enum ProgressManager {
 
     // Private instance variables.
 
-    /** Indicates if the dialog is showing. */
-    private boolean mIsShowing;
+    /** The current progress state: true => a long running task is active; false => inactive. */
+    private boolean mProgressState = false;
+
+    /** The chat envelope fragment is paying attention to progress spinner events. */
+    private boolean mIsRegistered = false;
 
     // Public instance methods
 
-    /** Dismiss the initial loading dialog if one is showing. */
-    public void hide() {
-        Log.d(TAG, "Attempting to hide the progress dialog.");
-        if (mIsShowing) {
-            //mProgressBar.setVisibility(View.GONE);
-            //mProgressBar = null;
-            mIsShowing = false;
-        }
+    /** Process an event bus registration. */
+    @Subscribe public void onRegistrationChangeEvent(@NonNull RegistrationChangeEvent event) {
+        // Track the state of the ChatEnvelopeRegistration class event bus registration.  When the
+        // class is registered update it with the current progress spinner state.
+        if (event.name != null && event.name.equals(ChatEnvelopeFragment.class.getName()))
+            mIsRegistered = event.changeType == RegistrationChangeEvent.REGISTERED;
+        if (mIsRegistered)
+            post(mProgressState);
+        String status = mIsRegistered ? "is" : "is not";
+        Log.d(TAG, format(Locale.US, "The chat envelope %s registered.", status));
     }
 
-    /** Return TRUE iff the progress spinner is being shown. */
-    public boolean isShowing() {
-        return mIsShowing;
+    /** Dismiss the initial loading dialog if one is showing. */
+    public void hide() {
+        post(false);
+    }
+
+    /** Initialize the progress manager. */
+    public void init() {
+        // Initialize by ensuring that the progress manager is registered with the app event bus
+        // and that the current chat enveelope registration state has been captured.
+        AppEventManager.instance.register(this);
+        String name = ChatEnvelopeFragment.class.getName();
+        mIsRegistered = AppEventManager.instance.isRegistered(name);
     }
 
     /** Show the initial loading dialog. */
-    public void show(@NonNull final Context context) {
-        show(context, "Starting...", "Please wait while the app starts up...");
+    public void show() {
+        post(true);
     }
 
-    /** Show a loading dialog with a given message. */
-    public void show(@SuppressWarnings("unused") final Context context,
-                     @SuppressWarnings("unused") final String title,
-                     @SuppressWarnings("unused") final String message) {
-        // Create and display the progress dialog.
-        Log.d(TAG, "Turning on progress spinner now.");
-        //mProgressBar = new ProgressBar(context);
-        //mProgressBar.setTitle(title);
-        //mProgressBar.setMessage(message);
-        //mProgressBar.setVisibility(View.VISIBLE);
-        mIsShowing = true;
-    }
+    // Private instance methods.
 
+    /** Post the current progress spinner state to the chat envelope fragment. */
+    private void post(final boolean state) {
+        // Persist the given state and determine if the app event bus can be used to handle the
+        // request to provide the User with feedback on a time consuming activity using the chat
+        // envelope.
+        mProgressState = state;
+        if (mIsRegistered)
+            AppEventManager.instance.post(new ProgressSpinnerEvent(state));
+        String status = mIsRegistered ? "has" : "has not";
+        String format = "The progress spinner state {%s} %s been posted.";
+        Log.d(TAG, format(Locale.US, format, state, status));
+    }
 }

--- a/app/src/main/res/layout/chat_envelope.xml
+++ b/app/src/main/res/layout/chat_envelope.xml
@@ -32,8 +32,6 @@ http://www.gnu.org/licenses
 
     <View style="@style/DimmerTheme"
         android:id="@+id/chatDimmer"
-        android:layout_height="0dp"
-        android:layout_width="0dp"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:visibility="visible" />
@@ -69,5 +67,22 @@ http://www.gnu.org/licenses
             tools:visibility="visible"/>
 
     </android.support.design.widget.CoordinatorLayout>
+
+    <View style="@style/DimmerTheme"
+        android:id="@+id/chatProgressDimmer"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="gone" />
+
+    <ProgressBar style="?android:attr/progressBarStyle"
+        android:id="@+id/chatProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
<h1>Rationale:</h1>

When issuing invitations, GC uses a system activity to actually accept recipients as targets of the invitation. This activity loads contacts from the device which could take multiple seconds. This delay will show a GameChat fragment during causing some confusion and the possibility of unwanted User interactions. To remove this bad behavior this commit adds a progress spinner to be shown while the potential recipients are loaded and the send activity started.

This is the second in a series of changes to make invitations more robust.

In addition, a number of Android Studio warnings have been eliminated by adopting the recommended fixes.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/ChatEnvelopeFragment.java

- onProgressSpinnerChange(): new method used to control the dimmer and progress bar (spinner) used to indicate a wait is required.
- onClick(): apply an AS warning fix to remove an unnecessary cast.

modified:   app/src/main/java/com/pajato/android/gamechat/chat/fragment/SelectInviteFragment.java

- onClick(): use the ProgressManager to show the progress bar spinner.
- onResume(): initialize the selections to un-selected.
- (many): apply some AS warning fixes for unnecessary casts.

modified:   app/src/main/java/com/pajato/android/gamechat/common/BaseFragment.java

- Summary: apply AS warning fixes (for unnecessary casts and potential NPE violations); some cosmetic indentation ajustments.

modified:   app/src/main/java/com/pajato/android/gamechat/common/DispatchManager.java
modified:   app/src/main/java/com/pajato/android/gamechat/common/FabManager.java

- Summary: apply AS warning fixes for some unnecessary casts.

modified:   app/src/main/java/com/pajato/android/gamechat/common/InvitationManager.java

- onInvitationResult(): ensure that the progress bar spinner is stopped (hidden).

modified:   app/src/main/java/com/pajato/android/gamechat/event/AppEventManager.java

- isRegistered(): new method to determine if a class has been registered with the app event bus.

new file:   app/src/main/java/com/pajato/android/gamechat/event/ProgressSpinnerEvent.java

- Summary: new file to provide a hook to notify the envelope fragment that the progress bar spinner needs to be set of cleared.

modified:   app/src/main/java/com/pajato/android/gamechat/main/MainActivity.java

- onAuthenticationChange(): defer hiding the progress bar spinner until it is actually needed.
- onBackPressed(), onActivityResult(): ensure that the progress bar spinner is cleared.
- init(): ensure that the ProgressManager class is initialized.

modified:   app/src/main/java/com/pajato/android/gamechat/main/ProgressManager.java

- Summary: overhaul the class to ensure that the chat envelope can be notified when it is ready to stop showing the progress bar spinner.  This can be delayed by Android's activity and framework lifecycle events.

modified:   app/src/main/res/layout/chat_envelope.xml

- Summary: add a special dimmer and the progress bar spinner.