### PR TITLE
Pressing Enter sends Messages

### DIFF
--- a/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
+++ b/app/src/main/java/com/pajato/android/gamechat/chat/fragment/ShowMessagesFragment.java
@@ -24,8 +24,11 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import com.pajato.android.gamechat.R;
 import com.pajato.android.gamechat.chat.BaseChatFragment;
@@ -67,7 +70,8 @@ import static com.pajato.android.gamechat.main.MainService.ROOM_KEY;
  *
  * @author Paul Michael Reilly
  */
-public class ShowMessagesFragment extends BaseChatFragment implements View.OnClickListener {
+public class ShowMessagesFragment extends BaseChatFragment implements View.OnClickListener,
+        TextView.OnEditorActionListener {
 
     // Public instance methods.
 
@@ -145,6 +149,14 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
             updateAdapterList();
     }
 
+    /** Handle an enter key press to allow the user to press enter to send their text. */
+    @Override public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
+        if (i == EditorInfo.IME_NULL) {
+            postMessage(textView);
+        }
+        return false;
+    }
+
     /** Handle a menu item selection. */
     @Subscribe public void onMenuItem(final MenuItemEvent event) {
         if (!this.mActive)
@@ -195,6 +207,7 @@ public class ShowMessagesFragment extends BaseChatFragment implements View.OnCli
         // Set up the edit text field and the send button.
         EditText editText = (EditText) layout.findViewById(R.id.messageEditText);
         editText.addTextChangedListener(new EditTextWatcher(layout));
+        editText.setOnEditorActionListener(this);
         View sendButton = layout.findViewById(R.id.sendButton);
         sendButton.setOnClickListener(this);
     }

--- a/app/src/main/res/layout/chat_messages.xml
+++ b/app/src/main/res/layout/chat_messages.xml
@@ -65,8 +65,9 @@ http://www.gnu.org/licenses
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_marginStart="8dp"
-            android:inputType="textAutoCorrect"
-            android:hint="@string/editMessageHint" />
+            android:hint="@string/editMessageHint"
+            android:imeOptions="actionSend"
+            android:inputType="textAutoCorrect" />
         <LinearLayout
             android:id="@+id/sendButtonBox"
             android:layout_width="match_parent"


### PR DESCRIPTION
# Rationale
A bug was reported that pressing enter while typing messages on a hardware keyboard (for example, on a chromebook, or on an external bluetooth keyboard) failed to send a message, simply doing nothing. This has been resolved, and pressing enter should now send messages. In addition, software keyboards should now have a send button instead of an enter key when entering text in the message window.

# Changed Files

## chat/fragment/ShowMessagesFragment
* Now Implements **TextView.OnEditorActionListener** to handle enter key presses.
* New method *onEditorAction* handles an action key press, which should only be called when the Editor Action code is "IME_NULL", the EditorInfo code for the enter key. When this happens, we call postMessage as though we had just clicked send.
* We also set the message's EditText's onEditorActionListener to **this**, which seemed the most prudent, as any reasonable alternatives that I could see were far messier (involving another pre-existing class to only handle what essentially amounts to a keyboard onClick, or writing a NEW class just for this one specific call).

## layout/chat_messages
* Added new field to **messageEditText**, *imeOptions* which specifies what Action Button should be present on software keyboards. Previously we had used the default Enter key, but now we have *send* instead. I think it might merit a discussion on whether or not we need the external *send* key now, as I can see both sides.