### PR TITLE
Adding "Set Up Game" Screen

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
+++ b/app/src/main/java/com/pajato/android/gamechat/common/FragmentType.java
@@ -43,6 +43,7 @@ import com.pajato.android.gamechat.exp.fragment.ExpShowGroupsFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowOfflineFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowRoomsFragment;
 import com.pajato.android.gamechat.exp.fragment.ExpShowSignedOutFragment;
+import com.pajato.android.gamechat.exp.fragment.SetupExperienceFragment;
 import com.pajato.android.gamechat.exp.fragment.ShowExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.ShowNoExperiencesFragment;
 import com.pajato.android.gamechat.exp.fragment.TTTFragment;
@@ -92,6 +93,7 @@ public enum FragmentType {
     roomMembersList(ChatShowMembersFragment.class, standardBlack, R.layout.chat_members, chat),
     selectGroupsRooms(SelectInviteFragment.class, standardBlack,
             R.layout.select_for_invite, chat),
+    setupExp(SetupExperienceFragment.class, standardWhite, R.layout.exp_setup, exp),
     tictactoe (TTTFragment.class, standardWhite, R.layout.exp_ttt, tttET, exp);
 
     // Public instance variables.

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -66,6 +66,7 @@ import static com.pajato.android.gamechat.common.FragmentType.chess;
 import static com.pajato.android.gamechat.common.FragmentType.expRoomList;
 import static com.pajato.android.gamechat.common.FragmentType.experienceList;
 import static com.pajato.android.gamechat.common.FragmentType.selectGroupsRooms;
+import static com.pajato.android.gamechat.common.FragmentType.setupExp;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_EXPERIENCE_KEY;
 import static com.pajato.android.gamechat.database.AccountManager.SIGNED_OUT_OWNER_ID;
@@ -383,6 +384,8 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             } else {
                 showFutureFeatureMessage(R.string.signedOutGames);
             }
+        } else if (type.equals(setupExp)) {
+            showFutureFeatureMessage(R.string.SettingUnavailable);
         }
     }
 
@@ -495,7 +498,11 @@ public abstract class BaseExperienceFragment extends BaseFragment {
     private void processFamItem(final MenuEntry entry) {
         // Dismiss the FAB and dispatch
         FabManager.game.dismissMenu(this);
-        DispatchManager.instance.dispatchToGame(this, entry.fragmentType);
+        if (entry.fragmentType == setupExp) {
+            DispatchManager.instance.dispatchToFragment(this, setupExp);
+        } else {
+            DispatchManager.instance.dispatchToGame(this, entry.fragmentType);
+        }
     }
 
     /** Resume the current fragment experience. */

--- a/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/BaseExperienceFragment.java
@@ -417,7 +417,7 @@ public abstract class BaseExperienceFragment extends BaseFragment {
             case R.string.InviteFriendMessage:
                 // If not on a tablet, make sure that we switch to the chat perspective
                 if (!PaneManager.instance.isTablet()) {
-                    ViewPager viewPager = (ViewPager) getActivity().findViewById(R.id.viewpager);
+                    ViewPager viewPager = getActivity().findViewById(R.id.viewpager);
                     if (viewPager != null) viewPager.setCurrentItem(PaneManager.CHAT_INDEX);
                 }
                 String groupKey = mExperience.getGroupKey();

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/CheckersFragment.java
@@ -51,7 +51,7 @@ import java.util.List;
 import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static com.pajato.android.gamechat.R.color.colorAccent;
 import static com.pajato.android.gamechat.R.color.colorPrimary;
-import static com.pajato.android.gamechat.R.id.player_1_icon;
+import static com.pajato.android.gamechat.R.id.player1Icon;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
@@ -177,9 +177,9 @@ public class CheckersFragment extends BaseExperienceFragment {
         mBoard.init(this, mTileClickHandler); // = (GridLayout) mLayout.findViewById(board);
 
         // Color the player icons and create a tile click handler.
-        ImageView playerOneIcon = (ImageView) mLayout.findViewById(player_1_icon);
+        ImageView playerOneIcon = (ImageView) mLayout.findViewById(player1Icon);
         playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
-        ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
+        ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player2Icon);
         playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ChessFragment.java
@@ -167,9 +167,9 @@ public class ChessFragment extends BaseExperienceFragment {
         mBoard.init(this, mTileClickHandler);
 
         // Color the Player Icons.
-        ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player_1_icon);
+        ImageView playerOneIcon = (ImageView) mLayout.findViewById(R.id.player1Icon);
         playerOneIcon.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
-        ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player_2_icon);
+        ImageView playerTwoIcon = (ImageView) mLayout.findViewById(R.id.player2Icon);
         playerTwoIcon.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
     }
 

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/ExpEnvelopeFragment.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static com.pajato.android.gamechat.common.FragmentKind.exp;
 import static com.pajato.android.gamechat.common.FragmentType.checkers;
 import static com.pajato.android.gamechat.common.FragmentType.chess;
+import static com.pajato.android.gamechat.common.FragmentType.setupExp;
 import static com.pajato.android.gamechat.common.FragmentType.tictactoe;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
@@ -114,6 +115,7 @@ public class ExpEnvelopeFragment extends BaseExperienceFragment {
     /** Return the home FAM used in the top level show games and show no games fragments. */
     private List<MenuEntry> getHomeMenu() {
         final List<MenuEntry> menu = new ArrayList<>();
+        menu.add(getEntry(R.string.SetupNewExp, R.drawable.ic_settings_black_24dp, setupExp));
         menu.add(getEntry(R.string.PlayTicTacToe, R.mipmap.ic_tictactoe_red, tictactoe));
         menu.add(getEntry(R.string.PlayCheckers, R.mipmap.ic_checkers, checkers));
         menu.add(getEntry(R.string.PlayChess, R.mipmap.ic_chess, chess));

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
@@ -1,0 +1,139 @@
+package com.pajato.android.gamechat.exp.fragment;
+
+import android.content.Context;
+import android.graphics.drawable.GradientDrawable;
+import android.support.v4.content.ContextCompat;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.pajato.android.gamechat.R;
+import com.pajato.android.gamechat.common.Dispatcher;
+import com.pajato.android.gamechat.common.FabManager;
+import com.pajato.android.gamechat.common.ToolbarManager;
+import com.pajato.android.gamechat.common.adapter.ListItem;
+import com.pajato.android.gamechat.event.ClickEvent;
+import com.pajato.android.gamechat.exp.BaseExperienceFragment;
+
+import org.greenrobot.eventbus.Subscribe;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static android.graphics.PorterDuff.Mode.SRC_ATOP;
+import static com.pajato.android.gamechat.R.color.colorAccent;
+import static com.pajato.android.gamechat.R.color.colorPrimary;
+import static com.pajato.android.gamechat.R.color.colorVeryLightGray;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
+import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.settings;
+import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
+
+/**
+ *
+ */
+public class SetupExperienceFragment extends BaseExperienceFragment {
+    private int mExpId = R.id.IconTicTacToe;
+
+    @Override public String getToolbarSubtitle() {
+        return null;
+    }
+
+    @Override public String getToolbarTitle() {
+        return getString(R.string.SetupNewExp);
+    }
+
+    /** Handle a button click event by delegating the event to the base class. */
+    @Subscribe public void onClick(final ClickEvent event) {
+        logEvent("SetupExp Click Event: " + event.toString());
+
+        int viewId = event.view.getId();
+
+        switch (viewId) {
+            case R.id.friendLayout:
+                showFutureFeatureMessage(R.string.ChooseOpponent);
+                break;
+            case R.id.timerZero:
+            case R.id.timerFifteen:
+            case R.id.timerThirty:
+            case R.id.timerFortyFive:
+            case R.id.timerSixty:
+                List<Integer> timers = Arrays.asList(R.id.timerZero, R.id.timerFifteen,
+                        R.id.timerThirty, R.id.timerFortyFive, R.id.timerSixty);
+                setBorder(timers, viewId);
+                showFutureFeatureMessage(R.string.TurnTimer);
+                break;
+            case R.id.player1Icon:
+            case R.id.player2Icon:
+                List<Integer> playIcons = Arrays.asList(R.id.player1Icon, R.id.player2Icon);
+                setBorder(playIcons, viewId);
+                showFutureFeatureMessage(R.string.ChooseColor);
+                break;
+            case R.id.tutorMode:
+            case R.id.noTutor:
+                List<Integer> tutorIcons = Arrays.asList(R.id.tutorMode, R.id.noTutor);
+                setBorder(tutorIcons, viewId);
+                showFutureFeatureMessage(R.string.TutorMode);
+                break;
+            case R.id.IconCheckers:
+            case R.id.IconChess:
+            case R.id.IconTicTacToe:
+                List<Integer> gameIcons = Arrays.asList(R.id.IconCheckers, R.id.IconChess, R.id.IconTicTacToe);
+                mExpId = viewId;
+                setBorder(gameIcons, viewId);
+                break;
+            case R.id.playWithSetup:
+                processClickEvent(mLayout.findViewById(mExpId), this.type);
+                break;
+            default:
+                processClickEvent(event.view, this.type);
+                break;
+        }
+    }
+
+    @Override public void onResume() {
+        super.onResume();
+        FabManager.game.setImage(R.drawable.ic_add_white_24dp);
+        FabManager.game.init(this, GAME_HOME_FAM_KEY);
+    }
+
+    @Override public void onSetup(Context context, Dispatcher dispatcher) {
+        mDispatcher = dispatcher;
+    }
+
+    @Override public void onStart() {
+        super.onStart();
+        ToolbarManager.instance.init(this, helpAndFeedback, chat, invite, settings);
+
+        ImageView imageView = mLayout.findViewById(R.id.player1Icon);
+        imageView.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
+        imageView = mLayout.findViewById(R.id.player2Icon);
+        imageView.setColorFilter(ContextCompat.getColor(getContext(), colorAccent), SRC_ATOP);
+        imageView = mLayout.findViewById(R.id.tutorMode);
+        imageView.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
+        imageView = mLayout.findViewById(R.id.noTutor);
+        imageView.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
+
+        List<Integer> choices = Arrays.asList(R.id.timerZero, R.id.timerFifteen, R.id.timerThirty,
+                R.id.timerFortyFive, R.id.timerSixty, R.id.player1Icon, R.id.player2Icon,
+                R.id.tutorMode, R.id.noTutor, R.id.IconCheckers, R.id.IconChess, R.id.IconTicTacToe);
+        setBorder(choices, -1);
+    }
+
+    @Override public List<ListItem> getList() {
+        return null;
+    }
+
+    private void setBorder(List<Integer> ids, int chosenId) {
+        for (int iconId : ids) {
+            View view = mLayout.findViewById(iconId);
+            if (view == null)
+                break;
+            if (view.getId() == chosenId) {
+                view.setBackgroundResource(R.drawable.button_background_selected);
+            } else {
+                view.setBackgroundResource(R.drawable.button_background);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
@@ -1,7 +1,6 @@
 package com.pajato.android.gamechat.exp.fragment;
 
 import android.content.Context;
-import android.graphics.drawable.GradientDrawable;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.widget.ImageView;
@@ -22,7 +21,6 @@ import java.util.List;
 import static android.graphics.PorterDuff.Mode.SRC_ATOP;
 import static com.pajato.android.gamechat.R.color.colorAccent;
 import static com.pajato.android.gamechat.R.color.colorPrimary;
-import static com.pajato.android.gamechat.R.color.colorVeryLightGray;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.chat;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.helpAndFeedback;
 import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.invite;
@@ -43,16 +41,19 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
         return getString(R.string.SetupNewExp);
     }
 
-    /** Handle a button click event by delegating the event to the base class. */
+    /** Accept parameters for an experience, and handle other button click events by delegating the
+     *  event to the base class. */
     @Subscribe public void onClick(final ClickEvent event) {
         logEvent("SetupExp Click Event: " + event.toString());
 
         int viewId = event.view.getId();
 
         switch (viewId) {
+            // TODO: Implement "choose an opponent" with choices from your groups.
             case R.id.friendLayout:
                 showFutureFeatureMessage(R.string.ChooseOpponent);
                 break;
+            // TODO: Implement game turn timers.
             case R.id.timerZero:
             case R.id.timerFifteen:
             case R.id.timerThirty:
@@ -63,18 +64,21 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
                 setBorder(timers, viewId);
                 showFutureFeatureMessage(R.string.TurnTimer);
                 break;
+            // TODO: Implement side choice.
             case R.id.player1Icon:
             case R.id.player2Icon:
                 List<Integer> playIcons = Arrays.asList(R.id.player1Icon, R.id.player2Icon);
                 setBorder(playIcons, viewId);
                 showFutureFeatureMessage(R.string.ChooseColor);
                 break;
+            // TODO: Implement tutor mode.
             case R.id.tutorMode:
             case R.id.noTutor:
                 List<Integer> tutorIcons = Arrays.asList(R.id.tutorMode, R.id.noTutor);
                 setBorder(tutorIcons, viewId);
                 showFutureFeatureMessage(R.string.TutorMode);
                 break;
+            // Choose a specific game to play with them.
             case R.id.IconCheckers:
             case R.id.IconChess:
             case R.id.IconTicTacToe:
@@ -82,6 +86,7 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
                 mExpId = viewId;
                 setBorder(gameIcons, viewId);
                 break;
+            // The 'submit' button which actually kicks off the game based on the choices made.
             case R.id.playWithSetup:
                 processClickEvent(mLayout.findViewById(mExpId), this.type);
                 break;
@@ -91,6 +96,7 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
         }
     }
 
+    /* Setup the FAB. */
     @Override public void onResume() {
         super.onResume();
         FabManager.game.setImage(R.drawable.ic_add_white_24dp);
@@ -101,6 +107,7 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
         mDispatcher = dispatcher;
     }
 
+    /** Initialize the toolbar and apply color to the icons that require it. */
     @Override public void onStart() {
         super.onStart();
         ToolbarManager.instance.init(this, helpAndFeedback, chat, invite, settings);
@@ -113,27 +120,28 @@ public class SetupExperienceFragment extends BaseExperienceFragment {
         imageView.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
         imageView = mLayout.findViewById(R.id.noTutor);
         imageView.setColorFilter(ContextCompat.getColor(getContext(), colorPrimary), SRC_ATOP);
-
-        List<Integer> choices = Arrays.asList(R.id.timerZero, R.id.timerFifteen, R.id.timerThirty,
-                R.id.timerFortyFive, R.id.timerSixty, R.id.player1Icon, R.id.player2Icon,
-                R.id.tutorMode, R.id.noTutor, R.id.IconCheckers, R.id.IconChess, R.id.IconTicTacToe);
-        setBorder(choices, -1);
     }
 
     @Override public List<ListItem> getList() {
         return null;
     }
 
+    /** Applies a drawable resource background to all the resources specified in the a list of
+     * resource IDs. An "unselected" background is given to views specified in the list, and a
+     * "selected" background is applied to one that is specified as a separate parameter.
+     * @param ids a list of resource ids that should be "set" to having a normal background.
+     * @param chosenId the id that has been "selected" and receives a special background drawable.*/
     private void setBorder(List<Integer> ids, int chosenId) {
         for (int iconId : ids) {
             View view = mLayout.findViewById(iconId);
             if (view == null)
                 break;
-            if (view.getId() == chosenId) {
-                view.setBackgroundResource(R.drawable.button_background_selected);
-            } else {
-                view.setBackgroundResource(R.drawable.button_background);
-            }
+            view.setBackgroundResource(R.drawable.button_background);
         }
+
+        View view = mLayout.findViewById(chosenId);
+        if (view != null)
+            view.setBackgroundResource(R.drawable.button_background_selected);
+
     }
 }

--- a/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/exp/fragment/SetupExperienceFragment.java
@@ -28,7 +28,8 @@ import static com.pajato.android.gamechat.common.ToolbarManager.MenuItemType.set
 import static com.pajato.android.gamechat.exp.fragment.ExpEnvelopeFragment.GAME_HOME_FAM_KEY;
 
 /**
- *
+ * Handles setup of an experience, from choosing an opponent and choosing a game, to enabling fully
+ * optional settings like a tutor mode or game timer.
  */
 public class SetupExperienceFragment extends BaseExperienceFragment {
     private int mExpId = R.id.IconTicTacToe;

--- a/app/src/main/res/drawable/button_background.xml
+++ b/app/src/main/res/drawable/button_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="3dp"
+        android:color="@color/colorPrimary" />
+    <corners android:radius="5dp" />
+    <padding
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp" />
+</shape>

--- a/app/src/main/res/drawable/button_background_selected.xml
+++ b/app/src/main/res/drawable/button_background_selected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/colorVeryLightGray" />
+    <stroke
+        android:width="3dp"
+        android:color="@color/colorPrimary" />
+    <corners android:radius="5dp" />
+    <padding
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp" />
+</shape>

--- a/app/src/main/res/layout/exp_checkers.xml
+++ b/app/src/main/res/layout/exp_checkers.xml
@@ -65,7 +65,7 @@ http://www.gnu.org/licenses
             app:layout_constraintBottom_toBottomOf="@id/wins"
             tools:text="0" />
 
-        <ImageView android:id="@+id/player_1_icon"
+        <ImageView android:id="@+id/player1Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
@@ -83,9 +83,9 @@ http://www.gnu.org/licenses
             android:textColor="@color/colorPrimary"
             android:textSize="20sp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/player_1_icon"
-            app:layout_constraintRight_toLeftOf="@+id/player_1_icon"
-            app:layout_constraintTop_toTopOf="@+id/player_1_icon" />
+            app:layout_constraintBottom_toBottomOf="@+id/player1Icon"
+            app:layout_constraintRight_toLeftOf="@+id/player1Icon"
+            app:layout_constraintTop_toTopOf="@+id/player1Icon" />
 
         <TextView android:id="@+id/rightIndicator1"
             android:layout_width="wrap_content"
@@ -97,10 +97,10 @@ http://www.gnu.org/licenses
             android:textSize="20sp"
             android:textStyle="bold"
             app:layout_constraintRight_toLeftOf="@id/player1WinCount"
-            app:layout_constraintTop_toTopOf="@+id/player_1_icon"
-            app:layout_constraintBottom_toBottomOf="@+id/player_1_icon"/>
+            app:layout_constraintTop_toTopOf="@+id/player1Icon"
+            app:layout_constraintBottom_toBottomOf="@+id/player1Icon"/>
 
-        <ImageView android:id="@+id/player_2_icon"
+        <ImageView android:id="@+id/player2Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
@@ -121,9 +121,9 @@ http://www.gnu.org/licenses
             android:textSize="20sp"
             android:textStyle="bold"
             android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@+id/player_2_icon"
+            app:layout_constraintBottom_toBottomOf="@+id/player2Icon"
             app:layout_constraintLeft_toRightOf="@id/player2WinCount"
-            app:layout_constraintTop_toTopOf="@+id/player_2_icon" />
+            app:layout_constraintTop_toTopOf="@+id/player2Icon" />
 
         <TextView android:id="@+id/rightIndicator2"
             android:layout_width="wrap_content"
@@ -134,9 +134,9 @@ http://www.gnu.org/licenses
             android:textSize="20sp"
             android:textStyle="bold"
             android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@+id/player_2_icon"
-            app:layout_constraintLeft_toRightOf="@+id/player_2_icon"
-            app:layout_constraintTop_toTopOf="@+id/player_2_icon" />
+            app:layout_constraintBottom_toBottomOf="@+id/player2Icon"
+            app:layout_constraintLeft_toRightOf="@+id/player2Icon"
+            app:layout_constraintTop_toTopOf="@+id/player2Icon" />
 
         <TextView android:id="@+id/status"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/exp_setup.xml
+++ b/app/src/main/res/layout/exp_setup.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/app/src/main/res/layout/exp_setup.xml
+++ b/app/src/main/res/layout/exp_setup.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/spacer"
+        android:layout_width="16dp"
+        android:layout_height="56dp"
+        android:layout_marginEnd="148dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <include layout="@layout/exp_toolbar_inc" />
+
+    <android.support.v7.widget.LinearLayoutCompat
+        android:id="@+id/friendLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@color/colorPrimary"
+        android:onClick="onClick"
+        android:orientation="horizontal"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/spacer">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginStart="8dp"
+            android:text="@string/friend"
+            android:textColor="@color/white"
+            android:textSize="20sp" />
+
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/friend"
+            app:srcCompat="@drawable/ic_arrow_drop_down_white_24px" />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+    <android.support.v7.widget.LinearLayoutCompat
+        android:id="@+id/colorLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/friendLayout">
+
+        <ImageView
+            android:id="@+id/player1Icon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/button_background_selected"
+            android:contentDescription="@string/player1"
+            android:onClick="onClick"
+            app:srcCompat="@drawable/ic_account_circle_black_36dp" />
+
+        <ImageView
+            android:id="@+id/player2Icon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/button_background"
+            android:contentDescription="@string/player2"
+            android:onClick="onClick"
+            app:srcCompat="@drawable/ic_account_circle_black_36dp" />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+    <android.support.v7.widget.LinearLayoutCompat
+        android:id="@+id/timerLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start|center_vertical"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/colorLayout">
+
+        <TextView
+            android:id="@+id/timerZero"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:layout_marginBottom="4dp"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/button_background_selected"
+            android:gravity="center"
+            android:onClick="onClick"
+            android:paddingEnd="8dp"
+            android:paddingStart="8dp"
+            android:text="@string/TimerZero"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/timerFifteen"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/button_background"
+            android:gravity="center"
+            android:onClick="onClick"
+            android:paddingEnd="4dp"
+            android:paddingStart="4dp"
+            android:text="@string/Timer15"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/timerThirty"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/button_background"
+            android:gravity="center"
+            android:onClick="onClick"
+            android:paddingEnd="4dp"
+            android:paddingStart="4dp"
+            android:text="@string/Timer30"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/timerFortyFive"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/button_background"
+            android:gravity="center"
+            android:onClick="onClick"
+            android:paddingEnd="4dp"
+            android:paddingStart="4dp"
+            android:text="@string/Timer45"
+            android:textSize="32sp" />
+
+        <TextView
+            android:id="@+id/timerSixty"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/button_background"
+            android:gravity="center"
+            android:onClick="onClick"
+            android:paddingEnd="4dp"
+            android:paddingStart="4dp"
+            android:text="@string/Timer60"
+            android:textSize="32sp" />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+    <android.support.v7.widget.LinearLayoutCompat
+        android:id="@+id/tutorLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/timerLayout">
+
+        <ImageView
+            android:id="@+id/noTutor"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/button_background_selected"
+            android:contentDescription="@string/player1"
+            android:onClick="onClick"
+            app:srcCompat="@drawable/ic_clear_black_24dp" />
+
+        <ImageView
+            android:id="@+id/tutorMode"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/button_background"
+            android:contentDescription="@string/player1"
+            android:onClick="onClick"
+            app:srcCompat="@drawable/ic_verified_user_black_24dp" />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+    <android.support.v7.widget.LinearLayoutCompat
+        android:id="@+id/gameChoiceLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/tutorLayout">
+
+        <ImageView
+            android:id="@+id/IconTicTacToe"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/button_background_selected"
+            android:contentDescription="@string/TicTacToeImageDesc"
+            android:onClick="onClick"
+            android:src="@mipmap/ic_tictactoe_red" />
+
+        <ImageView
+            android:id="@+id/IconCheckers"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/button_background"
+            android:contentDescription="@string/CheckersImageDesc"
+            android:onClick="onClick"
+            android:src="@mipmap/ic_checkers" />
+
+        <ImageView
+            android:id="@+id/IconChess"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/button_background"
+            android:contentDescription="@string/ChessImageDesc"
+            android:onClick="onClick"
+            android:src="@mipmap/ic_chess" />
+
+    </android.support.v7.widget.LinearLayoutCompat>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/Opponent"
+        android:textSize="16sp"
+
+        app:layout_constraintBottom_toBottomOf="@id/friendLayout"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toTopOf="@id/friendLayout" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/PlayAs"
+        android:textSize="16sp"
+
+        app:layout_constraintBottom_toBottomOf="@id/colorLayout"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toTopOf="@id/colorLayout" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/TurnTimer"
+        android:textSize="16sp"
+
+        app:layout_constraintBottom_toBottomOf="@id/timerLayout"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toTopOf="@id/timerLayout" />
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/TutorMode"
+        android:textSize="16sp"
+
+        app:layout_constraintBottom_toBottomOf="@id/tutorLayout"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toTopOf="@id/tutorLayout" />
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/GameChoice"
+        android:textSize="16sp"
+
+        app:layout_constraintBottom_toBottomOf="@id/gameChoiceLayout"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toTopOf="@id/gameChoiceLayout" />
+
+    <TextView
+        android:id="@+id/playWithSetup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@color/colorPrimary"
+        android:onClick="onClick"
+        android:paddingBottom="8dp"
+        android:paddingEnd="16dp"
+        android:paddingStart="16dp"
+        android:paddingTop="8dp"
+        android:text="@string/PlayButton"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+
+        app:layout_constraintLeft_toRightOf="@id/spacer"
+        app:layout_constraintRight_toLeftOf="@id/spacer"
+        app:layout_constraintTop_toBottomOf="@id/gameChoiceLayout" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,4 +62,5 @@
     <string name="switch_account">\u25bc</string>
     <string name="me">me</string>
     <string name="FutureNavigationOperation">This operation</string>
+    <string name="PlayButton">Play!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,5 +62,4 @@
     <string name="switch_account">\u25bc</string>
     <string name="me">me</string>
     <string name="FutureNavigationOperation">This operation</string>
-    <string name="PlayButton">Play!</string>
 </resources>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -4,9 +4,12 @@
     <string name="CheckersImageDesc">Checkers image.</string>
     <string name="ChessDisplayName">Chess</string>
     <string name="ChessImageDesc">Chess image.</string>
+    <string name="ChooseColor">Choose your Color</string>
+    <string name="ChooseOpponent">Choose Opponent</string>
     <string name="ExpGroupsToolbarTitle">Groups with Games</string>
     <string name="ExpRoomsToolbarTitle">Rooms with Games</string>
     <string name="FutureSelectRooms">Select rooms</string>
+    <string name="GameChoice">Game:</string>
     <string name="InvalidButton">You must click on an empty button!  Try again.</string>
     <string name="MenuIconDesc">Floating action menu icon.</string>
     <string name="MyExperiencesToolbarTitle">Your Games</string>
@@ -15,6 +18,7 @@
     <string name="NoGamesOfflineText">Select a game button to create a game.</string>
     <string name="NoGamesMessageText">Select a game button to create a game, or join other rooms to play or watch ongoing games.</string>
     <string name="NoGamesToolbarTitle">No Games</string>
+    <string name="Opponent">Opponent:</string>
     <string name="PlayAgain">Play Again</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
@@ -24,12 +28,16 @@
     <string name="PromotePawnMsg">Promote Your Pawn:</string>
     <string name="ResetGameTitle">Restart Game?</string>
     <string name="ResetGameMessage">Restarting this game will clear the board and any previous moves. Do you really want to restart this game?</string>
+    <string name="SetupNewExp">Set Up a New Game</string>
+    <string name="SettingUnavailable">This game configuration</string>
     <string name="SignedOutMessageText">You are signed out.  You can play games, but it is more fun to use GameChat while signed in.</string>
     <string name="StartNewGame">Starting a new game.  Enjoy!</string>
     <string name="TicTacToeDisplayName">Tic-Tac-Toe</string>
     <string name="TicTacToeImageDesc">TicTacToe image.</string>
     <string name="TieMessage">Tie game!</string>
     <string name="TieMessageNotification">Well done players</string>
+    <string name="TurnTimer">Turn Timer:</string>
+    <string name="TutorMode">Tutor Mode:</string>
     <string name="WinMessageFormat">%1$s Wins!</string>
     <string name="WinMessageNotificationFormat">Congratulations %s, you win!</string>
     <string name="chess_promotion_bishop">Bishop</string>
@@ -53,4 +61,10 @@
     <string name="NotAPlayerMessageText">You are not a player in this game.</string>
     <string name="PlayOutOfTurnMessageText">Please wait for your turn.</string>
     <string name="CheckMateText">Checkmate!</string>
+    <string name="TimerZero">0</string>
+    <string name="Timer15">15</string>
+    <string name="Timer30">30</string>
+    <string name="Timer45">45</string>
+    <string name="Timer60">60</string>
+    <string name="PlayAs">Play as:</string>
 </resources>

--- a/app/src/main/res/values/strings_exp.xml
+++ b/app/src/main/res/values/strings_exp.xml
@@ -20,6 +20,7 @@
     <string name="NoGamesToolbarTitle">No Games</string>
     <string name="Opponent">Opponent:</string>
     <string name="PlayAgain">Play Again</string>
+    <string name="PlayButton">Play!</string>
     <string name="PlayCheckers">Play Checkers</string>
     <string name="PlayChess">Play Chess</string>
     <string name="PlayModeComputerMenuTitle">Play the computer</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 03 14:38:36 EDT 2017
+#Fri Sep 15 14:34:01 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
# Rationale
With how the current app is handled, any time we need to add a new setting we need to add it to the play screen, which is an unsustainable model. Having a "set up game" screen while still enabling players to jump directly into the game is an acceptable solution. As is, it is largely placeholders waiting for functions to be implemented (I have added TODOs in the relevant file, **SetupExperienceFragment**).

# New Files

## exp/fragment/SetupExperienceFragment
* The new fragment that handles our setup is a relatively simple menu with a lot of TODOs to handle future functioning. In the future, it should handle setup of an experience, from choosing an opponent and choosing a game, to enabling fully optional settings like a tutor mode or game timer.

## res/drawable/button_background
* A simple shape drawable of a white background with rectangle blue border with rounded corners.

## res/drawable/button_background_selected
* Another simple shape drawable, identical to button_background but with a gray background to give it a more featured look, showing the user that this is their current 'selected' option.

## res/layout/exp_setup
* A menu for **SetupExperienceFragment** of settings choices (done primarily through images) and labels, positioned with a ConstraintLayout to allow for exact and even spacing. An invisible "spacer" view behind the toolbar enables positioning of the columns.

# Changed Files

## common/FragmentType
* Added the new FragmentType *setupExp* for the new fragment.

## exp/BaseExperienceFragment
* Added a catch-all clause for the **SetupExperienceFragment** click events.
* Added dispatching in *processFamItem* for the new FAM entry for the **SetupExperienceFragment**

## exp/fragment/CheckersFragment
* Changed the player icons resource Id from player_1_icon and player_2_icon to player1Icon and player2Icon to more closely follow our conventions of preferring camelCase to under_scores for resource IDs.

## exp/fragment/ChessFragment
* Changed the player icons resource Id from player_1_icon and player_2_icon to player1Icon and player2Icon to more closely follow our conventions of preferring camelCase to under_scores for resource IDs.

## exp/fragment/ExpEnvelopeFragment
* Adding a Menu Entry for the new **SetupExperienceFragment**.

## res/layout/exp_checkers

## exp/fragment/CheckersFragment
* Changed the player icons resource Id from player_1_icon and player_2_icon to player1Icon and player2Icon to more closely follow our conventions of preferring camelCase to under_scores for resource IDs.

## res/values/strings_exp
* Added several new strings for our big new Set Up Experience menu.

## build.gradle
* Updated gradle plugin to the most current version.

## gradle-wrapper.properties
* Updated distribution url (automated by gradle plugin).